### PR TITLE
Minor casing fix to 'Many Indexes Modified' message

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3645,7 +3645,7 @@ BEGIN
                      'Many Indexes Modified',
                      'Write Queries Are Hitting >= 5 Indexes',
                      'No URL yet',
-                     'This can cause lots of hidden I/O -- Run sp_BLitzIndex for more information.') ;
+                     'This can cause lots of hidden I/O -- Run sp_BlitzIndex for more information.') ;
 
         IF EXISTS (SELECT 1/0
                     FROM   ##bou_BlitzCacheProcs p


### PR DESCRIPTION
Changes proposed in this pull request:
 - Corrected a casing issue in the message for 'Many Indexes Modified'

How to test this code:
 -  Run against a database with Write queries hitting >- 5 indexes
 -  Validate the casing on the Details column in the output

Has been tested on (remove any that don't apply):
 - SQL Server 2014
