### PR TITLE
Issue 766/movefiles fails with long paths

### DIFF
--- a/DatabaseRestore.sql
+++ b/DatabaseRestore.sql
@@ -47,8 +47,6 @@ SET NOCOUNT ON;
 DECLARE @cmd NVARCHAR(4000), @sql NVARCHAR(MAX), @LastFullBackup NVARCHAR(500), @BackupFile NVARCHAR(500);
 DECLARE @FileList TABLE (BackupFile NVARCHAR(255));
 
-DECLARE @MoveDataLocation AS NVARCHAR(500), @MoveDataLocationName AS NVARCHAR(500), @MoveLogLocation AS NVARCHAR(500), @MoveLogLocationName AS NVARCHAR(500);
-
 IF @RestoreDatabaseName IS NULL
 	SET @RestoreDatabaseName = @Database;
 

--- a/DatabaseRestore.sql
+++ b/DatabaseRestore.sql
@@ -92,7 +92,7 @@ DECLARE @FileListParameters TABLE
 INSERT INTO @FileListParameters
 EXEC ('RESTORE FILELISTONLY FROM DISK='''+@BackupPathFull + @LastFullBackup+'''');
 
-DECLARE @MoveOption AS NVARCHAR(1000)= '';
+DECLARE @MoveOption AS NVARCHAR(MAX)= '';
 
 IF @MoveFiles = 1
 BEGIN


### PR DESCRIPTION
Fixes #766 (DatabaseRestore - Restores fail when using @MoveFiles=1 with long paths / multiple files).

Changes proposed in this pull request:
 - Remove 4 unused variables
 - Change @MoveOption variable to nvarchar(MAX)

How to test this code:
 - Backup up a database to multiple files (i.e. 8) to a directory with a relatively long path (i.e. C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Backup). Then attempt to restore using @MoveFiles=1. This should now work.

Has been tested on (remove any that don't apply):
 - SQL Server 2016