### PR TITLE
#293 Support for @OutputServerName in sp_BlitzCache

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -22,127 +22,117 @@ CREATE TABLE ##bou_BlitzCacheResults (
 );
 
 CREATE TABLE ##bou_BlitzCacheProcs (
-        SPID INT ,
-        QueryType NVARCHAR(256),
-        DatabaseName sysname,
-        AverageCPU DECIMAL(38,4),
-        AverageCPUPerMinute DECIMAL(38,4),
-        TotalCPU DECIMAL(38,4),
-        PercentCPUByType MONEY,
-        PercentCPU MONEY,
-        AverageDuration DECIMAL(38,4),
-        TotalDuration DECIMAL(38,4),
-        PercentDuration MONEY,
-        PercentDurationByType MONEY,
-        AverageReads BIGINT,
-        TotalReads BIGINT,
-        PercentReads MONEY,
-        PercentReadsByType MONEY,
-        ExecutionCount BIGINT,
-        PercentExecutions MONEY,
-        PercentExecutionsByType MONEY,
-        ExecutionsPerMinute MONEY,
-        TotalWrites BIGINT,
-        AverageWrites MONEY,
-        PercentWrites MONEY,
-        PercentWritesByType MONEY,
-        WritesPerMinute MONEY,
-        PlanCreationTime DATETIME,
-        LastExecutionTime DATETIME,
-        PlanHandle VARBINARY(64),
-		[Remove Plan Handle From Cache] AS 
-			CASE WHEN [PlanHandle] IS NOT NULL 
-			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [PlanHandle], 1) + ');'
-			ELSE 'N/A' END,
-		SqlHandle VARBINARY(64),
-			[Remove SQL Handle From Cache] AS 
-			CASE WHEN [SqlHandle] IS NOT NULL 
-			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [SqlHandle], 1) + ');'
-			ELSE 'N/A' END,
-		[SQL Handle More Info] AS 
-			CASE WHEN [SqlHandle] IS NOT NULL 
-			THEN 'EXEC sp_BlitzCache @OnlySqlHandles = ''' + CONVERT(VARCHAR(128), [SqlHandle], 1) + '''; '
-			ELSE 'N/A' END,
-		QueryHash BINARY(8),
-		[Query Hash More Info] AS 
-			CASE WHEN [QueryHash] IS NOT NULL 
-			THEN 'EXEC sp_BlitzCache @OnlyQueryHashes = ''' + CONVERT(VARCHAR(32), [QueryHash], 1) + '''; '
-			ELSE 'N/A' END,
-        QueryPlanHash BINARY(8),
-        StatementStartOffset INT,
-        StatementEndOffset INT,
-        MinReturnedRows BIGINT,
-        MaxReturnedRows BIGINT,
-        AverageReturnedRows MONEY,
-        TotalReturnedRows BIGINT,
-        LastReturnedRows BIGINT,
-		/*The Memory Grant columns are only supported 
-		  in certain versions, giggle giggle.
-		*/
-		MinGrantKB BIGINT,
-		MaxGrantKB BIGINT,
-		MinUsedGrantKB BIGINT, 
-		MaxUsedGrantKB BIGINT,
-		PercentMemoryGrantUsed MONEY,
-		AvgMaxMemoryGrant MONEY,
-        QueryText NVARCHAR(MAX),
-        QueryPlan XML,
-        /* these next four columns are the total for the type of query.
-            don't actually use them for anything apart from math by type.
-            */
-        TotalWorkerTimeForType BIGINT,
-        TotalElapsedTimeForType BIGINT,
-        TotalReadsForType BIGINT,
-        TotalExecutionCountForType BIGINT,
-        TotalWritesForType BIGINT,
-        NumberOfPlans INT,
-        NumberOfDistinctPlans INT,
-        SerialDesiredMemory FLOAT,
-        SerialRequiredMemory FLOAT,
-        CachedPlanSize FLOAT,
-        CompileTime FLOAT,
-        CompileCPU FLOAT ,
-        CompileMemory FLOAT ,
-        min_worker_time BIGINT,
-        max_worker_time BIGINT,
-        is_forced_plan BIT,
-        is_forced_parameterized BIT,
-        is_cursor BIT,
-        is_parallel BIT,
-		is_forced_serial BIT,
-		is_key_lookup_expensive BIT,
-		key_lookup_cost FLOAT,
-		is_remote_query_expensive BIT,
-		remote_query_cost FLOAT,
-        frequent_execution BIT,
-        parameter_sniffing BIT,
-        unparameterized_query BIT,
-        near_parallel BIT,
-        plan_warnings BIT,
-        plan_multiple_plans BIT,
-        long_running BIT,
-        downlevel_estimator BIT,
-        implicit_conversions BIT,
-        busy_loops BIT,
-        tvf_join BIT,
-        tvf_estimate BIT,
-        compile_timeout BIT,
-        compile_memory_limit_exceeded BIT,
-        warning_no_join_predicate BIT,
-        QueryPlanCost FLOAT,
-        missing_index_count INT,
-        unmatched_index_count INT,
-        min_elapsed_time BIGINT,
-        max_elapsed_time BIGINT,
-        age_minutes MONEY,
-        age_minutes_lifetime MONEY,
-        is_trivial BIT,
-		trace_flags_session VARCHAR(1000),
-		is_unused_grant BIT,
-        SetOptions VARCHAR(MAX),
-        Warnings VARCHAR(MAX)
-    );
-GO 
+    SPID INT ,
+    QueryType nvarchar(256),
+    DatabaseName sysname,
+    AverageCPU decimal(38,4),
+    AverageCPUPerMinute decimal(38,4),
+    TotalCPU decimal(38,4),
+    PercentCPUByType money,
+    PercentCPU money,
+    AverageDuration decimal(38,4),
+    TotalDuration decimal(38,4),
+    PercentDuration money,
+    PercentDurationByType money,
+    AverageReads bigint,
+    TotalReads bigint,
+    PercentReads money,
+    PercentReadsByType money,
+    ExecutionCount bigint,
+    PercentExecutions money,
+    PercentExecutionsByType money,
+    ExecutionsPerMinute money,
+    TotalWrites bigint,
+    AverageWrites money,
+    PercentWrites money,
+    PercentWritesByType money,
+    WritesPerMinute money,
+    PlanCreationTime datetime,
+    LastExecutionTime datetime,
+    PlanHandle varbinary(64),
+	[Remove Plan Handle From Cache] AS 
+		CASE WHEN [PlanHandle] IS NOT NULL 
+		THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [PlanHandle], 1) + ');'
+		ELSE 'N/A' END,
+    SqlHandle varbinary(64),
+	[Remove SQL Handle From Cache] AS 
+	CASE WHEN [SqlHandle] IS NOT NULL 
+	THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [SqlHandle], 1) + ');'
+	ELSE 'N/A' END,
+	[SQL Handle More Info] AS 
+		CASE WHEN [SqlHandle] IS NOT NULL 
+		THEN 'EXEC sp_BlitzCache @OnlySqlHandles = ''' + CONVERT(VARCHAR(128), [SqlHandle], 1) + '''; '
+		ELSE 'N/A' END,
+    QueryHash binary(8),
+	[Query Hash More Info] AS 
+		CASE WHEN [QueryHash] IS NOT NULL 
+		THEN 'EXEC sp_BlitzCache @OnlyQueryHashes = ''' + CONVERT(VARCHAR(32), [QueryHash], 1) + '''; '
+		ELSE 'N/A' END,
+    QueryPlanHash binary(8),
+    StatementStartOffset int,
+    StatementEndOffset int,
+    MinReturnedRows bigint,
+    MaxReturnedRows bigint,
+    AverageReturnedRows money,
+    TotalReturnedRows bigint,
+    LastReturnedRows bigint,trace_flags_global varchar(1000),
+    QueryText nvarchar(max),
+    QueryPlan xml,
+    /* these next four columns are the total for the type of query.
+        don't actually use them for anything apart from math by type.
+        */
+    TotalWorkerTimeForType bigint,
+    TotalElapsedTimeForType bigint,
+    TotalReadsForType bigint,
+    TotalExecutionCountForType bigint,
+    TotalWritesForType bigint,
+    NumberOfPlans int,
+    NumberOfDistinctPlans int,
+    SerialDesiredMemory float,
+    SerialRequiredMemory float,
+    CachedPlanSize float,
+    CompileTime float,
+    CompileCPU float ,
+    CompileMemory float ,
+    min_worker_time bigint,
+    max_worker_time bigint,
+    is_forced_plan bit,
+    is_forced_parameterized bit,
+    is_cursor bit,
+    is_parallel bit,
+	is_key_lookup_expensive bit,
+	key_lookup_cost float,
+	is_remote_query_expensive bit,
+	remote_query_cost float,
+	is_forced_serial bit,
+    frequent_execution bit,
+    parameter_sniffing bit,
+    unparameterized_query bit,
+    near_parallel bit,
+    plan_warnings bit,
+    plan_multiple_plans bit,
+    long_running bit,
+    downlevel_estimator bit,
+    implicit_conversions bit,
+    busy_loops bit,
+    tvf_join bit,
+    tvf_estimate bit,
+    compile_timeout bit,
+    compile_memory_limit_exceeded bit,
+    warning_no_join_predicate bit,
+    QueryPlanCost float,
+    missing_index_count int,
+    unmatched_index_count int,
+    min_elapsed_time bigint,
+    max_elapsed_time bigint,
+    age_minutes money,
+    age_minutes_lifetime money,
+    is_trivial bit,
+	trace_flags_session varchar(1000),
+    SetOptions VARCHAR(MAX),
+    Warnings VARCHAR(MAX)
+);
+GO
 
 ALTER PROCEDURE dbo.sp_BlitzCache
     @Help BIT = 0,
@@ -189,7 +179,7 @@ Known limitations of this version:
  - This query will not run on SQL Server 2005.
  - SQL Server 2008 and 2008R2 have a bug in trigger stats, so that output is
    excluded by default.
- - @IgnoreQueryHashes and @OnlyQueryHashes require a CSV list of hashes
+ - @IgnoreQueryHashes and @only_query_hashes require a CSV list of hashes
    with no spaces between the hash values.
  - @OutputServerName is not functional yet.
 
@@ -262,7 +252,7 @@ SOFTWARE.
 '
 
 
-DECLARE @nl NVARCHAR(2) = NCHAR(13) + NCHAR(10) ;
+DECLARE @nl nvarchar(2) = NCHAR(13) + NCHAR(10) ;
 
 IF @Help = 1
 BEGIN
@@ -278,7 +268,7 @@ BEGIN
     UNION ALL
     SELECT N'@SortOrder',
            N'VARCHAR(10)',
-           N'Data processing and display order. @SortOrder will still be used, even when preparing output for a table or for excel. Possible values are: "CPU", "Reads", "Writes", "Duration", "Executions", "Recent Compilations", "Memory Grant". Additionally, the word "Average" or "Avg" can be used to sort on averages rather than total. "Executions per minute" and "Executions / minute" can be used to sort by execution per minute. For the truly lazy, "xpm" can also be used.'
+           N'Data processing and display order. @SortOrder will still be used, even when preparing output for a table or for excel. Possible values are: "CPU", "Reads", "Writes", "Duration", "Executions", "Recent Compilations". Additionally, the word "Average" or "Avg" can be used to sort on averages rather than total. "Executions per minute" and "Executions / minute" can be used to sort by execution per minute. For the truly lazy, "xpm" can also be used.'
 
     UNION ALL
     SELECT N'@UseTriggersAnyway',
@@ -499,36 +489,6 @@ BEGIN
            N'The maximum number of rows returned by any execution of this query.'
 
     UNION ALL
-    SELECT N'MinGrantKB',
-           N'BIGINT',
-           N'The minim memory grant the query received in kb.'
-
-    UNION ALL
-    SELECT N'MaxGrantKB',
-           N'BIGINT',
-           N'The maximum memory grant the query received in kb.'
-
-    UNION ALL
-    SELECT N'MinUsedGrantKB',
-           N'BIGINT',
-           N'The minim used memory grant the query received in kb.'
-
-    UNION ALL
-    SELECT N'MaxUsedGrantKB',
-           N'BIGINT',
-           N'The maximum used memory grant the query received in kb.'
-
-    UNION ALL
-    SELECT N'PercentMemoryGrantUsed',
-           N'MONEY',
-           N'Result of dividing the maximum grant used by the minimum granted.'
-
-    UNION ALL
-    SELECT N'AvgMaxMemoryGrant',
-           N'MONEY',
-           N'The average maximum memory grant for a query.'
-
-    UNION ALL
     SELECT N'# Plans',
            N'INT',
            N'The total number of execution plans found that match a given query.'
@@ -607,11 +567,6 @@ BEGIN
            N'Seconds' ,
            N'Triggers a "Long Running Query Warning" when average duration, max CPU time, or max clock time is higher than this number.'
 
-    UNION ALL
-    SELECT N'Unused Memory Grant Warning' AS [Configuration Parameter] ,
-           N'10' ,
-           N'Percent' ,
-           N'Triggers an "Unused Memory Grant Warning" when a query uses >= X percent of its memory grant.'
     RETURN
 END
 
@@ -643,38 +598,38 @@ IF OBJECT_ID('tempdb.dbo.##bou_BlitzCacheProcs') IS NULL
 BEGIN
     CREATE TABLE ##bou_BlitzCacheProcs (
         SPID INT ,
-        QueryType NVARCHAR(256),
+        QueryType nvarchar(256),
         DatabaseName sysname,
-        AverageCPU DECIMAL(38,4),
-        AverageCPUPerMinute DECIMAL(38,4),
-        TotalCPU DECIMAL(38,4),
-        PercentCPUByType MONEY,
-        PercentCPU MONEY,
-        AverageDuration DECIMAL(38,4),
-        TotalDuration DECIMAL(38,4),
-        PercentDuration MONEY,
-        PercentDurationByType MONEY,
-        AverageReads BIGINT,
-        TotalReads BIGINT,
-        PercentReads MONEY,
-        PercentReadsByType MONEY,
-        ExecutionCount BIGINT,
-        PercentExecutions MONEY,
-        PercentExecutionsByType MONEY,
-        ExecutionsPerMinute MONEY,
-        TotalWrites BIGINT,
-        AverageWrites MONEY,
-        PercentWrites MONEY,
-        PercentWritesByType MONEY,
-        WritesPerMinute MONEY,
-        PlanCreationTime DATETIME,
-        LastExecutionTime DATETIME,
-        PlanHandle VARBINARY(64),
+        AverageCPU decimal(38,4),
+        AverageCPUPerMinute decimal(38,4),
+        TotalCPU decimal(38,4),
+        PercentCPUByType money,
+        PercentCPU money,
+        AverageDuration decimal(38,4),
+        TotalDuration decimal(38,4),
+        PercentDuration money,
+        PercentDurationByType money,
+        AverageReads bigint,
+        TotalReads bigint,
+        PercentReads money,
+        PercentReadsByType money,
+        ExecutionCount bigint,
+        PercentExecutions money,
+        PercentExecutionsByType money,
+        ExecutionsPerMinute money,
+        TotalWrites bigint,
+        AverageWrites money,
+        PercentWrites money,
+        PercentWritesByType money,
+        WritesPerMinute money,
+        PlanCreationTime datetime,
+        LastExecutionTime datetime,
+        PlanHandle varbinary(64),
 		[Remove Plan Handle From Cache] AS 
 			CASE WHEN [PlanHandle] IS NOT NULL 
 			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [PlanHandle], 1) + ');'
 			ELSE 'N/A' END,
-		SqlHandle VARBINARY(64),
+		SqlHandle varbinary(64),
 			[Remove SQL Handle From Cache] AS 
 			CASE WHEN [SqlHandle] IS NOT NULL 
 			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [SqlHandle], 1) + ');'
@@ -683,79 +638,72 @@ BEGIN
 			CASE WHEN [SqlHandle] IS NOT NULL 
 			THEN 'EXEC sp_BlitzCache @OnlySqlHandles = ''' + CONVERT(VARCHAR(128), [SqlHandle], 1) + '''; '
 			ELSE 'N/A' END,
-		QueryHash BINARY(8),
+		QueryHash binary(8),
 		[Query Hash More Info] AS 
 			CASE WHEN [QueryHash] IS NOT NULL 
 			THEN 'EXEC sp_BlitzCache @OnlyQueryHashes = ''' + CONVERT(VARCHAR(32), [QueryHash], 1) + '''; '
 			ELSE 'N/A' END,
-        QueryPlanHash BINARY(8),
-        StatementStartOffset INT,
-        StatementEndOffset INT,
-        MinReturnedRows BIGINT,
-        MaxReturnedRows BIGINT,
-        AverageReturnedRows MONEY,
-        TotalReturnedRows BIGINT,
-        LastReturnedRows BIGINT,
-		MinGrantKB BIGINT,
-		MaxGrantKB BIGINT,
-		MinUsedGrantKB BIGINT, 
-		MaxUsedGrantKB BIGINT,
-		PercentMemoryGrantUsed MONEY,
-		AvgMaxMemoryGrant MONEY,
-        QueryText NVARCHAR(MAX),
-        QueryPlan XML,
+        QueryPlanHash binary(8),
+        StatementStartOffset int,
+        StatementEndOffset int,
+        MinReturnedRows bigint,
+        MaxReturnedRows bigint,
+        AverageReturnedRows money,
+        TotalReturnedRows bigint,
+        LastReturnedRows bigint,
+        QueryText nvarchar(max),
+        QueryPlan xml,
         /* these next four columns are the total for the type of query.
             don't actually use them for anything apart from math by type.
             */
-        TotalWorkerTimeForType BIGINT,
-        TotalElapsedTimeForType BIGINT,
-        TotalReadsForType BIGINT,
-        TotalExecutionCountForType BIGINT,
-        TotalWritesForType BIGINT,
-        NumberOfPlans INT,
-        NumberOfDistinctPlans INT,
-        SerialDesiredMemory FLOAT,
-        SerialRequiredMemory FLOAT,
-        CachedPlanSize FLOAT,
-        CompileTime FLOAT,
-        CompileCPU FLOAT ,
-        CompileMemory FLOAT ,
-        min_worker_time BIGINT,
-        max_worker_time BIGINT,
-        is_forced_plan BIT,
-        is_forced_parameterized BIT,
-        is_cursor BIT,
-        is_parallel BIT,
-		is_forced_serial BIT,
-		is_key_lookup_expensive BIT,
-		key_lookup_cost FLOAT,
-		is_remote_query_expensive BIT,
-		remote_query_cost FLOAT,
-        frequent_execution BIT,
-        parameter_sniffing BIT,
-        unparameterized_query BIT,
-        near_parallel BIT,
-        plan_warnings BIT,
-        plan_multiple_plans BIT,
-        long_running BIT,
-        downlevel_estimator BIT,
-        implicit_conversions BIT,
-        busy_loops BIT,
-        tvf_join BIT,
-        tvf_estimate BIT,
-        compile_timeout BIT,
-        compile_memory_limit_exceeded BIT,
-        warning_no_join_predicate BIT,
-        QueryPlanCost FLOAT,
-        missing_index_count INT,
-        unmatched_index_count INT,
-        min_elapsed_time BIGINT,
-        max_elapsed_time BIGINT,
-        age_minutes MONEY,
-        age_minutes_lifetime MONEY,
-        is_trivial BIT,
-		trace_flags_session VARCHAR(1000),
-		is_unused_grant BIT,
+        TotalWorkerTimeForType bigint,
+        TotalElapsedTimeForType bigint,
+        TotalReadsForType bigint,
+        TotalExecutionCountForType bigint,
+        TotalWritesForType bigint,
+        NumberOfPlans int,
+        NumberOfDistinctPlans int,
+        SerialDesiredMemory float,
+        SerialRequiredMemory float,
+        CachedPlanSize float,
+        CompileTime float,
+        CompileCPU float ,
+        CompileMemory float ,
+        min_worker_time bigint,
+        max_worker_time bigint,
+        is_forced_plan bit,
+        is_forced_parameterized bit,
+        is_cursor bit,
+        is_parallel bit,
+		is_forced_serial bit,
+		is_key_lookup_expensive bit,
+		key_lookup_cost float,
+		is_remote_query_expensive bit,
+		remote_query_cost float,
+        frequent_execution bit,
+        parameter_sniffing bit,
+        unparameterized_query bit,
+        near_parallel bit,
+        plan_warnings bit,
+        plan_multiple_plans bit,
+        long_running bit,
+        downlevel_estimator bit,
+        implicit_conversions bit,
+        busy_loops bit,
+        tvf_join bit,
+        tvf_estimate bit,
+        compile_timeout bit,
+        compile_memory_limit_exceeded bit,
+        warning_no_join_predicate bit,
+        QueryPlanCost float,
+        missing_index_count int,
+        unmatched_index_count int,
+        min_elapsed_time bigint,
+        max_elapsed_time bigint,
+        age_minutes money,
+        age_minutes_lifetime money,
+        is_trivial bit,
+		trace_flags_session varchar(1000),
         SetOptions VARCHAR(MAX),
         Warnings VARCHAR(MAX)
     );
@@ -774,12 +722,6 @@ IF @DurationFilter IS NOT NULL
   SET @DurationFilter_i = CAST((@DurationFilter * 1000.0) AS INT)
 
 SET @DatabaseName = LTRIM(RTRIM(@DatabaseName)) ;
-IF (DB_ID(@DatabaseName)) IS NULL AND @DatabaseName <> ''
-BEGIN
-   RAISERROR('The database you specified does not exist. Please check the name and try again.', 16, 1);
-   RETURN;
-END
-
 
 SET @SortOrder = LOWER(@SortOrder);
 SET @SortOrder = REPLACE(REPLACE(@SortOrder, 'average', 'avg'), '.', '');
@@ -791,10 +733,11 @@ SET @SortOrder = REPLACE(@SortOrder, 'recent compilations', 'compiles');
 
 IF @SortOrder NOT IN ('cpu', 'avg cpu', 'reads', 'avg reads', 'writes', 'avg writes',
                        'duration', 'avg duration', 'executions', 'avg executions',
-                       'compiles', 'memory grant', 'avg memory grant')
+                       'compiles')
   SET @SortOrder = 'cpu';
 
-SELECT @OutputDatabaseName = QUOTENAME(@OutputDatabaseName),
+SELECT @OutputServerName   = QUOTENAME(@OutputServerName),
+	   @OutputDatabaseName = QUOTENAME(@OutputDatabaseName),
        @OutputSchemaName   = QUOTENAME(@OutputSchemaName),
        @OutputTableName    = QUOTENAME(@OutputTableName);
 
@@ -809,7 +752,7 @@ ELSE IF @Reanalyze = 0
   DELETE ##bou_BlitzCacheResults
     WHERE SPID = @@SPID;
 
-IF @SkipAnalysis = 1
+if @SkipAnalysis = 1
     SET @HideSummary = 1;
 
 IF @Reanalyze = 1 
@@ -849,20 +792,20 @@ CREATE TABLE #only_sql_handles (
 );
 
 CREATE TABLE #p (
-    SqlHandle VARBINARY(64),
-    TotalCPU BIGINT,
-    TotalDuration BIGINT,
-    TotalReads BIGINT,
-    TotalWrites BIGINT,
-    ExecutionCount BIGINT
+    SqlHandle varbinary(64),
+    TotalCPU bigint,
+    TotalDuration bigint,
+    TotalReads bigint,
+    TotalWrites bigint,
+    ExecutionCount bigint
 );
 
 CREATE TABLE #checkversion (
-    version NVARCHAR(128),
+    version nvarchar(128),
     common_version AS SUBSTRING(version, 1, CHARINDEX('.', version) + 1 ),
     major AS PARSENAME(CONVERT(VARCHAR(32), version), 4),
     minor AS PARSENAME(CONVERT(VARCHAR(32), version), 3),
-    build AS PARSENAME(CONVERT(VARCHAR(32), version), 2),
+    build AS PARSENAME(CONVERT(varchar(32), version), 2),
     revision AS PARSENAME(CONVERT(VARCHAR(32), version), 1)
 );
 
@@ -891,8 +834,8 @@ BEGIN
                SET @individual = SUBSTRING(@OnlySqlHandles, 0, PATINDEX('%,%',@OnlySqlHandles)) ;
                
                INSERT INTO #only_sql_handles
-               SELECT CAST('' AS XML).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
-               FROM (SELECT CASE SUBSTRING(@individual, 1, 2) WHEN '0x' THEN 3 ELSE 0 END) AS t(pos)
+               select cast('' as xml).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
+               from (select case substring(@individual, 1, 2) when '0x' then 3 else 0 end) as t(pos)
                
                --SELECT CAST(SUBSTRING(@individual, 1, 2) AS BINARY(8));
 
@@ -939,8 +882,8 @@ BEGIN
                SET @individual = SUBSTRING(@OnlyQueryHashes, 0, PATINDEX('%,%',@OnlyQueryHashes)) ;
                
                INSERT INTO #only_query_hashes
-               SELECT CAST('' AS XML).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
-               FROM (SELECT CASE SUBSTRING(@individual, 1, 2) WHEN '0x' THEN 3 ELSE 0 END) AS t(pos)
+               select cast('' as xml).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
+               from (select case substring(@individual, 1, 2) when '0x' then 3 else 0 end) as t(pos)
                
                --SELECT CAST(SUBSTRING(@individual, 1, 2) AS BINARY(8));
 
@@ -1006,24 +949,24 @@ BEGIN
    EXEC(@config_sql);
 END
 
-DECLARE @sql NVARCHAR(MAX) = N'',
-        @insert_list NVARCHAR(MAX) = N'',
-        @plans_triggers_select_list NVARCHAR(MAX) = N'',
-        @body NVARCHAR(MAX) = N'',
-        @body_where NVARCHAR(MAX) = N'WHERE 1 = 1 ' + @nl,
-        @body_order NVARCHAR(MAX) = N'ORDER BY #sortable# DESC OPTION (RECOMPILE) ',
+DECLARE @sql nvarchar(MAX) = N'',
+        @insert_list nvarchar(MAX) = N'',
+        @plans_triggers_select_list nvarchar(MAX) = N'',
+        @body nvarchar(MAX) = N'',
+        @body_where nvarchar(MAX) = N'WHERE 1 = 1 ' + @nl,
+        @body_order nvarchar(MAX) = N'ORDER BY #sortable# DESC OPTION (RECOMPILE) ',
         
-        @q NVARCHAR(1) = N'''',
-        @pv VARCHAR(20),
-        @pos TINYINT,
-        @v DECIMAL(6,2),
-        @build INT;
+        @q nvarchar(1) = N'''',
+        @pv varchar(20),
+        @pos tinyint,
+        @v decimal(6,2),
+        @build int;
 
 
 RAISERROR (N'Determining SQL Server version.',0,1) WITH NOWAIT;
 
 INSERT INTO #checkversion (version)
-SELECT CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128))
+SELECT CAST(SERVERPROPERTY('ProductVersion') as nvarchar(128))
 OPTION (RECOMPILE);
 
 
@@ -1032,16 +975,6 @@ SELECT @v = common_version ,
 FROM   #checkversion
 OPTION (RECOMPILE);
 
-IF (@SortOrder IN ('memory grant', 'avg memory grant')) 
-AND ((@v < 11)
-OR (@v = 11 AND @build < 6020) 
-OR (@v = 12 AND @build < 5000) 
-OR (@v = 13 AND @build < 1601))
-BEGIN
-   RAISERROR('Your version of SQL does not support sorting by memory grant or average memory grant. Please use another sort order.', 16, 1);
-   RETURN;
-END
-
 RAISERROR (N'Creating dynamic SQL based on SQL Server version.',0,1) WITH NOWAIT;
 
 SET @insert_list += N'
@@ -1049,8 +982,7 @@ INSERT INTO ##bou_BlitzCacheProcs (SPID, QueryType, DatabaseName, AverageCPU, To
                     PercentReadsByType, PercentExecutionsByType, AverageDuration, TotalDuration, AverageReads, TotalReads, ExecutionCount,
                     ExecutionsPerMinute, TotalWrites, AverageWrites, PercentWritesByType, WritesPerMinute, PlanCreationTime,
                     LastExecutionTime, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows,
-                    LastReturnedRows, MinGrantKB, MaxGrantKB, MinUsedGrantKB, MaxUsedGrantKB, PercentMemoryGrantUsed, AvgMaxMemoryGrant,
-					QueryText, QueryPlan, TotalWorkerTimeForType, TotalElapsedTimeForType, TotalReadsForType,
+                    LastReturnedRows, QueryText, QueryPlan, TotalWorkerTimeForType, TotalElapsedTimeForType, TotalReadsForType,
                     TotalExecutionCountForType, TotalWritesForType, SqlHandle, PlanHandle, QueryHash, QueryPlanHash,
                     min_worker_time, max_worker_time, is_parallel, min_elapsed_time, max_elapsed_time, age_minutes, age_minutes_lifetime) ' ;
 
@@ -1107,21 +1039,19 @@ IF @DurationFilter IS NOT NULL
    This should make it faster to process since we'll be pulling back fewer
    plans for processing.
  */
-SELECT @body += N'        ORDER BY ' +
-                CASE @SortOrder  WHEN N'cpu' THEN N'total_worker_time'
-                                 WHEN N'reads' THEN N'total_logical_reads'
-                                 WHEN N'writes' THEN N'total_logical_writes'
-                                 WHEN N'duration' THEN N'total_elapsed_time'
-                                 WHEN N'executions' THEN N'execution_count'
-                                 WHEN N'compiles' THEN N'cached_time'
-								 WHEN N'memory grant' THEN N'max_grant_kb'
+SELECT @body += '        ORDER BY ' +
+                CASE @SortOrder WHEN 'cpu' THEN 'total_worker_time'
+                                 WHEN 'reads' THEN 'total_logical_reads'
+                                 WHEN 'writes' THEN 'total_logical_writes'
+                                 WHEN 'duration' THEN 'total_elapsed_time'
+                                 WHEN 'executions' THEN 'execution_count'
+                                 WHEN 'compiles' THEN 'cached_time'
                                  /* And now the averages */
-                                 WHEN N'avg cpu' THEN N'total_worker_time / execution_count'
-                                 WHEN N'avg reads' THEN N'total_logical_reads / execution_count'
-                                 WHEN N'avg writes' THEN N'total_logical_writes / execution_count'
-                                 WHEN N'avg duration' THEN N'total_elapsed_time / execution_count'
-								 WHEN N'avg memory grant' THEN N'CASE WHEN max_grant_kb = 0 THEN 0 ELSE max_grant_kb / execution_count END'
-                                 WHEN N'avg executions' THEN 'CASE WHEN execution_count = 0 THEN 0
+                                 WHEN 'avg cpu' THEN 'total_worker_time / execution_count'
+                                 WHEN 'avg reads' THEN 'total_logical_reads / execution_count'
+                                 WHEN 'avg writes' THEN 'total_logical_writes / execution_count'
+                                 WHEN 'avg duration' THEN 'total_elapsed_time / execution_count'
+                                 WHEN 'avg executions' THEN 'CASE WHEN execution_count = 0 THEN 0
             WHEN COALESCE(CAST((CASE WHEN DATEDIFF(mi, cached_time, GETDATE()) > 0 AND execution_count > 1
                           THEN DATEDIFF(mi, cached_time, GETDATE())
                           ELSE NULL END) as MONEY), CAST((CASE WHEN DATEDIFF(mi, cached_time, last_execution_time) > 0 AND execution_count > 1
@@ -1133,7 +1063,7 @@ SELECT @body += N'        ORDER BY ' +
                           THEN DATEDIFF(mi, cached_time, last_execution_time)
                           ELSE Null END) as MONEY))) AS money)
             END '
-                END + N' DESC ' + @nl ;
+                END + ' DESC ' + @nl ;
 
 
                           
@@ -1202,12 +1132,6 @@ SELECT TOP (@Top)
        NULL AS AvgReturnedRows,
        NULL AS TotalReturnedRows,
        NULL AS LastReturnedRows,
-       NULL AS MinGrantKB,
-       NULL AS MaxGrantKB,
-       NULL AS MinUsedGrantKB, 
-	   NULL AS MaxUsedGrantKB,
-	   NULL AS PercentMemoryGrantUsed, 
-	   NULL AS AvgMaxMemoryGrant,
        st.text AS QueryText ,
        query_plan AS QueryPlan,
        t.t_TotalWorker,
@@ -1288,29 +1212,6 @@ BEGIN
            NULL AS TotalReturnedRows,
            NULL AS LastReturnedRows, ' ;
     END
-
-    IF (@v = 11 AND @build >= 6020) OR (@v = 12 AND @build >= 5000) OR (@v = 13 AND @build >= 1601)
-
-    BEGIN
-        SET @sql += N'
-           min_grant_kb AS MinGrantKB,
-           max_grant_kb AS MaxGrantKB,
-           min_used_grant_kb AS MinUsedGrantKB,
-           max_used_grant_kb AS MaxUsedGrantKB,
-           CAST(ISNULL(NULLIF(( max_used_grant_kb * 1.00 ), 0) / NULLIF(min_grant_kb, 0), 0) * 100. AS MONEY) AS PercentMemoryGrantUsed,
-		   CAST(ISNULL(NULLIF(( max_grant_kb * 1. ), 0) / NULLIF(execution_count, 0), 0) AS MONEY) AS AvgMaxMemoryGrant, ';
-    END
-    ELSE
-    BEGIN
-        SET @sql += N'
-           NULL AS MinGrantKB,
-           NULL AS MaxGrantKB,
-           NULL AS MinUsedGrantKB, 
-		   NULL AS MaxUsedGrantKB,
-		   NULL AS PercentMemoryGrantUsed, 
-		   NULL AS AvgMaxMemoryGrant, ' ;
-    END
-
     
     SET @sql += N'
            SUBSTRING(st.text, ( qs.statement_start_offset / 2 ) + 1, ( ( CASE qs.statement_end_offset
@@ -1333,7 +1234,7 @@ BEGIN
            qs.min_elapsed_time / 1000.0,
            qs.max_worker_time  / 1000.0,
            age_minutes,
-           age_minutes_lifetime ';
+           age_minutes_lifetime '
     
     SET @sql += REPLACE(REPLACE(@body, '#view#', 'dm_exec_query_stats'), 'cached_time', 'creation_time') ;
     
@@ -1348,10 +1249,7 @@ BEGIN
 END
 
 
-IF (@QueryFilter = 'all' 
-   AND (SELECT COUNT(*) FROM #only_query_hashes) = 0 
-   AND (SELECT COUNT(*) FROM #ignore_query_hashes) = 0) 
-   AND (@SortOrder NOT IN ('memory grant', 'avg memory grant'))
+IF (@QueryFilter = 'all' AND (SELECT COUNT(*) FROM #only_query_hashes) = 0 AND (SELECT COUNT(*) FROM #ignore_query_hashes) = 0) 
    OR (LEFT(@QueryFilter, 3) = 'pro')
 BEGIN
     SET @sql += @insert_list;
@@ -1361,7 +1259,7 @@ BEGIN
     SET @sql += @body_where ;
 
     IF @IgnoreSystemDBs = 1
-       SET @sql += N' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
+       SET @sql += ' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
 
     SET @sql += @body_order + @nl + @nl + @nl ;
 END
@@ -1383,7 +1281,6 @@ IF (@UseTriggersAnyway = 1 OR @v >= 11)
    AND (SELECT COUNT(*) FROM #only_query_hashes) = 0
    AND (SELECT COUNT(*) FROM #ignore_query_hashes) = 0
    AND (@QueryFilter = 'all')
-   AND (@SortOrder NOT IN ('memory grant', 'avg memory grant'))
 BEGIN
    RAISERROR (N'Adding SQL to collect trigger stats.',0,1) WITH NOWAIT;
 
@@ -1397,27 +1294,25 @@ BEGIN
    SET @sql += @body_where ;
 
    IF @IgnoreSystemDBs = 1
-      SET @sql += N' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
+      SET @sql += ' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
    
    SET @sql += @body_order + @nl + @nl + @nl ;
 END
 
 DECLARE @sort NVARCHAR(MAX);
 
-SELECT @sort = CASE @SortOrder  WHEN N'cpu' THEN N'total_worker_time'
-                                WHEN N'reads' THEN N'total_logical_reads'
-                                WHEN N'writes' THEN N'total_logical_writes'
-                                WHEN N'duration' THEN N'total_elapsed_time'
-                                WHEN N'executions' THEN N'execution_count'
-                                WHEN N'compiles' THEN N'cached_time'
-								WHEN N'memory grant' THEN N'max_grant_kb'
+SELECT @sort = CASE @SortOrder WHEN 'cpu' THEN 'total_worker_time'
+                                WHEN 'reads' THEN 'total_logical_reads'
+                                WHEN 'writes' THEN 'total_logical_writes'
+                                WHEN 'duration' THEN 'total_elapsed_time'
+                                WHEN 'executions' THEN 'execution_count'
+                                WHEN 'compiles' THEN 'cached_time'
                                 /* And now the averages */
-                                WHEN N'avg cpu' THEN N'total_worker_time / execution_count'
-                                WHEN N'avg reads' THEN N'total_logical_reads / execution_count'
-                                WHEN N'avg writes' THEN N'total_logical_writes / execution_count'
-                                WHEN N'avg duration' THEN N'total_elapsed_time / execution_count'
-								WHEN N'avg memory grant' THEN N'CASE WHEN max_grant_kb = 0 THEN 0 ELSE max_grant_kb / execution_count END'
-                                WHEN N'avg executions' THEN N'CASE WHEN execution_count = 0 THEN 0
+                                WHEN 'avg cpu' THEN 'total_worker_time / execution_count'
+                                WHEN 'avg reads' THEN 'total_logical_reads / execution_count'
+                                WHEN 'avg writes' THEN 'total_logical_writes / execution_count'
+                                WHEN 'avg duration' THEN 'total_elapsed_time / execution_count'
+                                WHEN 'avg executions' THEN 'CASE WHEN execution_count = 0 THEN 0
             WHEN COALESCE(age_minutes, age_minutes_lifetime, 0) = 0 THEN 0
             ELSE CAST((1.00 * execution_count / COALESCE(age_minutes, age_minutes_lifetime)) AS money)
             END'
@@ -1445,19 +1340,17 @@ WHERE x.rn = 1
 OPTION (RECOMPILE);
 ';
 
-SELECT @sort = CASE @SortOrder  WHEN N'cpu' THEN N'TotalCPU'
-                                WHEN N'reads' THEN N'TotalReads'
-                                WHEN N'writes' THEN N'TotalWrites'
-                                WHEN N'duration' THEN N'TotalDuration'
-                                WHEN N'executions' THEN N'ExecutionCount'
-                                WHEN N'compiles' THEN N'PlanCreationTime'
-								WHEN N'memory grant' THEN N'MaxGrantKB'
-                                WHEN N'avg cpu' THEN N'TotalCPU / ExecutionCount'
-                                WHEN N'avg reads' THEN N'TotalReads / ExecutionCount'
-                                WHEN N'avg writes' THEN N'TotalWrites / ExecutionCount'
-                                WHEN N'avg duration' THEN N'TotalDuration / ExecutionCount'
-								WHEN N'avg memory grant' THEN N'AvgMaxMemoryGrant'
-                                WHEN N'avg executions' THEN N'CASE WHEN ExecutionCount = 0 THEN 0
+SELECT @sort = CASE @SortOrder WHEN 'cpu' THEN 'TotalCPU'
+                                WHEN 'reads' THEN 'TotalReads'
+                                WHEN 'writes' THEN 'TotalWrites'
+                                WHEN 'duration' THEN 'TotalDuration'
+                                WHEN 'executions' THEN 'ExecutionCount'
+                                WHEN 'compiles' THEN 'PlanCreationTime'
+                                WHEN 'avg cpu' THEN 'TotalCPU / ExecutionCount'
+                                WHEN 'avg reads' THEN 'TotalReads / ExecutionCount'
+                                WHEN 'avg writes' THEN 'TotalWrites / ExecutionCount'
+                                WHEN 'avg duration' THEN 'TotalDuration / ExecutionCount'
+                                WHEN 'avg executions' THEN 'CASE WHEN ExecutionCount = 0 THEN 0
             WHEN COALESCE(age_minutes, age_minutes_lifetime, 0) = 0 THEN 0
             ELSE CAST((1.00 * ExecutionCount / COALESCE(age_minutes, age_minutes_lifetime)) AS money)
             END'
@@ -1471,19 +1364,6 @@ BEGIN
 
     EXEC sp_executesql @sql, N'@Top INT, @min_duration INT', @Top, @DurationFilter_i;
 END
-
-/*
---Debugging section
-SELECT DATALENGTH(@sql)
-PRINT SUBSTRING(@sql, 0, 4000)
-PRINT SUBSTRING(@sql, 4000, 8000)
-PRINT SUBSTRING(@sql, 8000, 12000)
-PRINT SUBSTRING(@sql, 16000, 24000)
-PRINT SUBSTRING(@sql, 24000, 28000)
-PRINT SUBSTRING(@sql, 28000, 32000)
-PRINT SUBSTRING(@sql, 32000, 36000)
-PRINT SUBSTRING(@sql, 36000, 40000)
-*/
 
 /* Update ##bou_BlitzCacheProcs to get Stored Proc info 
  * This should get totals for all statements in a Stored Proc
@@ -1562,7 +1442,7 @@ FROM (
                  ELSE CAST((100. * ExecutionCount) / @total_execution_count AS MONEY) END AS PercentExecutions,
             CASE DATEDIFF(mi, PlanCreationTime, LastExecutionTime)
                 WHEN 0 THEN 0
-                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS MONEY)
+                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS money)
             END AS ExecutionsPerMinute
     FROM (
         SELECT  PlanHandle,
@@ -1618,7 +1498,7 @@ FROM (
                  ELSE CAST((100. * ExecutionCount) / @total_execution_count AS MONEY) END AS PercentExecutions,
             CASE  DATEDIFF(mi, PlanCreationTime, LastExecutionTime)
                 WHEN 0 THEN 0
-                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS MONEY)
+                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS money)
             END AS ExecutionsPerMinute
     FROM (
         SELECT  DatabaseName,
@@ -1913,8 +1793,7 @@ DECLARE @execution_threshold INT = 1000 ,
         /* This is in average reads */
         @parameter_sniffing_io_threshold BIGINT = 100000 ,
         @ctp_threshold_pct TINYINT = 10,
-        @long_running_query_warning_seconds BIGINT = 300 * 1000 ,
-		@memory_grant_warning_percent INT = 10;
+        @long_running_query_warning_seconds BIGINT = 300 * 1000 ;
 
 IF EXISTS (SELECT 1/0 FROM #configuration WHERE 'frequent execution threshold' = LOWER(parameter_name))
 BEGIN
@@ -1971,17 +1850,6 @@ BEGIN
     RAISERROR(@msg, 0, 1) WITH NOWAIT;
 END
 
-IF EXISTS (SELECT 1/0 FROM #configuration WHERE 'unused memory grant' = LOWER(parameter_name))
-BEGIN
-    SELECT @memory_grant_warning_percent = CAST(value AS INT)
-    FROM   #configuration
-    WHERE 'unused memory grant' = LOWER(parameter_name) ;
-
-    SET @msg = ' Setting "unused memory grant" to ' + CAST(@long_running_query_warning_seconds AS VARCHAR(10));
-
-    RAISERROR(@msg, 0, 1) WITH NOWAIT;
-END
-
 DECLARE @ctp INT ;
 
 SELECT  @ctp = NULLIF(CAST(value AS INT), 0)
@@ -2010,8 +1878,7 @@ SET    frequent_execution = CASE WHEN ExecutionsPerMinute > @execution_threshold
                            WHEN max_elapsed_time > @long_running_query_warning_seconds THEN 1 END,
 	   is_key_lookup_expensive = CASE WHEN QueryPlanCost > (@ctp / 2) AND key_lookup_cost >= QueryPlanCost * .5 THEN 1 END,
 	   is_remote_query_expensive = CASE WHEN remote_query_cost >= QueryPlanCost * .05 THEN 1 END,
-	   is_forced_serial = CASE WHEN is_forced_serial = 1 AND QueryPlanCost > (@ctp / 2) THEN 1 END,
-	   is_unused_grant = CASE WHEN PercentMemoryGrantUsed <= @memory_grant_warning_percent AND MinGrantKB > 0 THEN 1 END
+	   is_forced_serial = CASE WHEN is_forced_serial = 1 AND QueryPlanCost > (@ctp / 2) THEN 1 END
 OPTION (RECOMPILE) ;
 
 
@@ -2079,8 +1946,7 @@ SET    Warnings = SUBSTRING(
 				  CASE WHEN is_key_lookup_expensive = 1 THEN ', Expensive Key Lookup' ELSE '' END +
 				  CASE WHEN is_remote_query_expensive = 1 THEN ', Expensive Remote Query' ELSE '' END + 
 				  CASE WHEN trace_flags_session IS NOT NULL THEN ', Session Level Trace Flag(s) Enabled: ' + trace_flags_session ELSE '' END +
-				  CASE WHEN is_remote_query_expensive = 1 THEN ', Expensive Remote Query' ELSE '' END +
-				  CASE WHEN is_unused_grant = 1 THEN ', Unused Memory Grant' ELSE '' END
+				  CASE WHEN is_remote_query_expensive = 1 THEN ', Expensive Remote Query' ELSE '' END
                   , 2, 200000) 
 				  OPTION (RECOMPILE) ;
 
@@ -2096,9 +1962,60 @@ SET    Warnings = SUBSTRING(
 
 
 Results:
-IF @OutputDatabaseName IS NOT NULL
-   AND @OutputSchemaName IS NOT NULL
-   AND @OutputTableName IS NOT NULL
+
+/* Checks if @OutputServerName is populated with a valid linked server, and that the database name specified is valid */
+				DECLARE @ValidOutputServer BIT
+				DECLARE @ValidOutputLocation BIT
+				DECLARE @LinkedServerDBCheck NVARCHAR(2000)
+				DECLARE @ValidLinkedServerDB INT
+				DECLARE @tmpdbchk table (cnt int)
+				IF @OutputServerName IS NOT NULL
+					BEGIN
+						IF EXISTS (SELECT server_id FROM sys.servers WHERE QUOTENAME([name]) = @OutputServerName)
+							BEGIN
+								SET @LinkedServerDBCheck = 'SELECT 1 WHERE EXISTS (SELECT * FROM '+@OutputServerName+'.master.sys.databases WHERE QUOTENAME([name]) = '''+@OutputDatabaseName+''')'
+								INSERT INTO @tmpdbchk EXEC sys.sp_executesql @LinkedServerDBCheck
+								SET @ValidLinkedServerDB = (SELECT COUNT(*) FROM @tmpdbchk)
+								IF (@ValidLinkedServerDB > 0)
+									BEGIN
+										SET @ValidOutputServer = 1
+										SET @ValidOutputLocation = 1
+									END
+								ELSE
+									RAISERROR('The specified database was not found on the output server', 16, 0)
+							END
+						ELSE
+							BEGIN
+								RAISERROR('The specified output server was not found', 16, 0)
+							END
+					END
+				ELSE
+					BEGIN
+						IF @OutputDatabaseName IS NOT NULL
+							AND @OutputSchemaName IS NOT NULL
+							AND @OutputTableName IS NOT NULL
+							AND EXISTS ( SELECT *
+								 FROM   sys.databases
+								 WHERE  QUOTENAME([name]) = @OutputDatabaseName)
+							BEGIN
+								SET @ValidOutputLocation = 1
+							END
+						ELSE IF @OutputDatabaseName IS NOT NULL
+							AND @OutputSchemaName IS NOT NULL
+							AND @OutputTableName IS NOT NULL
+							AND NOT EXISTS ( SELECT *
+								 FROM   sys.databases
+								 WHERE  QUOTENAME([name]) = @OutputDatabaseName)
+							BEGIN
+								RAISERROR('The specified output database was not found on this server', 16, 0)
+							END
+						ELSE
+							BEGIN
+								SET @ValidOutputLocation = 0 
+							END
+					END
+
+IF @ValidOutputLocation = 1
 BEGIN
     RAISERROR('Writing results to table.', 0, 1) WITH NOWAIT;
 
@@ -2119,42 +2036,42 @@ BEGIN
         + @OutputSchemaName + '.'
         + @OutputTableName
         + N'(ID bigint NOT NULL IDENTITY(1,1),
-          ServerName nvarchar(256),
+          ServerName NVARCHAR(256),
 		  CheckDate DATETIMEOFFSET,
-          Version nvarchar(256),
-          QueryType nvarchar(256),
-          Warnings varchar(max),
+          Version NVARCHAR(256),
+          QueryType NVARCHAR(256),
+          Warnings varchar(MAX),
           DatabaseName sysname,
-          SerialDesiredMemory float,
-          SerialRequiredMemory float,
-          AverageCPU bigint,
-          TotalCPU bigint,
-          PercentCPUByType money,
-          CPUWeight money,
-          AverageDuration bigint,
-          TotalDuration bigint,
-          DurationWeight money,
-          PercentDurationByType money,
-          AverageReads bigint,
-          TotalReads bigint,
-          ReadWeight money,
-          PercentReadsByType money,
-          AverageWrites bigint,
-          TotalWrites bigint,
-          WriteWeight money,
-          PercentWritesByType money,
-          ExecutionCount bigint,
-          ExecutionWeight money,
-          PercentExecutionsByType money,' + N'
-          ExecutionsPerMinute money,
-          PlanCreationTime datetime,
-          LastExecutionTime datetime,
-		  PlanHandle varbinary(64),
+          SerialDesiredMemory FLOAT,
+          SerialRequiredMemory FLOAT,
+          AverageCPU BIGINT,
+          TotalCPU BIGINT,
+          PercentCPUByType MONEY,
+          CPUWeight MONEY,
+          AverageDuration BIGINT,
+          TotalDuration BIGINT,
+          DurationWeight MONEY,
+          PercentDurationByType MONEY,
+          AverageReads BIGINT,
+          TotalReads BIGINT,
+          ReadWeight MONEY,
+          PercentReadsByType MONEY,
+          AverageWrites BIGINT,
+          TotalWrites BIGINT,
+          WriteWeight MONEY,
+          PercentWritesByType MONEY,
+          ExecutionCount BIGINT,
+          ExecutionWeight MONEY,
+          PercentExecutionsByType MONEY,' + N'
+          ExecutionsPerMinute MONEY,
+          PlanCreationTime DATETIME,
+          LastExecutionTime DATETIME,
+		  PlanHandle VARBINARY(64),
 		  [Remove Plan Handle From Cache] AS 
 			CASE WHEN [PlanHandle] IS NOT NULL 
 			THEN ''DBCC FREEPROCCACHE ('' + CONVERT(VARCHAR(128), [PlanHandle], 1) + '');''
 			ELSE ''N/A'' END,
-		  SqlHandle varbinary(64),
+		  SqlHandle VARBINARY(64),
 			[Remove SQL Handle From Cache] AS 
 			CASE WHEN [SqlHandle] IS NOT NULL 
 			THEN ''DBCC FREEPROCCACHE ('' + CONVERT(VARCHAR(128), [SqlHandle], 1) + '');''
@@ -2163,72 +2080,120 @@ BEGIN
 			CASE WHEN [SqlHandle] IS NOT NULL 
 			THEN ''EXEC sp_BlitzCache @OnlySqlHandles = '''''' + CONVERT(VARCHAR(128), [SqlHandle], 1) + ''''''; ''
 			ELSE ''N/A'' END,
-		  QueryHash binary(8),
+		  QueryHash BINARY(8),
 		  [Query Hash More Info] AS 
 			CASE WHEN [QueryHash] IS NOT NULL 
 			THEN ''EXEC sp_BlitzCache @OnlyQueryHashes = '''''' + CONVERT(VARCHAR(32), [QueryHash], 1) + ''''''; ''
 			ELSE ''N/A'' END,
-          QueryPlanHash binary(8),
-          StatementStartOffset int,
-          StatementEndOffset int,
-          MinReturnedRows bigint,
-          MaxReturnedRows bigint,
-          AverageReturnedRows money,
-          TotalReturnedRows bigint,
-          QueryText nvarchar(max),
-          QueryPlan xml,
-          NumberOfPlans int,
-          NumberOfDistinctPlans int,
-		  MinGrantKB BIGINT,
-		  MaxGrantKB BIGINT,
-		  MinUsedGrantKB BIGINT, 
-		  MaxUsedGrantKB BIGINT,
-		  PercentMemoryGrantUsed MONEY,
-		  AvgMaxMemoryGrant MONEY,
+          QueryPlanHash BINARY(8),
+          StatementStartOffset INT,
+          StatementEndOffset INT,
+          MinReturnedRows BIGINT,
+          MAXReturnedRows BIGINT,
+          AverageReturnedRows MONEY,
+          TotalReturnedRows BIGINT,
+          QueryText NVARCHAR(MAX),
+          QueryPlan XML,
+          NumberOfPlans INT,
+          NumberOfDistinctPlans INT,
           CONSTRAINT [PK_' +CAST(NEWID() AS NCHAR(36)) + '] PRIMARY KEY CLUSTERED(ID))';
 
-    EXEC sp_executesql @insert_sql ;
+	IF @ValidOutputServer = 1
+		BEGIN
+			SET @insert_sql = REPLACE(@insert_sql,''''+@OutputSchemaName+'''',''''''+@OutputSchemaName+'''''')
+			SET @insert_sql = REPLACE(@insert_sql,''''+@OutputTableName+'''',''''''+@OutputTableName+'''''')
+			SET @insert_sql = REPLACE(@insert_sql,'XML','[NVARCHAR](MAX)')
+			EXEC('EXEC('''+@insert_sql+''') AT ' + @OutputServerName);
+		END   
+	ELSE
+		BEGIN
+			EXEC sp_executesql @insert_sql;
+		END
 
-
-    SET @insert_sql =N' IF EXISTS(SELECT * FROM '
-          + @OutputDatabaseName
-          + N'.INFORMATION_SCHEMA.SCHEMATA WHERE QUOTENAME(SCHEMA_NAME) = '''
-          + @OutputSchemaName + N''') '
-          + 'INSERT '
-          + @OutputDatabaseName + '.'
-          + @OutputSchemaName + '.'
-          + @OutputTableName
-          + N' (ServerName, CheckDate, Version, QueryType, DatabaseName, AverageCPU, TotalCPU, PercentCPUByType, CPUWeight, AverageDuration, TotalDuration, DurationWeight, PercentDurationByType, AverageReads, TotalReads, ReadWeight, PercentReadsByType, '
-          + N' AverageWrites, TotalWrites, WriteWeight, PercentWritesByType, ExecutionCount, ExecutionWeight, PercentExecutionsByType, '
-          + N' ExecutionsPerMinute, PlanCreationTime, LastExecutionTime, PlanHandle, SqlHandle, QueryHash, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows, QueryText, QueryPlan, NumberOfPlans, NumberOfDistinctPlans, Warnings, '
-          + N' SerialRequiredMemory, SerialDesiredMemory, MinGrantKB, MaxGrantKB, MinUsedGrantKB, MaxUsedGrantKB, PercentMemoryGrantUsed, AvgMaxMemoryGrant) '
-          + N'SELECT TOP (@Top) '
-          + QUOTENAME(CAST(SERVERPROPERTY('ServerName') AS NVARCHAR(128)), N'''') + N', SYSDATETIMEOFFSET(),'
-          + QUOTENAME(CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128)), N'''') + ', '
-          + N' QueryType, DatabaseName, AverageCPU, TotalCPU, PercentCPUByType, PercentCPU, AverageDuration, TotalDuration, PercentDuration, PercentDurationByType, AverageReads, TotalReads, PercentReads, PercentReadsByType, '
-          + N' AverageWrites, TotalWrites, PercentWrites, PercentWritesByType, ExecutionCount, PercentExecutions, PercentExecutionsByType, '
-          + N' ExecutionsPerMinute, PlanCreationTime, LastExecutionTime, PlanHandle, SqlHandle, QueryHash, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows, QueryText, QueryPlan, NumberOfPlans, NumberOfDistinctPlans, Warnings, '
-          + N' SerialRequiredMemory, SerialDesiredMemory, MinGrantKB, MaxGrantKB, MinUsedGrantKB, MaxUsedGrantKB, PercentMemoryGrantUsed, AvgMaxMemoryGrant '
-          + N' FROM ##bou_BlitzCacheProcs '
+		IF @ValidOutputServer = 1
+		BEGIN
+		SET @insert_sql =N' IF EXISTS(SELECT * FROM '
+				+ @OutputServerName + '.'
+				+ @OutputDatabaseName
+				+ N'.INFORMATION_SCHEMA.SCHEMATA WHERE QUOTENAME(SCHEMA_NAME) = '''
+				+ @OutputSchemaName + N''') '
+				+ 'INSERT '
+				+ @OutputDatabaseName + '.'
+				+ @OutputSchemaName + '.'
+				+ @OutputTableName
+				+ N' (ServerName, CheckDate, Version, QueryType, DatabaseName, AverageCPU, TotalCPU, PercentCPUByType, CPUWeight, AverageDuration, TotalDuration, DurationWeight, PercentDurationByType, AverageReads, TotalReads, ReadWeight, PercentReadsByType, '
+				+ N' AverageWrites, TotalWrites, WriteWeight, PercentWritesByType, ExecutionCount, ExecutionWeight, PercentExecutionsByType, '
+				+ N' ExecutionsPerMinute, PlanCreationTime, LastExecutionTime, PlanHandle, SqlHandle, QueryHash, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows, QueryText, QueryPlan, NumberOfPlans, NumberOfDistinctPlans, Warnings, '
+				+ N' SerialRequiredMemory, SerialDesiredMemory) '
+				+ N'SELECT TOP '+CONVERT(VARCHAR,@Top)+' '
+				+ QUOTENAME(CAST(SERVERPROPERTY('ServerName') AS NVARCHAR(128)), N'''') + N', SYSDATETIMEOFFSET(),'
+				+ QUOTENAME(CAST(SERVERPROPERTY('ProductVersion') as nvarchar(128)), N'''') + ', '
+				+ N' QueryType, DatabaseName, AverageCPU, TotalCPU, PercentCPUByType, PercentCPU, AverageDuration, TotalDuration, PercentDuration, PercentDurationByType, AverageReads, TotalReads, PercentReads, PercentReadsByType, '
+				+ N' AverageWrites, TotalWrites, PercentWrites, PercentWritesByType, ExecutionCount, PercentExecutions, PercentExecutionsByType, '
+				+ N' ExecutionsPerMinute, PlanCreationTime, LastExecutionTime, PlanHandle, SqlHandle, QueryHash, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows, QueryText, QueryPlan, NumberOfPlans, NumberOfDistinctPlans, Warnings, '
+				+ N' SerialRequiredMemory, SerialDesiredMemory '
+				+ N' FROM ##bou_BlitzCacheProcs '
           
-    SELECT @insert_sql += N' ORDER BY ' + CASE @SortOrder WHEN 'cpu' THEN N' TotalCPU '
-                                                    WHEN 'reads' THEN N' TotalReads '
-                                                    WHEN 'writes' THEN N' TotalWrites '
-                                                    WHEN 'duration' THEN N' TotalDuration '
-                                                    WHEN 'executions' THEN N' ExecutionCount '
-                                                    WHEN 'compiles' THEN N' PlanCreationTime '
-													WHEN 'memory grant' THEN N' MaxGrantKB'
-                                                    WHEN 'avg cpu' THEN N' AverageCPU'
-                                                    WHEN 'avg reads' THEN N' AverageReads'
-                                                    WHEN 'avg writes' THEN N' AverageWrites'
-                                                    WHEN 'avg duration' THEN N' AverageDuration'
-                                                    WHEN 'avg executions' THEN N' ExecutionsPerMinute'
-													WHEN 'avg memory grant' THEN N' AvgMaxMemoryGrant'
-                                                    END + N' DESC '
+			SELECT @insert_sql += N' ORDER BY ' + CASE @SortOrder WHEN 'cpu' THEN ' TotalCPU '
+															WHEN 'reads' THEN ' TotalReads '
+															WHEN 'writes' THEN ' TotalWrites '
+															WHEN 'duration' THEN ' TotalDuration '
+															WHEN 'executions' THEN ' ExecutionCount '
+															WHEN 'compiles' THEN ' PlanCreationTime '
+															WHEN 'avg cpu' THEN 'AverageCPU'
+															WHEN 'avg reads' THEN 'AverageReads'
+															WHEN 'avg writes' THEN 'AverageWrites'
+															WHEN 'avg duration' THEN 'AverageDuration'
+															WHEN 'avg executions' THEN 'ExecutionsPerMinute'
+															END + N' DESC '
 
-    SET @insert_sql += N' OPTION (RECOMPILE) ; '    
+			SET @insert_sql += N' OPTION (RECOMPILE) ; '    
     
-    EXEC sp_executesql @insert_sql, N'@Top INT', @Top;
+			SET @insert_sql = REPLACE(@insert_sql,''''+@OutputSchemaName+'''',''''''+@OutputSchemaName+'''''')
+			SET @insert_sql = REPLACE(@insert_sql,''''+@OutputTableName+'''',''''''+@OutputTableName+'''''')
+			SET @insert_sql = REPLACE(@insert_sql,'XML','[NVARCHAR](MAX)')
+			EXEC('EXEC('''+@insert_sql+''') AT ' + @OutputServerName);
+		END   
+	ELSE
+		BEGIN
+			SET @insert_sql =N' IF EXISTS(SELECT * FROM '
+				+ @OutputDatabaseName
+				+ N'.INFORMATION_SCHEMA.SCHEMATA WHERE QUOTENAME(SCHEMA_NAME) = '''
+				+ @OutputSchemaName + N''') '
+				+ 'INSERT '
+				+ @OutputDatabaseName + '.'
+				+ @OutputSchemaName + '.'
+				+ @OutputTableName
+				+ N' (ServerName, CheckDate, Version, QueryType, DatabaseName, AverageCPU, TotalCPU, PercentCPUByType, CPUWeight, AverageDuration, TotalDuration, DurationWeight, PercentDurationByType, AverageReads, TotalReads, ReadWeight, PercentReadsByType, '
+				+ N' AverageWrites, TotalWrites, WriteWeight, PercentWritesByType, ExecutionCount, ExecutionWeight, PercentExecutionsByType, '
+				+ N' ExecutionsPerMinute, PlanCreationTime, LastExecutionTime, PlanHandle, SqlHandle, QueryHash, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows, QueryText, QueryPlan, NumberOfPlans, NumberOfDistinctPlans, Warnings, '
+				+ N' SerialRequiredMemory, SerialDesiredMemory) '
+				+ N'SELECT TOP (@Top) '
+				+ QUOTENAME(CAST(SERVERPROPERTY('ServerName') AS NVARCHAR(128)), N'''') + N', SYSDATETIMEOFFSET(),'
+				+ QUOTENAME(CAST(SERVERPROPERTY('ProductVersion') as nvarchar(128)), N'''') + ', '
+				+ N' QueryType, DatabaseName, AverageCPU, TotalCPU, PercentCPUByType, PercentCPU, AverageDuration, TotalDuration, PercentDuration, PercentDurationByType, AverageReads, TotalReads, PercentReads, PercentReadsByType, '
+				+ N' AverageWrites, TotalWrites, PercentWrites, PercentWritesByType, ExecutionCount, PercentExecutions, PercentExecutionsByType, '
+				+ N' ExecutionsPerMinute, PlanCreationTime, LastExecutionTime, PlanHandle, SqlHandle, QueryHash, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows, QueryText, QueryPlan, NumberOfPlans, NumberOfDistinctPlans, Warnings, '
+				+ N' SerialRequiredMemory, SerialDesiredMemory '
+				+ N' FROM ##bou_BlitzCacheProcs '
+          
+			SELECT @insert_sql += N' ORDER BY ' + CASE @SortOrder WHEN 'cpu' THEN ' TotalCPU '
+															WHEN 'reads' THEN ' TotalReads '
+															WHEN 'writes' THEN ' TotalWrites '
+															WHEN 'duration' THEN ' TotalDuration '
+															WHEN 'executions' THEN ' ExecutionCount '
+															WHEN 'compiles' THEN ' PlanCreationTime '
+															WHEN 'avg cpu' THEN 'AverageCPU'
+															WHEN 'avg reads' THEN 'AverageReads'
+															WHEN 'avg writes' THEN 'AverageWrites'
+															WHEN 'avg duration' THEN 'AverageDuration'
+															WHEN 'avg executions' THEN 'ExecutionsPerMinute'
+															END + N' DESC '
+
+			SET @insert_sql += N' OPTION (RECOMPILE) ; '    
+    
+			EXEC sp_executesql @insert_sql, N'@Top INT', @Top;
+		END
 
     RETURN
 END
@@ -2273,12 +2238,6 @@ BEGIN
             AverageReturnedRows,
             MinReturnedRows,
             MaxReturnedRows,
-		    MinGrantKB,
-		    MaxGrantKB,
-		    MinUsedGrantKB, 
-		    MaxUsedGrantKB,
-		    PercentMemoryGrantUsed,
-			AvgMaxMemoryGrant,
             NumberOfPlans,
             NumberOfDistinctPlans,
             PlanCreationTime AS [Created At],
@@ -2299,13 +2258,11 @@ BEGIN
                               WHEN 'duration' THEN ' TotalDuration '
                               WHEN 'executions' THEN ' ExecutionCount '
                               WHEN 'compiles' THEN ' PlanCreationTime '
-							  WHEN 'memory grant' THEN 'MaxGrantKB'
                               WHEN 'avg cpu' THEN 'AverageCPU'
                               WHEN 'avg reads' THEN 'AverageReads'
                               WHEN 'avg writes' THEN 'AverageWrites'
                               WHEN 'avg duration' THEN 'AverageDuration'
                               WHEN 'avg executions' THEN 'ExecutionsPerMinute'
-							  WHEN 'avg memory grant' THEN 'AvgMaxMemoryGrant'
                               END + N' DESC '
 
     SET @sql += N' OPTION (RECOMPILE) ; '
@@ -2341,11 +2298,6 @@ BEGIN
     AverageWrites AS [Avg Writes],
     PercentWrites AS [Write Weight],
     AverageReturnedRows AS [Average Rows],
-	MinGrantKB AS [Minimum Memory Grant KB],
-	MaxGrantKB AS [Maximum Memory Grant KB],
-	MinUsedGrantKB AS [Minimum Used Grant KB], 
-	MaxUsedGrantKB AS [Maximum Used Grant KB],
-	AvgMaxMemoryGrant AS [Average Max Memory Grant],
     PlanCreationTime AS [Created At],
     LastExecutionTime AS [Last Execution],
 	PlanHandle AS [Plan Handle], 
@@ -2362,7 +2314,7 @@ BEGIN
 
     IF @ExpertMode = 2 /* Opserver */
     BEGIN
-        SET @columns += N'        SUBSTRING(
+        SET @columns += '        SUBSTRING(
                   CASE WHEN warning_no_join_predicate = 1 THEN '', 20'' ELSE '''' END +
                   CASE WHEN compile_timeout = 1 THEN '', 18'' ELSE '''' END +
                   CASE WHEN compile_memory_limit_exceeded = 1 THEN '', 19'' ELSE '''' END +
@@ -2387,9 +2339,8 @@ BEGIN
                   CASE WHEN is_trivial = 1 THEN '', 24'' ELSE '''' END + 
 				  CASE WHEN is_forced_serial = 1 THEN '', 25'' ELSE '''' END +
                   CASE WHEN is_key_lookup_expensive = 1 THEN '', 26'' ELSE '''' END +
-				  CASE WHEN is_remote_query_expensive = 1 THEN '', 28'' ELSE '''' END + 
-				  CASE WHEN trace_flags_session IS NOT NULL THEN '', 29'' ELSE '''' END + 
-				  CASE WHEN is_unused_grant = 1 THEN '', 30'' ELSE '''' END
+				  CASE WHEN is_remote_query_expensive = 1 THEN '', 28'' ELSE '''' END  + 
+				  CASE WHEN trace_flags_session IS NOT NULL THEN '' , 29'' ELSE '''' END
 				  , 2, 200000) AS opserver_warning , ' + @nl ;
     END
     
@@ -2419,11 +2370,6 @@ BEGIN
         AverageReturnedRows AS [Avg Rows],
         MinReturnedRows AS [Min Rows],
         MaxReturnedRows AS [Max Rows],
-		MinGrantKB AS [Minimum Memory Grant KB],
-		MaxGrantKB AS [Maximum Memory Grant KB],
-		MinUsedGrantKB AS [Minimum Used Grant KB], 
-		MaxUsedGrantKB AS [Maximum Used Grant KB],
-		AvgMaxMemoryGrant AS [Average Max Memory Grant],
         NumberOfPlans AS [# Plans],
         NumberOfDistinctPlans AS [# Distinct Plans],
         PlanCreationTime AS [Created At],
@@ -2454,19 +2400,17 @@ SELECT  TOP (@Top) ' + @columns + @nl + N'
 FROM    ##bou_BlitzCacheProcs
 WHERE   SPID = @spid ' + @nl
 
-SELECT @sql += N' ORDER BY ' + CASE @SortOrder WHEN 'cpu' THEN N' TotalCPU '
-                                                WHEN 'reads' THEN N' TotalReads '
-                                                WHEN 'writes' THEN N' TotalWrites '
-                                                WHEN 'duration' THEN N' TotalDuration '
-                                                WHEN 'executions' THEN N' ExecutionCount '
-                                                WHEN 'compiles' THEN N' PlanCreationTime '
-												WHEN 'memory grant' THEN N' MaxGrantKB'
-                                                WHEN 'avg cpu' THEN N' AverageCPU'
-                                                WHEN 'avg reads' THEN N' AverageReads'
-                                                WHEN 'avg writes' THEN N' AverageWrites'
-                                                WHEN 'avg duration' THEN N' AverageDuration'
-                                                WHEN 'avg executions' THEN N' ExecutionsPerMinute'
-												WHEN 'avg memory grant' THEN N' AvgMaxMemoryGrant'
+SELECT @sql += N' ORDER BY ' + CASE @SortOrder WHEN 'cpu' THEN ' TotalCPU '
+                                                WHEN 'reads' THEN ' TotalReads '
+                                                WHEN 'writes' THEN ' TotalWrites '
+                                                WHEN 'duration' THEN ' TotalDuration '
+                                                WHEN 'executions' THEN ' ExecutionCount '
+                                                WHEN 'compiles' THEN ' PlanCreationTime '
+                                                WHEN 'avg cpu' THEN 'AverageCPU'
+                                                WHEN 'avg reads' THEN 'AverageReads'
+                                                WHEN 'avg writes' THEN 'AverageWrites'
+                                                WHEN 'avg duration' THEN 'AverageDuration'
+                                                WHEN 'avg executions' THEN 'ExecutionsPerMinute'
                                END + N' DESC '
 SET @sql += N' OPTION (RECOMPILE) ; '
 
@@ -2599,7 +2543,7 @@ BEGIN
                     'Performance',
                     'Long Running Queries',
                     'http://brentozar.com/blitzcache/long-running-queries/',
-                    'Long running queries have been found. These are queries with an average duration longer than '
+                    'Long running queries have beend found. These are queries with an average duration longer than '
                     + CAST(@long_running_query_warning_seconds / 1000 / 1000 AS VARCHAR(5))
                     + ' second(s). These queries should be investigated for additional tuning options') ;
 
@@ -2808,22 +2752,9 @@ BEGIN
                     29,
                     100,
                     'Trace Flags',
-                    'Session Level Trace Flags Enabled',
+                    'Session Level Trace FLags Enabled',
                     'https://www.brentozar.com/blitz/trace-flags-enabled-globally/',
                     'Someone is enabling session level Trace Flags in a query.') ;
-
-        IF EXISTS (SELECT 1/0
-                   FROM   ##bou_BlitzCacheProcs p
-                   WHERE  p.is_unused_grant IS NOT NULL
-				   AND SPID = @@SPID)
-            INSERT INTO ##bou_BlitzCacheResults (SPID, CheckID, Priority, FindingsGroup, Finding, URL, Details)
-            VALUES (@@SPID,
-                    30,
-                    100,
-                    'Unused memory grants',
-                    'Queries are asking for more memory than they''re using',
-                    'No URL yet.',
-                    'Queries have large unused memory grants. This can cause concurrency issues, if queries are waiting a long time to get memory to run.') ;
 
         IF EXISTS (SELECT 1/0
                    FROM   #trace_flags AS tf 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -22,117 +22,127 @@ CREATE TABLE ##bou_BlitzCacheResults (
 );
 
 CREATE TABLE ##bou_BlitzCacheProcs (
-    SPID INT ,
-    QueryType nvarchar(256),
-    DatabaseName sysname,
-    AverageCPU decimal(38,4),
-    AverageCPUPerMinute decimal(38,4),
-    TotalCPU decimal(38,4),
-    PercentCPUByType money,
-    PercentCPU money,
-    AverageDuration decimal(38,4),
-    TotalDuration decimal(38,4),
-    PercentDuration money,
-    PercentDurationByType money,
-    AverageReads bigint,
-    TotalReads bigint,
-    PercentReads money,
-    PercentReadsByType money,
-    ExecutionCount bigint,
-    PercentExecutions money,
-    PercentExecutionsByType money,
-    ExecutionsPerMinute money,
-    TotalWrites bigint,
-    AverageWrites money,
-    PercentWrites money,
-    PercentWritesByType money,
-    WritesPerMinute money,
-    PlanCreationTime datetime,
-    LastExecutionTime datetime,
-    PlanHandle varbinary(64),
-	[Remove Plan Handle From Cache] AS 
-		CASE WHEN [PlanHandle] IS NOT NULL 
-		THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [PlanHandle], 1) + ');'
-		ELSE 'N/A' END,
-    SqlHandle varbinary(64),
-	[Remove SQL Handle From Cache] AS 
-	CASE WHEN [SqlHandle] IS NOT NULL 
-	THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [SqlHandle], 1) + ');'
-	ELSE 'N/A' END,
-	[SQL Handle More Info] AS 
-		CASE WHEN [SqlHandle] IS NOT NULL 
-		THEN 'EXEC sp_BlitzCache @OnlySqlHandles = ''' + CONVERT(VARCHAR(128), [SqlHandle], 1) + '''; '
-		ELSE 'N/A' END,
-    QueryHash binary(8),
-	[Query Hash More Info] AS 
-		CASE WHEN [QueryHash] IS NOT NULL 
-		THEN 'EXEC sp_BlitzCache @OnlyQueryHashes = ''' + CONVERT(VARCHAR(32), [QueryHash], 1) + '''; '
-		ELSE 'N/A' END,
-    QueryPlanHash binary(8),
-    StatementStartOffset int,
-    StatementEndOffset int,
-    MinReturnedRows bigint,
-    MaxReturnedRows bigint,
-    AverageReturnedRows money,
-    TotalReturnedRows bigint,
-    LastReturnedRows bigint,trace_flags_global varchar(1000),
-    QueryText nvarchar(max),
-    QueryPlan xml,
-    /* these next four columns are the total for the type of query.
-        don't actually use them for anything apart from math by type.
-        */
-    TotalWorkerTimeForType bigint,
-    TotalElapsedTimeForType bigint,
-    TotalReadsForType bigint,
-    TotalExecutionCountForType bigint,
-    TotalWritesForType bigint,
-    NumberOfPlans int,
-    NumberOfDistinctPlans int,
-    SerialDesiredMemory float,
-    SerialRequiredMemory float,
-    CachedPlanSize float,
-    CompileTime float,
-    CompileCPU float ,
-    CompileMemory float ,
-    min_worker_time bigint,
-    max_worker_time bigint,
-    is_forced_plan bit,
-    is_forced_parameterized bit,
-    is_cursor bit,
-    is_parallel bit,
-	is_key_lookup_expensive bit,
-	key_lookup_cost float,
-	is_remote_query_expensive bit,
-	remote_query_cost float,
-	is_forced_serial bit,
-    frequent_execution bit,
-    parameter_sniffing bit,
-    unparameterized_query bit,
-    near_parallel bit,
-    plan_warnings bit,
-    plan_multiple_plans bit,
-    long_running bit,
-    downlevel_estimator bit,
-    implicit_conversions bit,
-    busy_loops bit,
-    tvf_join bit,
-    tvf_estimate bit,
-    compile_timeout bit,
-    compile_memory_limit_exceeded bit,
-    warning_no_join_predicate bit,
-    QueryPlanCost float,
-    missing_index_count int,
-    unmatched_index_count int,
-    min_elapsed_time bigint,
-    max_elapsed_time bigint,
-    age_minutes money,
-    age_minutes_lifetime money,
-    is_trivial bit,
-	trace_flags_session varchar(1000),
-    SetOptions VARCHAR(MAX),
-    Warnings VARCHAR(MAX)
-);
-GO
+        SPID INT ,
+        QueryType NVARCHAR(256),
+        DatabaseName sysname,
+        AverageCPU DECIMAL(38,4),
+        AverageCPUPerMinute DECIMAL(38,4),
+        TotalCPU DECIMAL(38,4),
+        PercentCPUByType MONEY,
+        PercentCPU MONEY,
+        AverageDuration DECIMAL(38,4),
+        TotalDuration DECIMAL(38,4),
+        PercentDuration MONEY,
+        PercentDurationByType MONEY,
+        AverageReads BIGINT,
+        TotalReads BIGINT,
+        PercentReads MONEY,
+        PercentReadsByType MONEY,
+        ExecutionCount BIGINT,
+        PercentExecutions MONEY,
+        PercentExecutionsByType MONEY,
+        ExecutionsPerMinute MONEY,
+        TotalWrites BIGINT,
+        AverageWrites MONEY,
+        PercentWrites MONEY,
+        PercentWritesByType MONEY,
+        WritesPerMinute MONEY,
+        PlanCreationTime DATETIME,
+        LastExecutionTime DATETIME,
+        PlanHandle VARBINARY(64),
+		[Remove Plan Handle From Cache] AS 
+			CASE WHEN [PlanHandle] IS NOT NULL 
+			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [PlanHandle], 1) + ');'
+			ELSE 'N/A' END,
+		SqlHandle VARBINARY(64),
+			[Remove SQL Handle From Cache] AS 
+			CASE WHEN [SqlHandle] IS NOT NULL 
+			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [SqlHandle], 1) + ');'
+			ELSE 'N/A' END,
+		[SQL Handle More Info] AS 
+			CASE WHEN [SqlHandle] IS NOT NULL 
+			THEN 'EXEC sp_BlitzCache @OnlySqlHandles = ''' + CONVERT(VARCHAR(128), [SqlHandle], 1) + '''; '
+			ELSE 'N/A' END,
+		QueryHash BINARY(8),
+		[Query Hash More Info] AS 
+			CASE WHEN [QueryHash] IS NOT NULL 
+			THEN 'EXEC sp_BlitzCache @OnlyQueryHashes = ''' + CONVERT(VARCHAR(32), [QueryHash], 1) + '''; '
+			ELSE 'N/A' END,
+        QueryPlanHash BINARY(8),
+        StatementStartOffset INT,
+        StatementEndOffset INT,
+        MinReturnedRows BIGINT,
+        MaxReturnedRows BIGINT,
+        AverageReturnedRows MONEY,
+        TotalReturnedRows BIGINT,
+        LastReturnedRows BIGINT,
+		/*The Memory Grant columns are only supported 
+		  in certain versions, giggle giggle.
+		*/
+		MinGrantKB BIGINT,
+		MaxGrantKB BIGINT,
+		MinUsedGrantKB BIGINT, 
+		MaxUsedGrantKB BIGINT,
+		PercentMemoryGrantUsed MONEY,
+		AvgMaxMemoryGrant MONEY,
+        QueryText NVARCHAR(MAX),
+        QueryPlan XML,
+        /* these next four columns are the total for the type of query.
+            don't actually use them for anything apart from math by type.
+            */
+        TotalWorkerTimeForType BIGINT,
+        TotalElapsedTimeForType BIGINT,
+        TotalReadsForType BIGINT,
+        TotalExecutionCountForType BIGINT,
+        TotalWritesForType BIGINT,
+        NumberOfPlans INT,
+        NumberOfDistinctPlans INT,
+        SerialDesiredMemory FLOAT,
+        SerialRequiredMemory FLOAT,
+        CachedPlanSize FLOAT,
+        CompileTime FLOAT,
+        CompileCPU FLOAT ,
+        CompileMemory FLOAT ,
+        min_worker_time BIGINT,
+        max_worker_time BIGINT,
+        is_forced_plan BIT,
+        is_forced_parameterized BIT,
+        is_cursor BIT,
+        is_parallel BIT,
+		is_forced_serial BIT,
+		is_key_lookup_expensive BIT,
+		key_lookup_cost FLOAT,
+		is_remote_query_expensive BIT,
+		remote_query_cost FLOAT,
+        frequent_execution BIT,
+        parameter_sniffing BIT,
+        unparameterized_query BIT,
+        near_parallel BIT,
+        plan_warnings BIT,
+        plan_multiple_plans BIT,
+        long_running BIT,
+        downlevel_estimator BIT,
+        implicit_conversions BIT,
+        busy_loops BIT,
+        tvf_join BIT,
+        tvf_estimate BIT,
+        compile_timeout BIT,
+        compile_memory_limit_exceeded BIT,
+        warning_no_join_predicate BIT,
+        QueryPlanCost FLOAT,
+        missing_index_count INT,
+        unmatched_index_count INT,
+        min_elapsed_time BIGINT,
+        max_elapsed_time BIGINT,
+        age_minutes MONEY,
+        age_minutes_lifetime MONEY,
+        is_trivial BIT,
+		trace_flags_session VARCHAR(1000),
+		is_unused_grant BIT,
+        SetOptions VARCHAR(MAX),
+        Warnings VARCHAR(MAX)
+    );
+GO 
 
 ALTER PROCEDURE dbo.sp_BlitzCache
     @Help BIT = 0,
@@ -179,7 +189,7 @@ Known limitations of this version:
  - This query will not run on SQL Server 2005.
  - SQL Server 2008 and 2008R2 have a bug in trigger stats, so that output is
    excluded by default.
- - @IgnoreQueryHashes and @only_query_hashes require a CSV list of hashes
+ - @IgnoreQueryHashes and @OnlyQueryHashes require a CSV list of hashes
    with no spaces between the hash values.
  - @OutputServerName is functional, but query plans will return as NVARCHAR(MAX)
    rather than XML, and the summary table will not be stored.
@@ -253,7 +263,7 @@ SOFTWARE.
 '
 
 
-DECLARE @nl nvarchar(2) = NCHAR(13) + NCHAR(10) ;
+DECLARE @nl NVARCHAR(2) = NCHAR(13) + NCHAR(10) ;
 
 IF @Help = 1
 BEGIN
@@ -269,7 +279,7 @@ BEGIN
     UNION ALL
     SELECT N'@SortOrder',
            N'VARCHAR(10)',
-           N'Data processing and display order. @SortOrder will still be used, even when preparing output for a table or for excel. Possible values are: "CPU", "Reads", "Writes", "Duration", "Executions", "Recent Compilations". Additionally, the word "Average" or "Avg" can be used to sort on averages rather than total. "Executions per minute" and "Executions / minute" can be used to sort by execution per minute. For the truly lazy, "xpm" can also be used.'
+           N'Data processing and display order. @SortOrder will still be used, even when preparing output for a table or for excel. Possible values are: "CPU", "Reads", "Writes", "Duration", "Executions", "Recent Compilations", "Memory Grant". Additionally, the word "Average" or "Avg" can be used to sort on averages rather than total. "Executions per minute" and "Executions / minute" can be used to sort by execution per minute. For the truly lazy, "xpm" can also be used.'
 
     UNION ALL
     SELECT N'@UseTriggersAnyway',
@@ -490,6 +500,36 @@ BEGIN
            N'The maximum number of rows returned by any execution of this query.'
 
     UNION ALL
+    SELECT N'MinGrantKB',
+           N'BIGINT',
+           N'The minim memory grant the query received in kb.'
+
+    UNION ALL
+    SELECT N'MaxGrantKB',
+           N'BIGINT',
+           N'The maximum memory grant the query received in kb.'
+
+    UNION ALL
+    SELECT N'MinUsedGrantKB',
+           N'BIGINT',
+           N'The minim used memory grant the query received in kb.'
+
+    UNION ALL
+    SELECT N'MaxUsedGrantKB',
+           N'BIGINT',
+           N'The maximum used memory grant the query received in kb.'
+
+    UNION ALL
+    SELECT N'PercentMemoryGrantUsed',
+           N'MONEY',
+           N'Result of dividing the maximum grant used by the minimum granted.'
+
+    UNION ALL
+    SELECT N'AvgMaxMemoryGrant',
+           N'MONEY',
+           N'The average maximum memory grant for a query.'
+
+    UNION ALL
     SELECT N'# Plans',
            N'INT',
            N'The total number of execution plans found that match a given query.'
@@ -568,6 +608,11 @@ BEGIN
            N'Seconds' ,
            N'Triggers a "Long Running Query Warning" when average duration, max CPU time, or max clock time is higher than this number.'
 
+    UNION ALL
+    SELECT N'Unused Memory Grant Warning' AS [Configuration Parameter] ,
+           N'10' ,
+           N'Percent' ,
+           N'Triggers an "Unused Memory Grant Warning" when a query uses >= X percent of its memory grant.'
     RETURN
 END
 
@@ -599,38 +644,38 @@ IF OBJECT_ID('tempdb.dbo.##bou_BlitzCacheProcs') IS NULL
 BEGIN
     CREATE TABLE ##bou_BlitzCacheProcs (
         SPID INT ,
-        QueryType nvarchar(256),
+        QueryType NVARCHAR(256),
         DatabaseName sysname,
-        AverageCPU decimal(38,4),
-        AverageCPUPerMinute decimal(38,4),
-        TotalCPU decimal(38,4),
-        PercentCPUByType money,
-        PercentCPU money,
-        AverageDuration decimal(38,4),
-        TotalDuration decimal(38,4),
-        PercentDuration money,
-        PercentDurationByType money,
-        AverageReads bigint,
-        TotalReads bigint,
-        PercentReads money,
-        PercentReadsByType money,
-        ExecutionCount bigint,
-        PercentExecutions money,
-        PercentExecutionsByType money,
-        ExecutionsPerMinute money,
-        TotalWrites bigint,
-        AverageWrites money,
-        PercentWrites money,
-        PercentWritesByType money,
-        WritesPerMinute money,
-        PlanCreationTime datetime,
-        LastExecutionTime datetime,
-        PlanHandle varbinary(64),
+        AverageCPU DECIMAL(38,4),
+        AverageCPUPerMinute DECIMAL(38,4),
+        TotalCPU DECIMAL(38,4),
+        PercentCPUByType MONEY,
+        PercentCPU MONEY,
+        AverageDuration DECIMAL(38,4),
+        TotalDuration DECIMAL(38,4),
+        PercentDuration MONEY,
+        PercentDurationByType MONEY,
+        AverageReads BIGINT,
+        TotalReads BIGINT,
+        PercentReads MONEY,
+        PercentReadsByType MONEY,
+        ExecutionCount BIGINT,
+        PercentExecutions MONEY,
+        PercentExecutionsByType MONEY,
+        ExecutionsPerMinute MONEY,
+        TotalWrites BIGINT,
+        AverageWrites MONEY,
+        PercentWrites MONEY,
+        PercentWritesByType MONEY,
+        WritesPerMinute MONEY,
+        PlanCreationTime DATETIME,
+        LastExecutionTime DATETIME,
+        PlanHandle VARBINARY(64),
 		[Remove Plan Handle From Cache] AS 
 			CASE WHEN [PlanHandle] IS NOT NULL 
 			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [PlanHandle], 1) + ');'
 			ELSE 'N/A' END,
-		SqlHandle varbinary(64),
+		SqlHandle VARBINARY(64),
 			[Remove SQL Handle From Cache] AS 
 			CASE WHEN [SqlHandle] IS NOT NULL 
 			THEN 'DBCC FREEPROCCACHE (' + CONVERT(VARCHAR(128), [SqlHandle], 1) + ');'
@@ -639,72 +684,79 @@ BEGIN
 			CASE WHEN [SqlHandle] IS NOT NULL 
 			THEN 'EXEC sp_BlitzCache @OnlySqlHandles = ''' + CONVERT(VARCHAR(128), [SqlHandle], 1) + '''; '
 			ELSE 'N/A' END,
-		QueryHash binary(8),
+		QueryHash BINARY(8),
 		[Query Hash More Info] AS 
 			CASE WHEN [QueryHash] IS NOT NULL 
 			THEN 'EXEC sp_BlitzCache @OnlyQueryHashes = ''' + CONVERT(VARCHAR(32), [QueryHash], 1) + '''; '
 			ELSE 'N/A' END,
-        QueryPlanHash binary(8),
-        StatementStartOffset int,
-        StatementEndOffset int,
-        MinReturnedRows bigint,
-        MaxReturnedRows bigint,
-        AverageReturnedRows money,
-        TotalReturnedRows bigint,
-        LastReturnedRows bigint,
-        QueryText nvarchar(max),
-        QueryPlan xml,
+        QueryPlanHash BINARY(8),
+        StatementStartOffset INT,
+        StatementEndOffset INT,
+        MinReturnedRows BIGINT,
+        MaxReturnedRows BIGINT,
+        AverageReturnedRows MONEY,
+        TotalReturnedRows BIGINT,
+        LastReturnedRows BIGINT,
+		MinGrantKB BIGINT,
+		MaxGrantKB BIGINT,
+		MinUsedGrantKB BIGINT, 
+		MaxUsedGrantKB BIGINT,
+		PercentMemoryGrantUsed MONEY,
+		AvgMaxMemoryGrant MONEY,
+        QueryText NVARCHAR(MAX),
+        QueryPlan XML,
         /* these next four columns are the total for the type of query.
             don't actually use them for anything apart from math by type.
             */
-        TotalWorkerTimeForType bigint,
-        TotalElapsedTimeForType bigint,
-        TotalReadsForType bigint,
-        TotalExecutionCountForType bigint,
-        TotalWritesForType bigint,
-        NumberOfPlans int,
-        NumberOfDistinctPlans int,
-        SerialDesiredMemory float,
-        SerialRequiredMemory float,
-        CachedPlanSize float,
-        CompileTime float,
-        CompileCPU float ,
-        CompileMemory float ,
-        min_worker_time bigint,
-        max_worker_time bigint,
-        is_forced_plan bit,
-        is_forced_parameterized bit,
-        is_cursor bit,
-        is_parallel bit,
-		is_forced_serial bit,
-		is_key_lookup_expensive bit,
-		key_lookup_cost float,
-		is_remote_query_expensive bit,
-		remote_query_cost float,
-        frequent_execution bit,
-        parameter_sniffing bit,
-        unparameterized_query bit,
-        near_parallel bit,
-        plan_warnings bit,
-        plan_multiple_plans bit,
-        long_running bit,
-        downlevel_estimator bit,
-        implicit_conversions bit,
-        busy_loops bit,
-        tvf_join bit,
-        tvf_estimate bit,
-        compile_timeout bit,
-        compile_memory_limit_exceeded bit,
-        warning_no_join_predicate bit,
-        QueryPlanCost float,
-        missing_index_count int,
-        unmatched_index_count int,
-        min_elapsed_time bigint,
-        max_elapsed_time bigint,
-        age_minutes money,
-        age_minutes_lifetime money,
-        is_trivial bit,
-		trace_flags_session varchar(1000),
+        TotalWorkerTimeForType BIGINT,
+        TotalElapsedTimeForType BIGINT,
+        TotalReadsForType BIGINT,
+        TotalExecutionCountForType BIGINT,
+        TotalWritesForType BIGINT,
+        NumberOfPlans INT,
+        NumberOfDistinctPlans INT,
+        SerialDesiredMemory FLOAT,
+        SerialRequiredMemory FLOAT,
+        CachedPlanSize FLOAT,
+        CompileTime FLOAT,
+        CompileCPU FLOAT ,
+        CompileMemory FLOAT ,
+        min_worker_time BIGINT,
+        max_worker_time BIGINT,
+        is_forced_plan BIT,
+        is_forced_parameterized BIT,
+        is_cursor BIT,
+        is_parallel BIT,
+		is_forced_serial BIT,
+		is_key_lookup_expensive BIT,
+		key_lookup_cost FLOAT,
+		is_remote_query_expensive BIT,
+		remote_query_cost FLOAT,
+        frequent_execution BIT,
+        parameter_sniffing BIT,
+        unparameterized_query BIT,
+        near_parallel BIT,
+        plan_warnings BIT,
+        plan_multiple_plans BIT,
+        long_running BIT,
+        downlevel_estimator BIT,
+        implicit_conversions BIT,
+        busy_loops BIT,
+        tvf_join BIT,
+        tvf_estimate BIT,
+        compile_timeout BIT,
+        compile_memory_limit_exceeded BIT,
+        warning_no_join_predicate BIT,
+        QueryPlanCost FLOAT,
+        missing_index_count INT,
+        unmatched_index_count INT,
+        min_elapsed_time BIGINT,
+        max_elapsed_time BIGINT,
+        age_minutes MONEY,
+        age_minutes_lifetime MONEY,
+        is_trivial BIT,
+		trace_flags_session VARCHAR(1000),
+		is_unused_grant BIT,
         SetOptions VARCHAR(MAX),
         Warnings VARCHAR(MAX)
     );
@@ -723,6 +775,12 @@ IF @DurationFilter IS NOT NULL
   SET @DurationFilter_i = CAST((@DurationFilter * 1000.0) AS INT)
 
 SET @DatabaseName = LTRIM(RTRIM(@DatabaseName)) ;
+IF (DB_ID(@DatabaseName)) IS NULL AND @DatabaseName <> ''
+BEGIN
+   RAISERROR('The database you specified does not exist. Please check the name and try again.', 16, 1);
+   RETURN;
+END
+
 
 SET @SortOrder = LOWER(@SortOrder);
 SET @SortOrder = REPLACE(REPLACE(@SortOrder, 'average', 'avg'), '.', '');
@@ -734,7 +792,7 @@ SET @SortOrder = REPLACE(@SortOrder, 'recent compilations', 'compiles');
 
 IF @SortOrder NOT IN ('cpu', 'avg cpu', 'reads', 'avg reads', 'writes', 'avg writes',
                        'duration', 'avg duration', 'executions', 'avg executions',
-                       'compiles')
+                       'compiles', 'memory grant', 'avg memory grant')
   SET @SortOrder = 'cpu';
 
 SELECT @OutputServerName   = QUOTENAME(@OutputServerName),
@@ -753,7 +811,7 @@ ELSE IF @Reanalyze = 0
   DELETE ##bou_BlitzCacheResults
     WHERE SPID = @@SPID;
 
-if @SkipAnalysis = 1
+IF @SkipAnalysis = 1
     SET @HideSummary = 1;
 
 IF @Reanalyze = 1 
@@ -793,20 +851,20 @@ CREATE TABLE #only_sql_handles (
 );
 
 CREATE TABLE #p (
-    SqlHandle varbinary(64),
-    TotalCPU bigint,
-    TotalDuration bigint,
-    TotalReads bigint,
-    TotalWrites bigint,
-    ExecutionCount bigint
+    SqlHandle VARBINARY(64),
+    TotalCPU BIGINT,
+    TotalDuration BIGINT,
+    TotalReads BIGINT,
+    TotalWrites BIGINT,
+    ExecutionCount BIGINT
 );
 
 CREATE TABLE #checkversion (
-    version nvarchar(128),
+    version NVARCHAR(128),
     common_version AS SUBSTRING(version, 1, CHARINDEX('.', version) + 1 ),
     major AS PARSENAME(CONVERT(VARCHAR(32), version), 4),
     minor AS PARSENAME(CONVERT(VARCHAR(32), version), 3),
-    build AS PARSENAME(CONVERT(varchar(32), version), 2),
+    build AS PARSENAME(CONVERT(VARCHAR(32), version), 2),
     revision AS PARSENAME(CONVERT(VARCHAR(32), version), 1)
 );
 
@@ -835,8 +893,8 @@ BEGIN
                SET @individual = SUBSTRING(@OnlySqlHandles, 0, PATINDEX('%,%',@OnlySqlHandles)) ;
                
                INSERT INTO #only_sql_handles
-               select cast('' as xml).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
-               from (select case substring(@individual, 1, 2) when '0x' then 3 else 0 end) as t(pos)
+               SELECT CAST('' AS XML).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
+               FROM (SELECT CASE SUBSTRING(@individual, 1, 2) WHEN '0x' THEN 3 ELSE 0 END) AS t(pos)
                
                --SELECT CAST(SUBSTRING(@individual, 1, 2) AS BINARY(8));
 
@@ -883,8 +941,8 @@ BEGIN
                SET @individual = SUBSTRING(@OnlyQueryHashes, 0, PATINDEX('%,%',@OnlyQueryHashes)) ;
                
                INSERT INTO #only_query_hashes
-               select cast('' as xml).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
-               from (select case substring(@individual, 1, 2) when '0x' then 3 else 0 end) as t(pos)
+               SELECT CAST('' AS XML).value('xs:hexBinary( substring(sql:variable("@individual"), sql:column("t.pos")) )', 'varbinary(max)')
+               FROM (SELECT CASE SUBSTRING(@individual, 1, 2) WHEN '0x' THEN 3 ELSE 0 END) AS t(pos)
                
                --SELECT CAST(SUBSTRING(@individual, 1, 2) AS BINARY(8));
 
@@ -950,24 +1008,24 @@ BEGIN
    EXEC(@config_sql);
 END
 
-DECLARE @sql nvarchar(MAX) = N'',
-        @insert_list nvarchar(MAX) = N'',
-        @plans_triggers_select_list nvarchar(MAX) = N'',
-        @body nvarchar(MAX) = N'',
-        @body_where nvarchar(MAX) = N'WHERE 1 = 1 ' + @nl,
-        @body_order nvarchar(MAX) = N'ORDER BY #sortable# DESC OPTION (RECOMPILE) ',
+DECLARE @sql NVARCHAR(MAX) = N'',
+        @insert_list NVARCHAR(MAX) = N'',
+        @plans_triggers_select_list NVARCHAR(MAX) = N'',
+        @body NVARCHAR(MAX) = N'',
+        @body_where NVARCHAR(MAX) = N'WHERE 1 = 1 ' + @nl,
+        @body_order NVARCHAR(MAX) = N'ORDER BY #sortable# DESC OPTION (RECOMPILE) ',
         
-        @q nvarchar(1) = N'''',
-        @pv varchar(20),
-        @pos tinyint,
-        @v decimal(6,2),
-        @build int;
+        @q NVARCHAR(1) = N'''',
+        @pv VARCHAR(20),
+        @pos TINYINT,
+        @v DECIMAL(6,2),
+        @build INT;
 
 
 RAISERROR (N'Determining SQL Server version.',0,1) WITH NOWAIT;
 
 INSERT INTO #checkversion (version)
-SELECT CAST(SERVERPROPERTY('ProductVersion') as nvarchar(128))
+SELECT CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128))
 OPTION (RECOMPILE);
 
 
@@ -976,6 +1034,16 @@ SELECT @v = common_version ,
 FROM   #checkversion
 OPTION (RECOMPILE);
 
+IF (@SortOrder IN ('memory grant', 'avg memory grant')) 
+AND ((@v < 11)
+OR (@v = 11 AND @build < 6020) 
+OR (@v = 12 AND @build < 5000) 
+OR (@v = 13 AND @build < 1601))
+BEGIN
+   RAISERROR('Your version of SQL does not support sorting by memory grant or average memory grant. Please use another sort order.', 16, 1);
+   RETURN;
+END
+
 RAISERROR (N'Creating dynamic SQL based on SQL Server version.',0,1) WITH NOWAIT;
 
 SET @insert_list += N'
@@ -983,7 +1051,8 @@ INSERT INTO ##bou_BlitzCacheProcs (SPID, QueryType, DatabaseName, AverageCPU, To
                     PercentReadsByType, PercentExecutionsByType, AverageDuration, TotalDuration, AverageReads, TotalReads, ExecutionCount,
                     ExecutionsPerMinute, TotalWrites, AverageWrites, PercentWritesByType, WritesPerMinute, PlanCreationTime,
                     LastExecutionTime, StatementStartOffset, StatementEndOffset, MinReturnedRows, MaxReturnedRows, AverageReturnedRows, TotalReturnedRows,
-                    LastReturnedRows, QueryText, QueryPlan, TotalWorkerTimeForType, TotalElapsedTimeForType, TotalReadsForType,
+                    LastReturnedRows, MinGrantKB, MaxGrantKB, MinUsedGrantKB, MaxUsedGrantKB, PercentMemoryGrantUsed, AvgMaxMemoryGrant,
+					QueryText, QueryPlan, TotalWorkerTimeForType, TotalElapsedTimeForType, TotalReadsForType,
                     TotalExecutionCountForType, TotalWritesForType, SqlHandle, PlanHandle, QueryHash, QueryPlanHash,
                     min_worker_time, max_worker_time, is_parallel, min_elapsed_time, max_elapsed_time, age_minutes, age_minutes_lifetime) ' ;
 
@@ -1040,19 +1109,21 @@ IF @DurationFilter IS NOT NULL
    This should make it faster to process since we'll be pulling back fewer
    plans for processing.
  */
-SELECT @body += '        ORDER BY ' +
-                CASE @SortOrder WHEN 'cpu' THEN 'total_worker_time'
-                                 WHEN 'reads' THEN 'total_logical_reads'
-                                 WHEN 'writes' THEN 'total_logical_writes'
-                                 WHEN 'duration' THEN 'total_elapsed_time'
-                                 WHEN 'executions' THEN 'execution_count'
-                                 WHEN 'compiles' THEN 'cached_time'
+SELECT @body += N'        ORDER BY ' +
+                CASE @SortOrder  WHEN N'cpu' THEN N'total_worker_time'
+                                 WHEN N'reads' THEN N'total_logical_reads'
+                                 WHEN N'writes' THEN N'total_logical_writes'
+                                 WHEN N'duration' THEN N'total_elapsed_time'
+                                 WHEN N'executions' THEN N'execution_count'
+                                 WHEN N'compiles' THEN N'cached_time'
+								 WHEN N'memory grant' THEN N'max_grant_kb'
                                  /* And now the averages */
-                                 WHEN 'avg cpu' THEN 'total_worker_time / execution_count'
-                                 WHEN 'avg reads' THEN 'total_logical_reads / execution_count'
-                                 WHEN 'avg writes' THEN 'total_logical_writes / execution_count'
-                                 WHEN 'avg duration' THEN 'total_elapsed_time / execution_count'
-                                 WHEN 'avg executions' THEN 'CASE WHEN execution_count = 0 THEN 0
+                                 WHEN N'avg cpu' THEN N'total_worker_time / execution_count'
+                                 WHEN N'avg reads' THEN N'total_logical_reads / execution_count'
+                                 WHEN N'avg writes' THEN N'total_logical_writes / execution_count'
+                                 WHEN N'avg duration' THEN N'total_elapsed_time / execution_count'
+								 WHEN N'avg memory grant' THEN N'CASE WHEN max_grant_kb = 0 THEN 0 ELSE max_grant_kb / execution_count END'
+                                 WHEN N'avg executions' THEN 'CASE WHEN execution_count = 0 THEN 0
             WHEN COALESCE(CAST((CASE WHEN DATEDIFF(mi, cached_time, GETDATE()) > 0 AND execution_count > 1
                           THEN DATEDIFF(mi, cached_time, GETDATE())
                           ELSE NULL END) as MONEY), CAST((CASE WHEN DATEDIFF(mi, cached_time, last_execution_time) > 0 AND execution_count > 1
@@ -1064,7 +1135,7 @@ SELECT @body += '        ORDER BY ' +
                           THEN DATEDIFF(mi, cached_time, last_execution_time)
                           ELSE Null END) as MONEY))) AS money)
             END '
-                END + ' DESC ' + @nl ;
+                END + N' DESC ' + @nl ;
 
 
                           
@@ -1133,6 +1204,12 @@ SELECT TOP (@Top)
        NULL AS AvgReturnedRows,
        NULL AS TotalReturnedRows,
        NULL AS LastReturnedRows,
+       NULL AS MinGrantKB,
+       NULL AS MaxGrantKB,
+       NULL AS MinUsedGrantKB, 
+	   NULL AS MaxUsedGrantKB,
+	   NULL AS PercentMemoryGrantUsed, 
+	   NULL AS AvgMaxMemoryGrant,
        st.text AS QueryText ,
        query_plan AS QueryPlan,
        t.t_TotalWorker,
@@ -1213,6 +1290,29 @@ BEGIN
            NULL AS TotalReturnedRows,
            NULL AS LastReturnedRows, ' ;
     END
+
+    IF (@v = 11 AND @build >= 6020) OR (@v = 12 AND @build >= 5000) OR (@v = 13 AND @build >= 1601)
+
+    BEGIN
+        SET @sql += N'
+           min_grant_kb AS MinGrantKB,
+           max_grant_kb AS MaxGrantKB,
+           min_used_grant_kb AS MinUsedGrantKB,
+           max_used_grant_kb AS MaxUsedGrantKB,
+           CAST(ISNULL(NULLIF(( max_used_grant_kb * 1.00 ), 0) / NULLIF(min_grant_kb, 0), 0) * 100. AS MONEY) AS PercentMemoryGrantUsed,
+		   CAST(ISNULL(NULLIF(( max_grant_kb * 1. ), 0) / NULLIF(execution_count, 0), 0) AS MONEY) AS AvgMaxMemoryGrant, ';
+    END
+    ELSE
+    BEGIN
+        SET @sql += N'
+           NULL AS MinGrantKB,
+           NULL AS MaxGrantKB,
+           NULL AS MinUsedGrantKB, 
+		   NULL AS MaxUsedGrantKB,
+		   NULL AS PercentMemoryGrantUsed, 
+		   NULL AS AvgMaxMemoryGrant, ' ;
+    END
+
     
     SET @sql += N'
            SUBSTRING(st.text, ( qs.statement_start_offset / 2 ) + 1, ( ( CASE qs.statement_end_offset
@@ -1235,7 +1335,7 @@ BEGIN
            qs.min_elapsed_time / 1000.0,
            qs.max_worker_time  / 1000.0,
            age_minutes,
-           age_minutes_lifetime '
+           age_minutes_lifetime ';
     
     SET @sql += REPLACE(REPLACE(@body, '#view#', 'dm_exec_query_stats'), 'cached_time', 'creation_time') ;
     
@@ -1250,7 +1350,10 @@ BEGIN
 END
 
 
-IF (@QueryFilter = 'all' AND (SELECT COUNT(*) FROM #only_query_hashes) = 0 AND (SELECT COUNT(*) FROM #ignore_query_hashes) = 0) 
+IF (@QueryFilter = 'all' 
+   AND (SELECT COUNT(*) FROM #only_query_hashes) = 0 
+   AND (SELECT COUNT(*) FROM #ignore_query_hashes) = 0) 
+   AND (@SortOrder NOT IN ('memory grant', 'avg memory grant'))
    OR (LEFT(@QueryFilter, 3) = 'pro')
 BEGIN
     SET @sql += @insert_list;
@@ -1260,7 +1363,7 @@ BEGIN
     SET @sql += @body_where ;
 
     IF @IgnoreSystemDBs = 1
-       SET @sql += ' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
+       SET @sql += N' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
 
     SET @sql += @body_order + @nl + @nl + @nl ;
 END
@@ -1282,6 +1385,7 @@ IF (@UseTriggersAnyway = 1 OR @v >= 11)
    AND (SELECT COUNT(*) FROM #only_query_hashes) = 0
    AND (SELECT COUNT(*) FROM #ignore_query_hashes) = 0
    AND (@QueryFilter = 'all')
+   AND (@SortOrder NOT IN ('memory grant', 'avg memory grant'))
 BEGIN
    RAISERROR (N'Adding SQL to collect trigger stats.',0,1) WITH NOWAIT;
 
@@ -1295,25 +1399,27 @@ BEGIN
    SET @sql += @body_where ;
 
    IF @IgnoreSystemDBs = 1
-      SET @sql += ' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
+      SET @sql += N' AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''32767'') AND COALESCE(DB_NAME(database_id), CAST(pa.value AS sysname), '''') NOT IN (SELECT name FROM sys.databases WHERE is_distributor = 1)' + @nl ;
    
    SET @sql += @body_order + @nl + @nl + @nl ;
 END
 
 DECLARE @sort NVARCHAR(MAX);
 
