### PR TITLE
ISSUE-607-Collation-Error-in-Contained-Databases

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1602,7 +1602,7 @@ BEGIN TRY
    					   		   CASE WHEN cc.definition LIKE ''%.%'' THEN 1 ELSE 0 END AS is_function,
    					   		   ''ALTER TABLE '' + QUOTENAME(s.name) + ''.'' + QUOTENAME(t.name) + 
    					   		   '' ADD '' + QUOTENAME(c.name) + '' AS '' + cc.definition  + 
-							   CASE WHEN is_persisted = 1 THEN '' PERSISTED'' ELSE '''' END + '';'' AS [column_definition]
+							   CASE WHEN is_persisted = 1 THEN '' PERSISTED'' ELSE '''' END + '';'' COLLATE DATABASE_DEFAULT AS [column_definition]
    					   FROM    ' + QUOTENAME(@DatabaseName) + N'.sys.computed_columns AS cc
    					   JOIN    ' + QUOTENAME(@DatabaseName) + N'.sys.columns AS c
    					   ON      cc.object_id = c.object_id


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - Adds a COLLATE statement to the query that fails when running the procedure over a 'contained' database. Used the DATABASE_DEFAULT collation to be as safe as possible.
 - 
 - 

How to test this code:
 - set the database containment to 'Partial'
 `USE [master]`
`GO`
`ALTER DATABASE [YourDBNameHere] SET CONTAINMENT = PARTIAL WITH NO_WAIT`
`GO`
`exec sp_BlitzIndex`

Has been tested on (remove any that don't apply):
 - SQL Server 2016
- SQL Server 2016 SP1, AlwaysOn


 

https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/607