### PR TITLE
sp_foreachdb - create + alter procedure pattern

### DIFF
--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -1,11 +1,11 @@
 USE [master];
 GO
 
-IF OBJECT_ID('dbo.sp_foreachdb') IS NOT NULL
-    DROP PROCEDURE dbo.sp_foreachdb
+IF OBJECT_ID('dbo.sp_foreachdb') IS  NULL
+    EXEC ('CREATE PROCEDURE dbo.sp_foreachdb AS RETURN 0');
 GO
 
-CREATE PROCEDURE dbo.sp_foreachdb
+ALTER PROCEDURE dbo.sp_foreachdb
     @command NVARCHAR(MAX) ,
     @replace_character NCHAR(1) = N'?' ,
     @print_dbname BIT = 0 ,


### PR DESCRIPTION
Fixes #743 for sp_foreachdb.

Changes proposed in this pull request:

switching to "create if not exists and then alter procedure" pattern instead of drop/create
How to test this code:

Tested in an scenario where the procedure doesn't exist yet and then also when it already does.
Has been tested on (remove any that don't apply):

SQL Server 2008 R2