### PR TITLE
Issue 58 aaron bertrand

### DIFF
--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -1,0 +1,1 @@
+Placeholder


### PR DESCRIPTION
I added an exclude_list parameter to Aaron's sp_foreachdb because I had a use case where I needed to run a script against multiple databases on a server but had to skip specific databases.  