### PR TITLE
#412 sp_Blitz reporting too much free memory on small boxes

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2973,6 +2973,7 @@ AS
 									AND cTotal.counter_name = N'Total Server Memory (KB)                                                                                                        '
 								WHERE cFree.object_name LIKE N'%Memory Manager%'
 									AND cFree.counter_name = N'Free Memory (KB)                                                                                                                '
+									AND CAST(cTotal.cntr_value AS BIGINT) > 4000
 									AND CAST(cTotal.cntr_value AS BIGINT) * .3 <= CAST(cFree.cntr_value AS BIGINT)
                                     AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Standard%'
 


### PR DESCRIPTION
Closes #412. Added this to the WHERE clause on the free RAM check:

AND CAST(cTotal.cntr_value AS BIGINT) > 4000