-SELECT @sort = CASE @SortOrder WHEN 'cpu' THEN 'total_worker_time'
-                                WHEN 'reads' THEN 'total_logical_reads'
-                                WHEN 'writes' THEN 'total_logical_writes'
-                                WHEN 'duration' THEN 'total_elapsed_time'
-                                WHEN 'executions' THEN 'execution_count'
-                                WHEN 'compiles' THEN 'cached_time'
+SELECT @sort = CASE @SortOrder  WHEN N'cpu' THEN N'total_worker_time'
+                                WHEN N'reads' THEN N'total_logical_reads'
+                                WHEN N'writes' THEN N'total_logical_writes'
+                                WHEN N'duration' THEN N'total_elapsed_time'
+                                WHEN N'executions' THEN N'execution_count'
+                                WHEN N'compiles' THEN N'cached_time'
+								WHEN N'memory grant' THEN N'max_grant_kb'
                                 /* And now the averages */
-                                WHEN 'avg cpu' THEN 'total_worker_time / execution_count'
-                                WHEN 'avg reads' THEN 'total_logical_reads / execution_count'
-                                WHEN 'avg writes' THEN 'total_logical_writes / execution_count'
-                                WHEN 'avg duration' THEN 'total_elapsed_time / execution_count'
-                                WHEN 'avg executions' THEN 'CASE WHEN execution_count = 0 THEN 0
+                                WHEN N'avg cpu' THEN N'total_worker_time / execution_count'
+                                WHEN N'avg reads' THEN N'total_logical_reads / execution_count'
+                                WHEN N'avg writes' THEN N'total_logical_writes / execution_count'
+                                WHEN N'avg duration' THEN N'total_elapsed_time / execution_count'
+								WHEN N'avg memory grant' THEN N'CASE WHEN max_grant_kb = 0 THEN 0 ELSE max_grant_kb / execution_count END'
+                                WHEN N'avg executions' THEN N'CASE WHEN execution_count = 0 THEN 0
             WHEN COALESCE(age_minutes, age_minutes_lifetime, 0) = 0 THEN 0
             ELSE CAST((1.00 * execution_count / COALESCE(age_minutes, age_minutes_lifetime)) AS money)
             END'
