### PR TITLE
sp_BlitzTrace - create + alter procedure pattern

### DIFF
--- a/sp_BlitzTrace.sql
+++ b/sp_BlitzTrace.sql
@@ -7,10 +7,11 @@ SET QUOTED_IDENTIFIER ON;
 SET STATISTICS IO OFF;
 SET STATISTICS TIME OFF;
 GO
-IF OBJECT_ID('dbo.sp_BlitzTrace') IS NOT NULL
-    DROP PROCEDURE dbo.sp_BlitzTrace
+IF OBJECT_ID('dbo.sp_BlitzTrace') IS  NULL
+    EXEC ('CREATE PROCEDURE dbo.sp_BlitzTrace AS RETURN 0');
 GO
-CREATE PROCEDURE dbo.sp_BlitzTrace
+
+ALTER PROCEDURE dbo.sp_BlitzTrace
     @Debug BIT = 0 , /* 1 prints the statement and won't execute it */
     @SessionId INT = NULL ,
     @Action VARCHAR(5) = NULL ,  /* 'start', 'read', 'stop', 'drop'*/


### PR DESCRIPTION
Fixes #743 for sp_BlitzTrace.

Changes proposed in this pull request:
 - switching to "create if not exists and then alter procedure" pattern instead of drop/create

How to test this code:
 - Tested in an scenario where the procedure doesn't exist yet and then also when it already does.

Has been tested on (remove any that don't apply):
 - SQL Server 2008 R2
