### PR TITLE
#726 sp_BlitzIndex removing brackets around DESC

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -996,7 +996,7 @@ BEGIN TRY
         SET        key_column_names_with_sort_order_no_types = D2.key_column_names_with_sort_order_no_types
         FROM    #IndexSanity si
                 CROSS APPLY ( SELECT    RTRIM(STUFF( (SELECT    N', ' + QUOTENAME(c.column_name) + CASE c.is_descending_key
-                                    WHEN 1 THEN N' [DESC]'
+                                    WHEN 1 THEN N' DESC'
                                     ELSE N''
                                 END AS col_definition
                             FROM    #IndexColumns c


### PR DESCRIPTION
In previous versions, if you looked at the “Create TSQL” column that
has definitions for indexes, it had brackets around the DESC keyword.
That wasn’t valid T-SQL. Removed the brackets. Closes #726.