### PR TITLE
Quote file paths to avoid problems when paths have spaces

### DIFF
--- a/DatabaseRestore.sql
+++ b/DatabaseRestore.sql
@@ -53,7 +53,7 @@ IF @RestoreDatabaseName IS NULL
 	SET @RestoreDatabaseName = @Database;
 
 -- get list of files 
-SET @cmd = 'DIR /b '+ @BackupPathFull;
+SET @cmd = 'DIR /b "'+ @BackupPathFull + '"';
 INSERT INTO @FileList (BackupFile)
 EXEC master.sys.xp_cmdshell @cmd; 
 
@@ -160,7 +160,7 @@ END;
 --Clear out table variables for translogs
 DELETE FROM @FileList;
         
-SET @cmd = 'DIR /b '+ @BackupPathLog;
+SET @cmd = 'DIR /b "'+ @BackupPathLog + '"';
 INSERT INTO @FileList (BackupFile)
 EXEC master.sys.xp_cmdshell @cmd;
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - Add double-quotes around file names when passing to xp_cmdshell

How to test this code:
 - Execute dbo.DatabaseRestore against a path with a space in it

Has been tested on (remove any that don't apply):
 - SQL Server 2014

It's a small initial change... I hope to have another coming soon. :smile: 
