### PR TITLE
#582 sp_Blitz add warning for number of TempDB files

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -52,6 +52,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 50 | Reliability | Page Verification Not Optimal | http://BrentOzar.com/go/torn | 14 |
 | 50 | Reliability | Possibly Broken Log Shipping | http://BrentOzar.com/go/shipping | 111 |
 | 50 | Reliability | Remote Admin Connections Disabled | http://BrentOzar.com/go/dac | 100 |
+| 50 | Reliability | TempDB File Error | http://BrentOzar.com/go/tempdboops | 191 |
 | 50 | Reliability | Transaction Log Larger than Data File | http://BrentOzar.com/go/biglog | 75 |
 | 100 | In-Memory OLTP (Hekaton) | Transaction Errors | http://BrentOzar.com/go/hekaton | 147 |
 | 100 | Features | Missing Features | http://BrentOzar.com/ | 189 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3782,6 +3782,29 @@ IF @ProductVersionMajor >= 10 AND @ProductVersionMinor >= 50
 		                        EXECUTE(@StringToExecute);
 					END
 
+		/* Reliability - TempDB File Error */
+		IF NOT EXISTS ( SELECT  1
+										FROM    #SkipChecks
+										WHERE   DatabaseName IS NULL AND CheckID = 191 )
+			AND (SELECT COUNT(*) FROM sys.master_files WHERE database_id = 2) <> (SELECT COUNT(*) FROM tempdb.sys.database_files)
+				BEGIN
+					INSERT    INTO [#BlitzResults]
+							( [CheckID] ,
+								[Priority] ,
+								[FindingsGroup] ,
+								[Finding] ,
+								[URL] ,
+								[Details] )						
+						
+						SELECT
+						191 AS [CheckID] ,
+						50 AS [Priority] ,
+						'Reliability' AS [FindingsGroup] ,
+						'TempDB File Error' AS [Finding] ,
+						'http://BrentOzar.com/go/tempdboops' AS [URL] , 
+						'Mismatch between the number of TempDB files in sys.master_files versus tempdb.sys.database_files' AS [Details]
+				END
+
 
 				IF @CheckUserDatabaseObjects = 1
 					BEGIN


### PR DESCRIPTION
Check sys.master_files vs tempdb.sys.database_files, new check 191. Closes #582.