### PR TITLE
sp_BlitzCache.sql - added a cast to make it work

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -757,7 +757,7 @@ BEGIN
    RETURN;
 END
 
-SELECT @MinMemoryPerQuery = c.value FROM sys.configurations AS c WHERE c.name = 'min memory per query (KB)';
+SELECT @MinMemoryPerQuery = CAST(c.value AS INT) FROM sys.configurations AS c WHERE c.name = 'min memory per query (KB)';
 
 SET @SortOrder = LOWER(@SortOrder);
 SET @SortOrder = REPLACE(REPLACE(@SortOrder, 'average', 'avg'), '.', '');


### PR DESCRIPTION
Adds a cast to make the script work on SQL Server 2014 Developer Edition. ```c.value``` there is of type ```variadic``` and may not be implicitly converted into an int.

Changes proposed in this pull request:
 - Make it work on SQL Server 2014 Developer Edition

Has been tested on (remove any that don't apply):
 - SQL Server 2014
 - Unfortunately no other releases, since I do not have access to them