### PR TITLE
#84 - check when wait stats were last cleared

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -241,6 +241,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 230 | Security | Sysadmins | http://BrentOzar.com/go/sa | 4 |
 | 240 | Wait Stats | No Significant Waits Detected | http://BrentOzar.com/go/waits | 153 |
 | 240 | Wait Stats | Top Wait Stats | http://BrentOzar.com/go/waits | 152 |
+| 240 | Wait Stats | Wait Stats Have Been Cleared | http://BrentOzar.com/go/waits | 185 |
 | 250 | Informational | SQL Server Agent is running under an NT Service account | http://BrentOzar.com/go/setup | 170 |
 | 250 | Informational | SQL Server is running under an NT Service account | http://BrentOzar.com/go/setup | 169 |
 | 250 | Server Info | Agent is Currently Offline |  | 167 |


### PR DESCRIPTION
Adds check 185 to compare tempdb’s creation date vs the total length of
wait time for sqltrace_incremental_flush_sleep, with a 10% fudge
factor. If they’re different, check 185 is fired, plus the wait times
per hour are reset. Closes #84.