### PR TITLE
#593 sp_Blitz better Instant File Init checks

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -39,6 +39,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 20 | Reliability | Query Store Cleanup Disabled | http://BrentOzar.com/go/cleanup | 182 |
 | 20 | Reliability | Unsupported Build of SQL Server | http://BrentOzar.com/go/unsupported | 128 |
 | 20 | Reliability | User Databases on C Drive | http://BrentOzar.com/go/cdrive | 26 |
+| 50 | Performance | Instant File Initialization Not Enabled | http://BrentOzar.com/go/instant | 192 |
 | 50 | Performance | Log File Growths Slow | http://BrentOzar.com/go/filegrowth | 151 |
 | 50 | Performance | Poison Wait Detected: CMEMTHREAD & NUMA | http://BrentOzar.com/go/poison | 162 |
 | 50 | Performance | Poison Wait Detected: RESOURCE_SEMAPHORE | http://BrentOzar.com/go/poison | 108 |
@@ -256,6 +257,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 250 | Server Info | Full-text Filter Daemon is Currently Offline |  | 168 |
 | 250 | Server Info | Hardware |  | 84 |
 | 250 | Server Info | Hardware - NUMA Config |  | 114 |
+| 250 | Server Info | Instant File Initialization Enabled | http://BrentOzar.com/go/instant | 193 |
 | 250 | Server Info | Locked Pages in Memory Enabled | http://BrentOzar.com/go/lpim | 166 |
 | 250 | Server Info | Server Name | http://BrentOzar.com/go/servername | 130 |
 | 250 | Server Info | Services |  | 83 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -5473,7 +5473,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 													AND c.name = 'sql_memory_model' )
 							BEGIN
 										SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
-			SELECT  84 AS CheckID ,
+			SELECT  166 AS CheckID ,
 			250 AS Priority ,
 			''Server Info'' AS FindingsGroup ,
 			''Memory Model Unconventional'' AS Finding ,
@@ -5507,13 +5507,38 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 										  Details
 										)
 										SELECT
-												184 AS [CheckID] ,
+												193 AS [CheckID] ,
 												250 AS [Priority] ,
 												'Server Info' AS [FindingsGroup] ,
 												'Instant File Initialization Enabled' AS [Finding] ,
-												'' AS [URL] ,
+												'http://BrentOzar.com/go/instant' AS [URL] ,
 												'The service account has the Perform Volume Maintenance Tasks permission.'
 						END; 
+
+			/* Server Info - Instant File Initialization Not Enabled - Check 192 - SQL Server 2016 SP1 and newer */
+						IF NOT EXISTS ( SELECT  1
+										FROM    #SkipChecks
+										WHERE   DatabaseName IS NULL AND CheckID = 192 )
+							AND EXISTS ( SELECT  *
+											FROM    sys.all_objects o
+													INNER JOIN sys.all_columns c ON o.object_id = c.object_id
+											WHERE   o.name = 'dm_server_services'
+													AND c.name = 'instant_file_initialization_enabled' )
+							BEGIN
+										SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+			SELECT  192 AS CheckID ,
+			50 AS Priority ,
+			''Server Info'' AS FindingsGroup ,
+			''Instant File Initialization Not Enabled'' AS Finding ,
+			''http://BrentOzar.com/go/instant'' AS URL ,
+			''Consider enabling IFI for faster restores and data file growths.''
+			FROM sys.dm_server_services WHERE instant_file_initialization_enabled <> ''Y'' AND filename LIKE ''%sqlservr.exe%''';
+										EXECUTE(@StringToExecute);
+									END
+
+
+
+
 
 					IF NOT EXISTS ( SELECT  1
 									FROM    #SkipChecks


### PR DESCRIPTION
The existing IFI check had a duplicate check ID, so gave it a new one
(193). Added sys.dm_server_services check 192 for SQL 2016 SP1. Closes
#593.