### PR TITLE
#409 sp_Blitz skip maintenance plan checks in RDS

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -236,6 +236,8 @@ AS
 						INSERT INTO #SkipChecks (CheckID) VALUES (100); /* Remote DAC disabled */
 						INSERT INTO #SkipChecks (CheckID) VALUES (123);
 						INSERT INTO #SkipChecks (CheckID) VALUES (177);
+						INSERT INTO #SkipChecks (CheckID) VALUES (180); /* 180/181 are maintenance plans */
+						INSERT INTO #SkipChecks (CheckID) VALUES (181);
 			END /* Amazon RDS skipped checks */
 
 


### PR DESCRIPTION
Amazon RDS doesn’t allow access to maintenance plan tables. Skips
checks 180 and 181. Closes #409.