@@ -1341,17 +1447,19 @@ WHERE x.rn = 1
 OPTION (RECOMPILE);
 ';
 
-SELECT @sort = CASE @SortOrder WHEN 'cpu' THEN 'TotalCPU'
-                                WHEN 'reads' THEN 'TotalReads'
-                                WHEN 'writes' THEN 'TotalWrites'
-                                WHEN 'duration' THEN 'TotalDuration'
-                                WHEN 'executions' THEN 'ExecutionCount'
-                                WHEN 'compiles' THEN 'PlanCreationTime'
-                                WHEN 'avg cpu' THEN 'TotalCPU / ExecutionCount'
-                                WHEN 'avg reads' THEN 'TotalReads / ExecutionCount'
-                                WHEN 'avg writes' THEN 'TotalWrites / ExecutionCount'
-                                WHEN 'avg duration' THEN 'TotalDuration / ExecutionCount'
-                                WHEN 'avg executions' THEN 'CASE WHEN ExecutionCount = 0 THEN 0
+SELECT @sort = CASE @SortOrder  WHEN N'cpu' THEN N'TotalCPU'
+                                WHEN N'reads' THEN N'TotalReads'
+                                WHEN N'writes' THEN N'TotalWrites'
+                                WHEN N'duration' THEN N'TotalDuration'
+                                WHEN N'executions' THEN N'ExecutionCount'
+                                WHEN N'compiles' THEN N'PlanCreationTime'
+								WHEN N'memory grant' THEN N'MaxGrantKB'
+                                WHEN N'avg cpu' THEN N'TotalCPU / ExecutionCount'
+                                WHEN N'avg reads' THEN N'TotalReads / ExecutionCount'
+                                WHEN N'avg writes' THEN N'TotalWrites / ExecutionCount'
+                                WHEN N'avg duration' THEN N'TotalDuration / ExecutionCount'
+								WHEN N'avg memory grant' THEN N'AvgMaxMemoryGrant'
+                                WHEN N'avg executions' THEN N'CASE WHEN ExecutionCount = 0 THEN 0
             WHEN COALESCE(age_minutes, age_minutes_lifetime, 0) = 0 THEN 0
             ELSE CAST((1.00 * ExecutionCount / COALESCE(age_minutes, age_minutes_lifetime)) AS money)
             END'
