### PR TITLE
#748 sp_BlitzFirst adding poison wait check ID 30

### DIFF
--- a/Documentation/sp_BlitzFirst Checks by Priority.md
+++ b/Documentation/sp_BlitzFirst Checks by Priority.md
@@ -18,6 +18,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 1 | SQL Server Internal Maintenance | Data File Growing | http://BrentOzar.com/go/instant | 4 |
 | 1 | SQL Server Internal Maintenance | Log File Growing | http://BrentOzar.com/go/logsize | 13 |
 | 1 | SQL Server Internal Maintenance | Log File Shrinking | http://BrentOzar.com/go/logsize | 14 |
+| 10 | Server Performance | Poison Wait Detected | http://BrentOzar.com/go/poison | 30 |
 | 50 | Query Problems | Compilations/Sec High | http://BrentOzar.com/go/compile | 15 |
 | 50 | Query Problems | Plan Cache Erased Recently | http://BrentOzar.com/go/freeproccache | 7 |
 | 50 | Query Problems | Re-Compilations/Sec High | http://BrentOzar.com/go/recompile | 16 |

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -1339,6 +1339,21 @@ BEGIN
     WHERE wNow.wait_time_ms > (wBase.wait_time_ms + (.5 * (DATEDIFF(ss,@StartSampleTime,@FinishSampleTime)) * 1000)) /* Only look for things we've actually waited on for half of the time or more */
     ORDER BY (wNow.wait_time_ms - COALESCE(wBase.wait_time_ms,0)) DESC;
 
+    /* Server Performance - Poison Wait Detected - CheckID 30 */
+    INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, URL, Details, HowToStopIt, DetailsInt)
+    SELECT 30 AS CheckID,
+        10 AS Priority,
+        'Server Performance' AS FindingGroup,
+        'Poison Wait Detected: ' + wNow.wait_type AS Finding,
+        N'http://www.brentozar.com/go/poison/#' + wNow.wait_type AS URL,
+        'For ' + CAST(((wNow.wait_time_ms - COALESCE(wBase.wait_time_ms,0)) / 1000) AS NVARCHAR(100)) + ' seconds over the last ' + CASE @Seconds WHEN 0 THEN (CAST(DATEDIFF(dd,@StartSampleTime,@FinishSampleTime) AS NVARCHAR(10)) + ' days') ELSE (CAST(@Seconds AS NVARCHAR(10)) + ' seconds') END + ', SQL Server was waiting on this particular bottleneck.' + @LineFeed + @LineFeed AS Details,
+        'See the URL for more details on how to mitigate this wait type.' AS HowToStopIt,
+        ((wNow.wait_time_ms - COALESCE(wBase.wait_time_ms,0)) / 1000) AS DetailsInt
+    FROM #WaitStats wNow
+    LEFT OUTER JOIN #WaitStats wBase ON wNow.wait_type = wBase.wait_type AND wNow.SampleTime > wBase.SampleTime
+    WHERE wNow.wait_type IN ('RESOURCE_SEMAPHORE', 'RESOURCE_SEMAPHORE_QUERY_COMPILE', 'THREADPOOL') AND wNow.wait_time_ms > wBase.wait_time_ms;
+
+
     /* Server Performance - Slow Data File Reads - CheckID 11 */
 	IF EXISTS (SELECT * FROM #BlitzFirstResults WHERE Finding LIKE 'PAGEIOLATCH%')
 	BEGIN


### PR DESCRIPTION
Also modifies check 6 to include poison waits in the wait stats section
even if they’re not in the top 10. Closes #748.