### PR TITLE
sp_BlitzIndex - Flag if using columnstore indexes & trace 834

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -3095,7 +3095,7 @@ BEGIN;
             AND NOT (@GetAllDatabases = 1 OR @Mode = 0)
 
 			RAISERROR(N'check_id 72: Columnstore indexes with Trace Flag 834', 0,1) WITH NOWAIT;
-                IF EXISTS (SELECT * FROM #IndexSanity WHERE Index_Type IN (5,6))
+                IF EXISTS (SELECT * FROM #IndexSanity WHERE index_type IN (5,6))
 				AND EXISTS (SELECT * FROM #TraceStatus WHERE TraceFlag = 834 AND status = 1)
 				BEGIN
 				INSERT    #BlitzIndexResults ( check_id, index_sanity_id, Priority, findings_group, finding, [database_name], URL, details, index_definition,

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -156,6 +156,9 @@ IF OBJECT_ID('tempdb..#PartitionCompressionInfo') IS NOT NULL
 
 IF OBJECT_ID('tempdb..#ComputedColumns') IS NOT NULL 
     DROP TABLE #ComputedColumns;
+	
+IF OBJECT_ID('tempdb..#TraceStatus') IS NOT NULL
+	DROP TABLE #TraceStatus;
 
         RAISERROR (N'Create temp tables.',0,1) WITH NOWAIT;
         CREATE TABLE #BlitzIndexResults
@@ -564,7 +567,14 @@ IF OBJECT_ID('tempdb..#ComputedColumns') IS NOT NULL
 		  is_function INT NOT NULL,
 		  column_definition NVARCHAR(MAX) NULL
 		);
-
+		
+		CREATE TABLE #TraceStatus
+		(
+		 TraceFlag VARCHAR(10) ,
+		 status BIT ,
+		 Global BIT ,
+		 Session BIT
+		);
 
 
 IF @GetAllDatabases = 1
@@ -1622,6 +1632,11 @@ BEGIN TRY
 			EXEC sp_executesql @dsql;
 
 			END 
+			
+			RAISERROR (N'Gathering Trace Flag Information',0,1) WITH NOWAIT;
+			INSERT #TraceStatus
+			EXEC ('DBCC TRACESTATUS(-1) WITH NO_INFOMSGS')			
+			
 END                    
 END TRY
 BEGIN CATCH
@@ -3079,6 +3094,30 @@ BEGIN;
             OR [update_referential_action_desc] <> N'NO_ACTION')
             AND NOT (@GetAllDatabases = 1 OR @Mode = 0)
 
+			RAISERROR(N'check_id 72: Columnstore indexes with Trace Flag 834', 0,1) WITH NOWAIT;
+                IF EXISTS (SELECT * FROM #IndexSanity WHERE Index_Type IN (5,6))
+				AND EXISTS (SELECT * FROM #TraceStatus WHERE TraceFlag = 834 AND status = 1)
+				BEGIN
+				INSERT    #BlitzIndexResults ( check_id, index_sanity_id, Priority, findings_group, finding, [database_name], URL, details, index_definition,
+                                               secret_columns, index_usage_summary, index_size_summary )
+                    SELECT    72 AS check_id, 
+                            i.index_sanity_id,
+                            150 AS Priority,
+                            N'Abnormal Psychology' AS findings_group,
+                            'Columnstore Indexes are being used in conjunction with trace flag 834. Visit the link to see why this can be a bad idea' AS finding, 
+                            [database_name] AS [Database Name],
+                            N'https://support.microsoft.com/en-us/kb/3210239' AS URL,
+                            i.db_schema_object_indexid AS details, 
+                            i.index_definition,
+                            i.secret_columns,
+                            i.index_usage_summary,
+                            ISNULL(sz.index_size_summary,'') AS index_size_summary
+                    FROM    #IndexSanity AS i
+                    JOIN #IndexSanitySize sz ON i.index_sanity_id = sz.index_sanity_id
+                    WHERE i.index_type IN (5,6)
+                    OPTION    ( RECOMPILE )
+				END
+
     END
 
          ----------------------------------------
@@ -3367,7 +3406,7 @@ BEGIN;
                 br.index_sanity_id=sn.index_sanity_id
             LEFT JOIN #IndexCreateTsql ts ON 
                 br.index_sanity_id=ts.index_sanity_id
-            WHERE br.check_id IN (0, 1, 11, 22, 43, 68, 50, 60, 61, 62, 63, 64, 65)
+            WHERE br.check_id IN (0, 1, 11, 22, 43, 68, 50, 60, 61, 62, 63, 64, 65, 72)
             ORDER BY br.Priority ASC, br.check_id ASC, br.blitz_result_id ASC, br.findings_group ASC
 			OPTION (RECOMPILE);
 


### PR DESCRIPTION
Fixes #615 

Changes proposed in this pull request:
 - Added a check to see if columnstore indexes are in use alongside trace flag 834

How to test this code:
 - Find a server with columnstore indexes and flag 834 switched on (or make one) and run to ensure it flags.
 - Test on servers with either and both switched off to ensure it doesn't show.

Has been tested on (remove any that don't apply):
 - SQL Server 2016 Developer (with and without trace flags)
(couldn't test on earlier versions as the servers are currently in use and it requires a reboot for flag 834)

Inserts into mode = 0 if columnstore indexes exist and the trace flag 834 is switched on. Currently set to a 150 priority error under 'Abnormal Psychology'. 

#TraceStatus table and data insert logic taken from sp_Blitz for consistency.