@@ -1365,6 +1473,19 @@ BEGIN
 
     EXEC sp_executesql @sql, N'@Top INT, @min_duration INT', @Top, @DurationFilter_i;
 END
+
+/*
+--Debugging section
+SELECT DATALENGTH(@sql)
+PRINT SUBSTRING(@sql, 0, 4000)
+PRINT SUBSTRING(@sql, 4000, 8000)
+PRINT SUBSTRING(@sql, 8000, 12000)
+PRINT SUBSTRING(@sql, 16000, 24000)
+PRINT SUBSTRING(@sql, 24000, 28000)
+PRINT SUBSTRING(@sql, 28000, 32000)
+PRINT SUBSTRING(@sql, 32000, 36000)
+PRINT SUBSTRING(@sql, 36000, 40000)
+*/
 
 /* Update ##bou_BlitzCacheProcs to get Stored Proc info 
  * This should get totals for all statements in a Stored Proc
@@ -1443,7 +1564,7 @@ FROM (
                  ELSE CAST((100. * ExecutionCount) / @total_execution_count AS MONEY) END AS PercentExecutions,
             CASE DATEDIFF(mi, PlanCreationTime, LastExecutionTime)
                 WHEN 0 THEN 0
-                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS money)
+                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS MONEY)
             END AS ExecutionsPerMinute
     FROM (
         SELECT  PlanHandle,
@@ -1499,7 +1620,7 @@ FROM (
                  ELSE CAST((100. * ExecutionCount) / @total_execution_count AS MONEY) END AS PercentExecutions,
             CASE  DATEDIFF(mi, PlanCreationTime, LastExecutionTime)
                 WHEN 0 THEN 0
-                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS money)
+                ELSE CAST((1.00 * ExecutionCount / DATEDIFF(mi, PlanCreationTime, LastExecutionTime)) AS MONEY)
             END AS ExecutionsPerMinute
     FROM (
         SELECT  DatabaseName,
@@ -1794,7 +1915,8 @@ DECLARE @execution_threshold INT = 1000 ,
         /* This is in average reads */
         @parameter_sniffing_io_threshold BIGINT = 100000 ,
         @ctp_threshold_pct TINYINT = 10,
-        @long_running_query_warning_seconds BIGINT = 300 * 1000 ;
+        @long_running_query_warning_seconds BIGINT = 300 * 1000 ,
+		@memory_grant_warning_percent INT = 10;
 
 IF EXISTS (SELECT 1/0 FROM #configuration WHERE 'frequent execution threshold' = LOWER(parameter_name))
 BEGIN
@@ -1851,6 +1973,17 @@ BEGIN
     RAISERROR(@msg, 0, 1) WITH NOWAIT;
 END
 
+IF EXISTS (SELECT 1/0 FROM #configuration WHERE 'unused memory grant' = LOWER(parameter_name))
+BEGIN
+    SELECT @memory_grant_warning_percent = CAST(value AS INT)
+    FROM   #configuration
+    WHERE 'unused memory grant' = LOWER(parameter_name) ;
+
+    SET @msg = ' Setting "unused memory grant" to ' + CAST(@long_running_query_warning_seconds AS VARCHAR(10));
+
+    RAISERROR(@msg, 0, 1) WITH NOWAIT;
+END
+
 DECLARE @ctp INT ;
 
 SELECT  @ctp = NULLIF(CAST(value AS INT), 0)
@@ -1879,7 +2012,8 @@ SET    frequent_execution = CASE WHEN ExecutionsPerMinute > @execution_threshold
                            WHEN max_elapsed_time > @long_running_query_warning_seconds THEN 1 END,
 	   is_key_lookup_expensive = CASE WHEN QueryPlanCost > (@ctp / 2) AND key_lookup_cost >= QueryPlanCost * .5 THEN 1 END,
 	   is_remote_query_expensive = CASE WHEN remote_query_cost >= QueryPlanCost * .05 THEN 1 END,
-	   is_forced_serial = CASE WHEN is_forced_serial = 1 AND QueryPlanCost > (@ctp / 2) THEN 1 END
+	   is_forced_serial = CASE WHEN is_forced_serial = 1 AND QueryPlanCost > (@ctp / 2) THEN 1 END,
+	   is_unused_grant = CASE WHEN PercentMemoryGrantUsed <= @memory_grant_warning_percent AND MinGrantKB > 0 THEN 1 END
 OPTION (RECOMPILE) ;
 
 
@@ -1947,7 +2081,8 @@ SET    Warnings = SUBSTRING(
 				  CASE WHEN is_key_lookup_expensive = 1 THEN ', Expensive Key Lookup' ELSE '' END +
 				  CASE WHEN is_remote_query_expensive = 1 THEN ', Expensive Remote Query' ELSE '' END + 
 				  CASE WHEN trace_flags_session IS NOT NULL THEN ', Session Level Trace Flag(s) Enabled: ' + trace_flags_session ELSE '' END +
-				  CASE WHEN is_remote_query_expensive = 1 THEN ', Expensive Remote Query' ELSE '' END
+				  CASE WHEN is_remote_query_expensive = 1 THEN ', Expensive Remote Query' ELSE '' END +
+				  CASE WHEN is_unused_grant = 1 THEN ', Unused Memory Grant' ELSE '' END
                   , 2, 200000) 
 				  OPTION (RECOMPILE) ;
 
@@ -1963,7 +2098,6 @@ SET    Warnings = SUBSTRING(
 
 
 Results:
-
 /* Checks if @OutputServerName is populated with a valid linked server, and that the database name specified is valid */
 				DECLARE @ValidOutputServer BIT
 				DECLARE @ValidOutputLocation BIT
@@ -2241,6 +2375,12 @@ BEGIN
             AverageReturnedRows,
             MinReturnedRows,
             MaxReturnedRows,
+		    MinGrantKB,
+		    MaxGrantKB,
+		    MinUsedGrantKB, 
+		    MaxUsedGrantKB,
+		    PercentMemoryGrantUsed,
+			AvgMaxMemoryGrant,
             NumberOfPlans,
             NumberOfDistinctPlans,
             PlanCreationTime AS [Created At],
@@ -2261,11 +2401,13 @@ BEGIN
                               WHEN 'duration' THEN ' TotalDuration '
                               WHEN 'executions' THEN ' ExecutionCount '
                               WHEN 'compiles' THEN ' PlanCreationTime '
+							  WHEN 'memory grant' THEN 'MaxGrantKB'
                               WHEN 'avg cpu' THEN 'AverageCPU'
                               WHEN 'avg reads' THEN 'AverageReads'
                               WHEN 'avg writes' THEN 'AverageWrites'
                               WHEN 'avg duration' THEN 'AverageDuration'
                               WHEN 'avg executions' THEN 'ExecutionsPerMinute'
+							  WHEN 'avg memory grant' THEN 'AvgMaxMemoryGrant'
                               END + N' DESC '
 
     SET @sql += N' OPTION (RECOMPILE) ; '
@@ -2301,6 +2443,11 @@ BEGIN
     AverageWrites AS [Avg Writes],
     PercentWrites AS [Write Weight],
     AverageReturnedRows AS [Average Rows],
+	MinGrantKB AS [Minimum Memory Grant KB],
+	MaxGrantKB AS [Maximum Memory Grant KB],
+	MinUsedGrantKB AS [Minimum Used Grant KB], 
+	MaxUsedGrantKB AS [Maximum Used Grant KB],
+	AvgMaxMemoryGrant AS [Average Max Memory Grant],
     PlanCreationTime AS [Created At],
     LastExecutionTime AS [Last Execution],
 	PlanHandle AS [Plan Handle], 
@@ -2317,7 +2464,7 @@ BEGIN
 
     IF @ExpertMode = 2 /* Opserver */
     BEGIN
-        SET @columns += '        SUBSTRING(
+        SET @columns += N'        SUBSTRING(
                   CASE WHEN warning_no_join_predicate = 1 THEN '', 20'' ELSE '''' END +
                   CASE WHEN compile_timeout = 1 THEN '', 18'' ELSE '''' END +
                   CASE WHEN compile_memory_limit_exceeded = 1 THEN '', 19'' ELSE '''' END +
@@ -2342,8 +2489,9 @@ BEGIN
                   CASE WHEN is_trivial = 1 THEN '', 24'' ELSE '''' END + 
 				  CASE WHEN is_forced_serial = 1 THEN '', 25'' ELSE '''' END +
                   CASE WHEN is_key_lookup_expensive = 1 THEN '', 26'' ELSE '''' END +
-				  CASE WHEN is_remote_query_expensive = 1 THEN '', 28'' ELSE '''' END  + 
-				  CASE WHEN trace_flags_session IS NOT NULL THEN '' , 29'' ELSE '''' END
+				  CASE WHEN is_remote_query_expensive = 1 THEN '', 28'' ELSE '''' END + 
+				  CASE WHEN trace_flags_session IS NOT NULL THEN '', 29'' ELSE '''' END + 
+				  CASE WHEN is_unused_grant = 1 THEN '', 30'' ELSE '''' END
 				  , 2, 200000) AS opserver_warning , ' + @nl ;
     END
     
@@ -2373,6 +2521,11 @@ BEGIN
         AverageReturnedRows AS [Avg Rows],
         MinReturnedRows AS [Min Rows],
         MaxReturnedRows AS [Max Rows],
+		MinGrantKB AS [Minimum Memory Grant KB],
+		MaxGrantKB AS [Maximum Memory Grant KB],
+		MinUsedGrantKB AS [Minimum Used Grant KB], 
+		MaxUsedGrantKB AS [Maximum Used Grant KB],
+		AvgMaxMemoryGrant AS [Average Max Memory Grant],
         NumberOfPlans AS [# Plans],
         NumberOfDistinctPlans AS [# Distinct Plans],
         PlanCreationTime AS [Created At],
@@ -2403,17 +2556,19 @@ SELECT  TOP (@Top) ' + @columns + @nl + N'
 FROM    ##bou_BlitzCacheProcs
 WHERE   SPID = @spid ' + @nl
 
-SELECT @sql += N' ORDER BY ' + CASE @SortOrder WHEN 'cpu' THEN ' TotalCPU '
-                                                WHEN 'reads' THEN ' TotalReads '
-                                                WHEN 'writes' THEN ' TotalWrites '
-                                                WHEN 'duration' THEN ' TotalDuration '
-                                                WHEN 'executions' THEN ' ExecutionCount '
-                                                WHEN 'compiles' THEN ' PlanCreationTime '
-                                                WHEN 'avg cpu' THEN 'AverageCPU'
-                                                WHEN 'avg reads' THEN 'AverageReads'
-                                                WHEN 'avg writes' THEN 'AverageWrites'
-                                                WHEN 'avg duration' THEN 'AverageDuration'
-                                                WHEN 'avg executions' THEN 'ExecutionsPerMinute'
+SELECT @sql += N' ORDER BY ' + CASE @SortOrder WHEN 'cpu' THEN N' TotalCPU '
+                                                WHEN 'reads' THEN N' TotalReads '
+                                                WHEN 'writes' THEN N' TotalWrites '
+                                                WHEN 'duration' THEN N' TotalDuration '
+                                                WHEN 'executions' THEN N' ExecutionCount '
+                                                WHEN 'compiles' THEN N' PlanCreationTime '
+												WHEN 'memory grant' THEN N' MaxGrantKB'
+                                                WHEN 'avg cpu' THEN N' AverageCPU'
+                                                WHEN 'avg reads' THEN N' AverageReads'
+                                                WHEN 'avg writes' THEN N' AverageWrites'
+                                                WHEN 'avg duration' THEN N' AverageDuration'
+                                                WHEN 'avg executions' THEN N' ExecutionsPerMinute'
+												WHEN 'avg memory grant' THEN N' AvgMaxMemoryGrant'
                                END + N' DESC '
 SET @sql += N' OPTION (RECOMPILE) ; '
 
@@ -2546,7 +2701,7 @@ BEGIN
                     'Performance',
                     'Long Running Queries',
                     'http://brentozar.com/blitzcache/long-running-queries/',
-                    'Long running queries have beend found. These are queries with an average duration longer than '
+                    'Long running queries have been found. These are queries with an average duration longer than '
                     + CAST(@long_running_query_warning_seconds / 1000 / 1000 AS VARCHAR(5))
                     + ' second(s). These queries should be investigated for additional tuning options') ;
 
@@ -2755,9 +2910,22 @@ BEGIN
                     29,
                     100,
                     'Trace Flags',
-                    'Session Level Trace FLags Enabled',
+                    'Session Level Trace Flags Enabled',
                     'https://www.brentozar.com/blitz/trace-flags-enabled-globally/',
                     'Someone is enabling session level Trace Flags in a query.') ;
+
+        IF EXISTS (SELECT 1/0
+                   FROM   ##bou_BlitzCacheProcs p
+                   WHERE  p.is_unused_grant IS NOT NULL
+				   AND SPID = @@SPID)
+            INSERT INTO ##bou_BlitzCacheResults (SPID, CheckID, Priority, FindingsGroup, Finding, URL, Details)
+            VALUES (@@SPID,
+                    30,
+                    100,
+                    'Unused memory grants',
+                    'Queries are asking for more memory than they''re using',
+                    'No URL yet.',
+                    'Queries have large unused memory grants. This can cause concurrency issues, if queries are waiting a long time to get memory to run.') ;
 
         IF EXISTS (SELECT 1/0
                    FROM   #trace_flags AS tf 


### PR DESCRIPTION
Fixes #293 for sp_BlitzCache.

Changes proposed in this pull request:
- Support for @OutputServerName
- Updated error checking for @OutputDatabaseName variables for both linked and local servers

How to test this code:
- Run procedure output with @expertmode = 1 (for comparison)
- Run procedure with valid @OutputDatabaseName/SchemaName/TableName specified (should succeed in creating local table)
- Run procedure with @OutputServerName specified as valid linked server along with other Output variables (should succeed in creating remote table on linked server)
- Rerun both tests above without deleting testing tables to ensure that procedure doesn't try and create new table (it should dump results to the same table; tests IF EXISTS logic in permanent table creation)
- Run procedure with invalid @OutputServerName (server that is not linked and random name; both should fail)
- Run procedure with invalid local DB name (should fail)
- Run procedure with invalid linked DB name (Specify valid @OutputServerName; should fail)

Use the output from the @expertmode = 1 run to compare the output on both the local and remote tables...they should be the same.

Has been tested on:
- SQL Server 2008
- SQL Server 2008 R2
- SQL Server 2012
- **(UPDATE)** SQL Server 2016
