### PR TITLE
sp_BlitzFirst - Check 3 Fix

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -727,8 +727,7 @@ BEGIN
     FROM    sys.dm_tran_locks
     WHERE resource_type = N'DATABASE'
     AND     request_mode = N'S'
-    AND     request_status = N'GRANT'
-    AND     request_owner_type = N'SHARED_TRANSACTION_WORKSPACE') AS db ON s.session_id = db.request_session_id
+    AND     request_status = N'GRANT') AS db ON s.session_id = db.request_session_id
     CROSS APPLY sys.dm_exec_query_plan(r.plan_handle) pl
     WHERE r.command LIKE 'RESTORE%';
 


### PR DESCRIPTION
Fixes #552  .

Changes proposed in this pull request:
 - Removed request_owner_type from check 3 - Priority 1 (Restore Running)

How to test this code:
 - Run a database restore (code below from Brent's original bug report), while it's running EXEC sp_BlitzFirst. You should get a Priority 1 error (see screenshot) about backups currently running.

    USE msdb;
    GO
    ALTER DATABASE [StackOverflow] SET SINGLE_USER WITH ROLLBACK IMMEDIATE
RESTORE DATABASE [StackOverflow] FROM  DISK = N'M:\MSSQL\Backup\StackOverflow.bak' WITH  FILE = 1,  NOUNLOAD,  REPLACE,  STATS = 5
    ALTER DATABASE [StackOverflow] SET MULTI_USER
    GO

![image](https://cloud.githubusercontent.com/assets/20068038/21135941/6a6b6faa-c11b-11e6-8a32-13b6fe0e09e2.png)

Has been tested on:

 - SQL Server 2012 Enterprise (11.0.6020.0)
 - SQL Server 2014 Enterprise (12.0.4213.0)
 - SQL Server 2016 Developer (13.0.4001.0)

