### PR TITLE
#449 sp_Blitz add check 184 for cluster health

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -34,6 +34,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 20 | Reliability | Dangerous Build of SQL Server (Security) | https://technet.microsoft.com/en-us/library/security/MS14-044 | 157 |
 | 20 | Reliability | Databases in Unusual States | http://BrentOzar.com/go/repair | 102 |
 | 20 | Reliability | Memory Dumps Have Occurred | http://BrentOzar.com/go/dump | 171 |
+| 20 | Reliability | No Failover Cluster Nodes Available | http://BrentOzar.com/go/node | 184 |
 | 20 | Reliability | Plan Guides Failing | http://BrentOzar.com/go/guides | 164 |
 | 20 | Reliability | Query Store Cleanup Disabled | http://BrentOzar.com/go/cleanup | 182 |
 | 20 | Reliability | Unsupported Build of SQL Server | http://BrentOzar.com/go/unsupported | 128 |
@@ -61,9 +62,11 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 100 | Performance | Max Memory Set Too High | http://BrentOzar.com/go/max | 50 |
 | 100 | Performance | Memory Pressure Affecting Queries | http://BrentOzar.com/go/grants | 117 |
 | 100 | Performance | Partitioned database with non-aligned indexes | http://BrentOzar.com/go/aligned | 72 |
+| 100 | Performance | Repetitive Maintenance Tasks | https://ola.hallengren.com | 181 |
 | 100 | Performance | Resource Governor Enabled | http://BrentOzar.com/go/rg | 10 |
 | 100 | Performance | Server Triggers Enabled | http://BrentOzar.com/go/logontriggers/ | 11 |
 | 100 | Performance | Shrink Database Job | http://BrentOzar.com/go/autoshrink | 79 |
+| 100 | Performance | Shrink Database Step In Maintenance Plan | http://BrentOzar.com/go/autoshrink | 180 |
 | 100 | Performance | Single-Use Plans in Procedure Cache | http://BrentOzar.com/go/single | 35 |
 | 100 | Performance | Stored Procedure WITH RECOMPILE | http://BrentOzar.com/go/recompile | 78 |
 | 100 | Performance | Unusual SQL Server Edition | http://BrentOzar.com/go/workgroup | 97 |
@@ -255,5 +258,3 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 250 | Server Info | Virtual Server | http://BrentOzar.com/go/virtual | 103 |
 | 250 | Server Info | Windows Version |  | 172 |
 | 254 | Rundate | (Current Date) |  | 156 |
-| 100 | Performance | Shrink Database Step In Maintenance Plan | http://BrentOzar.com/go/autoshrink | 180 |
-| 100 | Performance | Repetitive Maintenance Tasks | https://ola.hallengren.com | 181 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3561,6 +3561,35 @@ IF @ProductVersionMajor >= 10 AND @ProductVersionMinor >= 50
 						END
 			
 
+			/* Reliability - No Failover Cluster Nodes Available - 184 */
+			IF NOT EXISTS ( SELECT  1
+								FROM    #SkipChecks
+								WHERE   DatabaseName IS NULL AND CheckID = 184 )
+					BEGIN
+						  INSERT    INTO [#BlitzResults]
+									( [CheckID] ,
+									  [Priority] ,
+									  [FindingsGroup] ,
+									  [Finding] ,
+									  [URL] ,
+									  [Details] )
+
+							SELECT TOP 1
+							  184 AS CheckID ,
+							  20 AS Priority ,
+							  'Reliability' AS FindingsGroup ,
+							  'No Failover Cluster Nodes Available' AS Finding ,
+							  'http://BrentOzar.com/go/node' AS URL ,
+							  'There are no failover cluster nodes available if the active node fails' AS Details
+							FROM (
+							  SELECT SUM(CASE WHEN [status] = 0 AND [is_current_owner] = 0 THEN 1 ELSE 0 END) AS [available_nodes]
+							  FROM sys.dm_os_cluster_nodes
+							) a
+							WHERE [available_nodes] < 1
+
+					END
+
+
 				IF @CheckUserDatabaseObjects = 1
 					BEGIN
 


### PR DESCRIPTION
Warn if sys.dm_os_cluster_nodes doesn’t have any ready-to-go failover
partners. Closes #449.