### PR TITLE
#526 sp_Blitz fixing arithmetic overflow in waits check

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -469,7 +469,7 @@ AS
             FROM sys.fn_trace_getinfo(1)
             WHERE traceid=1 AND property=2;
         
-        SELECT @MsSinceWaitsCleared = DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP) * 60000
+        SELECT @MsSinceWaitsCleared = DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP) * 60000.0
             FROM    sys.databases
             WHERE   name='tempdb';
 


### PR DESCRIPTION
Instead of * 60000, do * 60000.0. Closes #526.