### PR TITLE
AppVeyor CI Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![stars badge]][stars]
 [![forks badge]][forks]
 [![issues badge]][issues]
+[![AppVeyor branch](https://img.shields.io/appveyor/ci/BrentOzarULTD/SQL-Server-First-Responder-Kit/master.svg?maxAge=2592000)]()
+[![GitHub release](https://img.shields.io/github/release/BrentOzarULTD/SQL-Server-First-Responder-Kit.svg?maxAge=2592000)](https://ci.appveyor.com/api/projects/BrentOzarULTD/SQL-Server-First-Responder-Kit/artifacts/SQL_Server_First_Responder_Kit.zip?branch=master)
 
 You're a DBA, sysadmin, or developer who manages Microsoft SQL Servers. It's your fault if they're down or slow. These tools help you understand what's going on in your server.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+version: 1.0.{build}
+branches:
+  only:
+  - master
+services:
+- mssql2012sp1
+- mssql2012sp1rs
+- mssql2008r2sp2
+- mssql2008r2sp2rs
+- mssql2014
+- mssql2014rs
+
+artifacts: 
+  - path: SQL_Server_First_Responder_Kit.zip
+    name: scripts 
+
+build_script:
+  - ps: Write-Host 'Building...'
+  - ps: .\install.ps1
+
+test_script:
+  - ps: Write-Host 'Testing...'
+  - ps: sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i tests.sql -d "master" -b
+  - ps: sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i tests.sql -d "master" -b
+  - ps: sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i tests.sql -d "master" -b
+
+after_test:
+  - ps: Write-Host 'Packaging ...'
+  - ps: 7z a SQL_Server_First_Responder_Kit.zip sp_*.sql -r
+  - ps: ls
+
+deploy:
+  provider: GitHub
+  auth_token:
+    secure: CqWatOZAITE7uTenY58ol4QEap/qkCiI6V1TiJnpW4pLPucOJrjw+QPJY5/JLUZ/ # you need to generate a token from github and encrypt it using the encryption tool from appveyor and put the encrypted value to here.
+  artifact: scripts           # upload all NuGet packages to release assets
+  draft: false                # if you want to build on draft releases turn this on
+  prerelease: false           # if you want to build on prereleases turn this on
+  on:
+    branch: master                 # release from master branch only
+    appveyor_repo_tag: true        # deploy on tag push only  

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,32 @@
+sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_AskBrent.sql -d "master" -b
+sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_Blitz.sql -d "master" -b
+sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzCache.sql -d "master" -b
+sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzIndex.sql -d "master" -b
+sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzTrace.sql -d "master" -b
+$result = sqlcmd -S '(local)\SQL2014' -U 'sa' -P 'Password12!' -d 'master' -Q "SELECT name FROM sys.databases where name = 'ReportServer'" -b -W
+if ($result -eq 'ReportServer')
+{
+  sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzRS.sql -d "master" -b
+}
+
+sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_AskBrent.sql -d "master" -b
+sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_Blitz.sql -d "master" -b
+sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzCache.sql -d "master" -b
+sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzIndex.sql -d "master" -b
+sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzTrace.sql -d "master" -b
+$result = sqlcmd -S '(local)\SQL2012SP1' -U 'sa' -P 'Password12!' -d 'master' -Q "SELECT name FROM sys.databases where name = 'ReportServer'" -b -W
+if ($result -eq 'ReportServer')
+{
+  sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzRS.sql -d "master" -b
+}
+
+sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_AskBrent.sql -d "master" -b
+sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_Blitz.sql -d "master" -b
+sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_BlitzCache.sql -d "master" -b
+sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_BlitzIndex.sql -d "master" -b
+sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_BlitzTrace.sql -d "master" -b
+$result = sqlcmd -S '(local)\SQL2008R2SP2' -U 'sa' -P 'Password12!' -d 'master' -Q "SELECT name FROM sys.databases where name = 'ReportServer'" -b -W
+if ($result -eq 'ReportServer')
+{
+  sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_BlitzRS.sql -d "master" -b
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_AskBrent.sql -d "master" -b
+sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzFirst.sql -d "master" -b
 sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_Blitz.sql -d "master" -b
 sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzCache.sql -d "master" -b
 sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzIndex.sql -d "master" -b
@@ -9,7 +9,7 @@ if ($result -eq 'ReportServer')
   sqlcmd -S "(local)\SQL2014" -U "sa" -P "Password12!" -i sp_BlitzRS.sql -d "master" -b
 }
 
-sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_AskBrent.sql -d "master" -b
+sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzFirst.sql -d "master" -b
 sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_Blitz.sql -d "master" -b
 sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzCache.sql -d "master" -b
 sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzIndex.sql -d "master" -b
@@ -20,7 +20,7 @@ if ($result -eq 'ReportServer')
   sqlcmd -S "(local)\SQL2012SP1" -U "sa" -P "Password12!" -i sp_BlitzRS.sql -d "master" -b
 }
 
-sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_AskBrent.sql -d "master" -b
+sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_BlitzFirst.sql -d "master" -b
 sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_Blitz.sql -d "master" -b
 sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_BlitzCache.sql -d "master" -b
 sqlcmd -S "(local)\SQL2008R2SP2" -U "sa" -P "Password12!" -i sp_BlitzIndex.sql -d "master" -b

--- a/tests.sql
+++ b/tests.sql
@@ -1,0 +1,14 @@
+SELECT 
+	sp.name as SpName
+    , p.name AS Parameter
+FROM sys.procedures sp
+JOIN sys.parameters p 
+    ON sp.object_id = p.object_id
+JOIN sys.types t
+    ON p.system_type_id = t.system_type_id
+WHERE 
+	p.name like '%[_]%'
+	and sp.name in ('sp_AskBrent', 'sp_Blitz', 'sp_BlitzCache', 'sp_BlitzIndex', 'sp_BlitzRS', 'sp_BlitzTrace')
+
+IF @@ROWCOUNT > 0 
+	RAISERROR ('Underscore(s) found in parameter names', 16,0);

--- a/tests.sql
+++ b/tests.sql
@@ -8,7 +8,7 @@ JOIN sys.types t
     ON p.system_type_id = t.system_type_id
 WHERE 
 	p.name like '%[_]%'
-	and sp.name in ('sp_AskBrent', 'sp_Blitz', 'sp_BlitzCache', 'sp_BlitzIndex', 'sp_BlitzRS', 'sp_BlitzTrace')
+	and sp.name in ('sp_BlitzFirst', 'sp_Blitz', 'sp_BlitzCache', 'sp_BlitzIndex', 'sp_BlitzRS', 'sp_BlitzTrace')
 
 IF @@ROWCOUNT > 0 
 	RAISERROR ('Underscore(s) found in parameter names', 16,0);


### PR DESCRIPTION
hi,

### what this feature does: 
  - using appveyor server creates a clean installation of three sql server installations (2008r2, 2012sp1, 2014)
  - runs the scripts to these instances
    * if installation fails the build will fail
    * these installations does not contains ReportServer database (so sp_BlitzRS fails to install) so in install.ps1 file I have checked if ReportServer databases exits, if so i run the script file. in short sp_BlitzRS is nor actually been installed or tested. 
    * test script files (in test.sql i have add a test for _ characters in parameters.)
    * if the build was a tagged build appveyor puts script files in a zip file and push this artifact back to github in releases tab. 

### what i changed : 
I only added files
  - appveyor.yml
  - install.ps1
  - test.sql
and added two more badges to the readme.md (i don't understand why it shows too many changes)

### how to use it :
in order to use this feature you need to 
1. create an appveyor account from appveyor.com
2. create a token from github. (https://github.com/settings/tokens) (for permissions look at https://www.appveyor.com/docs/deployment/github search for text 'GitHub authentication token')
3. encrypt the token using https://ci.appveyor.com/tools/encrypt
4. put encrypted data to appveyor.yml file 