### PR TITLE
sp_BlitzFirst - Check if CPU >= 25% for non SQL Server processes

### DIFF
--- a/Documentation/sp_BlitzFirst Checks by Priority.md
+++ b/Documentation/sp_BlitzFirst Checks by Priority.md
@@ -22,6 +22,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 50 | Query Problems | Plan Cache Erased Recently | http://BrentOzar.com/go/freeproccache | 7 |
 | 50 | Query Problems | Re-Compilations/Sec High | http://BrentOzar.com/go/recompile | 16 |
 | 50 | Server Performance | High CPU Utilization | http://BrentOzar.com/go/cpu | 24 |
+| 50 | Server Performance | High CPU Utilization - Non SQL Processes | http://BrentOzar.com/go/cpu | 28 |
 | 50 | Server Performance | Page Life Expectancy Low | http://BrentOzar.com/go/ple | 10 |
 | 50 | Server Performance | Slow Data File Reads | http://BrentOzar.com/go/slow | 11 |
 | 50 | Server Performance | Slow Log File Writes | http://BrentOzar.com/go/slow | 12 |

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -962,7 +962,7 @@ BEGIN
 		
 		/* Highlight if non SQL processes are using >25% CPU */
 		INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, Details, DetailsInt, URL)
-	    SELECT 28,	50,	'Server Performance', 'High CPU Utilization', CONVERT(NVARCHAR(100),100 - (y.SQLUsage + y.SystemIdle)) + N'% - Other Processes (not SQL Server) are using this much CPU. This may impact on the performance of your SQL Server instance', 100 - (y.SQLUsage + y.SystemIdle), 'http://www.BrentOzar.com/go/cpu'
+	    SELECT 28,	50,	'Server Performance', 'High CPU Utilization - Not SQL', CONVERT(NVARCHAR(100),100 - (y.SQLUsage + y.SystemIdle)) + N'% - Other Processes (not SQL Server) are using this much CPU. This may impact on the performance of your SQL Server instance', 100 - (y.SQLUsage + y.SystemIdle), 'http://www.BrentOzar.com/go/cpu'
             FROM (
                 SELECT record,
                     record.value('(./Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]', 'int') AS SystemIdle

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -961,6 +961,7 @@ BEGIN
             ) AS y
 		
 		/* Highlight if non SQL processes are using >25% CPU */
+		INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, Details, DetailsInt, URL)
 	    SELECT 28,	50,	'Server Performance', 'High CPU Utilization', CONVERT(NVARCHAR(100),100 - (y.SQLUsage + y.SystemIdle)) + N'% - Other Processes (not SQL Server) are using this much CPU. This may impact on the performance of your SQL Server instance', 100 - (y.SQLUsage + y.SystemIdle), 'http://www.BrentOzar.com/go/cpu'
             FROM (
                 SELECT record,


### PR DESCRIPTION
Fixes #444  .

Changes proposed in this pull request:
 - Add check 28 to see if CPU is over 25% for non SQL Server processes.
 - Add check to documentation

How to test this code:
 - Run a CPU intensive process on the SQL Server box and check in task manager that it's using over 25% of the available CPU. Then run sp_BlitzFirst with @seconds < 30 and this should appear as a level 50 error
 - Alternatively, change the threshold down to 1% (on line 977) to show the issue appearing as per below;

![image](https://cloud.githubusercontent.com/assets/20068038/21138296/4d6cb440-c125-11e6-98f7-857516fdbcca.png)

Has been tested on (remove any that don't apply):
 - SQL Server 2012 Enterprise (11.0.6020.0)
 - SQL Server 2014 Enterprise (12.0.4213.0)
 - SQL Server 2016 Developer (13.0.4001.0)
