### PR TITLE
sp_Blitz Check if Min Server Memory = Max Server Memory

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -216,6 +216,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 200 | Performance | Old Compatibility Level | http://BrentOzar.com/go/compatlevel | 62 |
 | 200 | Performance | Snapshot Backups Occurring | http://BrentOzar.com/go/snaps | 178 |
 | 200 | Performance | User-Created Statistics In Place | http://BrentOzar.com/go/userstats | 122 |
+| 200 | Performance | Non-Dynamic Memory | http://BrentOzar.com/go/memory | 190 |
 | 200 | Reliability | Extended Stored Procedures in Master | http://BrentOzar.com/go/clr | 105 |
 | 200 | Surface Area | Endpoints Configured | http://BrentOzar.com/go/endpoints/ | 9 |
 | 210 | Non-Default Database Config | ANSI NULL Default Enabled | http://BrentOzar.com/go/dbdefaults | 135 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1507,8 +1507,8 @@ AS
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 190 )
 					BEGIN
-						SELECT @minservermemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'min server memory (MB)'
-						SELECT @maxservermemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'max server memory (MB)'
+						SELECT @MinServerMemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'min server memory (MB)'
+						SELECT @MaxServerMemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'max server memory (MB)'
 						
 						IF (@MinServerMemory = @MaxServerMemory)
 						BEGIN

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -138,7 +138,9 @@ AS
 			,@ResultText NVARCHAR(MAX)
 			,@crlf NVARCHAR(2)
 			,@Processors int
-			,@NUMANodes int;
+			,@NUMANodes int
+			,@MinServerMemory bigint
+			,@MaxServerMemory bigint;
 
 
 		SET @crlf = NCHAR(13) + NCHAR(10);
@@ -1502,6 +1504,34 @@ AS
 					END
 
 				IF NOT EXISTS ( SELECT  1
+								FROM    #SkipChecks
+								WHERE   DatabaseName IS NULL AND CheckID = 190 )
+					BEGIN
+						SELECT @minservermemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'min server memory (MB)'
+						SELECT @maxservermemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'max server memory (MB)'
+						
+						IF (@MinServerMemory = @MaxServerMemory)
+						BEGIN
+						INSERT INTO #BlitzResults
+								( CheckID ,
+								  Priority ,
+								  FindingsGroup ,
+								  Finding ,
+								  URL ,
+								  Details
+								)
+								VALUES  
+									(	190,
+										200,
+										'Performance',
+										'Non-Dynamic Memory',
+										'http://BrentOzar.com/go/memory',
+										'Minimum Server Memory setting is the same as the Maximum (both set to ' + CAST(@minservermemory AS NVARCHAR(50)) + '). This will not allow dynamic memory. Please revise memory settings'
+									)
+						END
+					END
+					
+					IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 188 )
 					BEGIN


### PR DESCRIPTION
Fixes #603 
Changes proposed in this pull request:
 - New alert to check if max server memory = min server memory

How to test this code:
 - Change server memory to the same as max memory and run the script.
 - Test with different settings to confirm it doesn't show

Has been tested on (remove any that don't apply):
 - SQL Server 2014
 - SQL Server 2016

Added two new parameters and then a block of code that will warn if min memory is the same as max.