### PR TITLE
Skip offline databases

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -832,6 +832,11 @@ BEGIN
    RAISERROR('The database you specified does not exist. Please check the name and try again.', 16, 1);
    RETURN;
 END
+IF (SELECT DATABASEPROPERTYEX(@DatabaseName, 'Status')) <> 'ONLINE'
+BEGIN
+   RAISERROR('The database you specified is not readable. Please check the name and try again. Better yet, check your server.', 16, 1);
+   RETURN;
+END
 
 SELECT @MinMemoryPerQuery = CONVERT(INT, c.value) FROM sys.configurations AS c WHERE c.name = 'min memory per query (KB)';
 


### PR DESCRIPTION
Closes #228

I think this does what you want when I read through the article. The only time we run a query like the one that throws an error in the article is when someone supplies @DatabaseName

```
Select *
From sys.dm_exec_cached_plans CP
CROSS APPLY sys.dm_exec_query_plan(CP.plan_handle) QP
Where QP.dbid = DB_ID('TwoTBDatabase')
```