### PR TITLE
sp_Blitz 2016 but not SP1

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -54,6 +54,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 50 | Reliability | Remote Admin Connections Disabled | http://BrentOzar.com/go/dac | 100 |
 | 50 | Reliability | Transaction Log Larger than Data File | http://BrentOzar.com/go/biglog | 75 |
 | 100 | In-Memory OLTP (Hekaton) | Transaction Errors | http://BrentOzar.com/go/hekaton | 147 |
+| 100 | Features | Missing Features | http://BrentOzar.com/ | 189 |
 | 100 | Performance | Change Tracking Enabled | http://BrentOzar.com/go/tracking | 112 |
 | 100 | Performance | Fill Factor Changed | http://brentozar.com/go/fillfactor | 60 |
 | 100 | Performance | High Number of Cached Plans | http://BrentOzar.com/go/planlimits | 161 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2891,7 +2891,7 @@ AS
 								BEGIN
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(189, 100, 'Features', 'Missing Features', 'https://blogs.msdn.microsoft.com/sqlreleaseservices/sql-server-2016-service-pack-1-sp1-released/',
-										'SQL 2016 Standard Edition is being used but not Service Pack 1. Check the URL for a list of Enterprise Features that are included in standard as of SP1.');
+										'SQL 2016 Standard Edition is being used but not Service Pack 1. Check the URL for a list of Enterprise Features that are included in Standard Edition as of SP1.');
 								END;
 
 							END;						

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2891,7 +2891,7 @@ AS
 								BEGIN
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(189, 100, 'Features', 'Missing Features', 'https://blogs.msdn.microsoft.com/sqlreleaseservices/sql-server-2016-service-pack-1-sp1-released/',
-										'SQL 2016 Standard Edition is being used but not the latest Service Pack (SP1). Check the URL for a list of Enterprise Features that are now included in standard.');
+										'SQL 2016 Standard Edition is being used but not Service Pack 1. Check the URL for a list of Enterprise Features that are included in standard as of SP1.');
 								END;
 
 							END;						

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2887,7 +2887,7 @@ AS
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 189 )
 							BEGIN
-							IF (@ProductVersionMajor = 13 AND @ProductVersionMinor <4001 AND @@VERSION LIKE '%Standard Edition%') 
+							IF (@ProductVersionMajor = 13 AND @ProductVersionMinor < 4001 AND @@VERSION LIKE '%Standard Edition%') 
 								BEGIN
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(189, 100, 'Features', 'Missing Features', 'https://blogs.msdn.microsoft.com/sqlreleaseservices/sql-server-2016-service-pack-1-sp1-released/',

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2881,7 +2881,20 @@ AS
 								END;
 
 							END;
+						
+						/* Check if SQL 2016 Standard Edition but not SP1 */
+						IF NOT EXISTS ( SELECT  1
+										FROM    #SkipChecks
+										WHERE   DatabaseName IS NULL AND CheckID = 157 )
+							BEGIN
+							IF (@ProductVersionMajor = 13 AND @ProductVersionMinor <4001 AND @@VERSION LIKE '%Standard Edition%') 
+								BEGIN
+								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
+									VALUES(189, 100, 'Features', 'Missing Features', 'https://blogs.msdn.microsoft.com/sqlreleaseservices/sql-server-2016-service-pack-1-sp1-released/',
+										'SQL 2016 Standard Edition is being used but not the latest Service Pack (SP1). Check the URL for a list of Enterprise Features that are now included in standard.');
+								END;
 
+							END;						
 
                         /* Performance - High Memory Use for In-Memory OLTP (Hekaton) */
                         IF NOT EXISTS ( SELECT  1

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2885,7 +2885,7 @@ AS
 						/* Check if SQL 2016 Standard Edition but not SP1 */
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
-										WHERE   DatabaseName IS NULL AND CheckID = 157 )
+										WHERE   DatabaseName IS NULL AND CheckID = 189 )
 							BEGIN
 							IF (@ProductVersionMajor = 13 AND @ProductVersionMinor <4001 AND @@VERSION LIKE '%Standard Edition%') 
 								BEGIN


### PR DESCRIPTION
Fixes #591  .

Changes proposed in this pull request:
 - Check if customer is on SQL Server 2016 Standard but does not have SP1 installed. Prompts that additional features now available.

How to test this code:
 - Run on SQL 2016 Standard Edition without SP1

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2012
 - SQL Server 2016 Developer (with standard edition check excluded)

