### PR TITLE
typo fix for case-sensistive servers

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1526,7 +1526,7 @@ AS
 										'Performance',
 										'Non-Dynamic Memory',
 										'http://BrentOzar.com/go/memory',
-										'Minimum Server Memory setting is the same as the Maximum (both set to ' + CAST(@minservermemory AS NVARCHAR(50)) + '). This will not allow dynamic memory. Please revise memory settings'
+										'Minimum Server Memory setting is the same as the Maximum (both set to ' + CAST(@MinServerMemory AS NVARCHAR(50)) + '). This will not allow dynamic memory. Please revise memory settings'
 									)
 						END
 					END


### PR DESCRIPTION
New to gitflow, sorry for any mistakes...

Fixes # .

Changes proposed in this pull request:
 - Allow sp_Blitz to be created / modified on case-sensitive server

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance - YES
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012 - YES
 - SQL Server 2014 - YES
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB

