### PR TITLE
Issue 814 - Added Differential Restore Feature to sp_DatabaseRestore 

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -1,33 +1,33 @@
 /*
-EXEC dbo.DatabaseRestore 
+EXEC dbo.sp_DatabaseRestore 
 	@Database = 'LogShipMe', 
 	@BackupPathFull = 'D:\Backup\SQL2016PROD1A\LogShipMe\FULL\', 
 	@BackupPathLog = 'D:\Backup\SQL2016PROD1A\LogShipMe\LOG\', 
 	@ContinueLogs = 0, 
 	@RunRecovery = 0;
 
-EXEC dbo.DatabaseRestore 
+EXEC dbo.sp_DatabaseRestore 
 	@Database = 'LogShipMe', 
 	@BackupPathFull = 'D:\Backup\SQL2016PROD1A\LogShipMe\FULL\', 
 	@BackupPathLog = 'D:\Backup\SQL2016PROD1A\LogShipMe\LOG\', 
 	@ContinueLogs = 1, 
 	@RunRecovery = 0;
 
-EXEC dbo.DatabaseRestore 
+EXEC dbo.sp_DatabaseRestore 
 	@Database = 'LogShipMe', 
 	@BackupPathFull = 'D:\Backup\SQL2016PROD1A\LogShipMe\FULL\', 
 	@BackupPathLog = 'D:\Backup\SQL2016PROD1A\LogShipMe\LOG\', 
 	@ContinueLogs = 1, 
 	@RunRecovery = 1;
 
-EXEC dbo.DatabaseRestore 
+EXEC dbo.sp_DatabaseRestore 
 	@Database = 'LogShipMe', 
 	@BackupPathFull = 'D:\Backup\SQL2016PROD1A\LogShipMe\FULL\', 
 	@BackupPathLog = 'D:\Backup\SQL2016PROD1A\LogShipMe\LOG\', 
 	@ContinueLogs = 0, 
 	@RunRecovery = 1;
 
-EXEC dbo.DatabaseRestore 
+EXEC dbo.sp_DatabaseRestore 
 	@Database = 'LogShipMe', 
 	@BackupPathFull = 'D:\Backup\SQL2016PROD1A\LogShipMe\FULL\', 
 	@BackupPathDiff = 'D:\Backup\SQL2016PROD1A\LogShipMe\DIFF\',
@@ -35,6 +35,18 @@ EXEC dbo.DatabaseRestore
 	@RestoreDiff = 1,
 	@ContinueLogs = 0, 
 	@RunRecovery = 1;
+
+EXEC dbo.sp_DatabaseRestore 
+	@Database = 'LogShipMe', 
+	@BackupPathFull = '\\StorageServer\LogShipMe\FULL\', 
+	@BackupPathDiff = '\\StorageServer\LogShipMe\DIFF\',
+	@BackupPathLog = '\\StorageServer\LogShipMe\LOG\', 
+	@RestoreDiff = 1,
+	@ContinueLogs = 0, 
+	@RunRecovery = 1,
+	@TestRestore = 1,
+	@RunCheckDB = 1,
+	@Debug = 0;
 */
 
 IF OBJECT_ID('dbo.sp_DatabaseRestore') IS NULL
@@ -48,7 +60,7 @@ ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
 AS
 SET NOCOUNT ON;
 
-DECLARE @cmd NVARCHAR(4000), @sql NVARCHAR(MAX), @LastFullBackup NVARCHAR(500), @LastDiffBackup NVARCHAR(500), @BackupFile NVARCHAR(500), @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0);
+DECLARE @cmd NVARCHAR(4000), @sql NVARCHAR(MAX), @LastFullBackup NVARCHAR(500), @LastDiffBackup NVARCHAR(500), @BackupFile NVARCHAR(500), @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0), @DiffLastLSN NUMERIC(25, 0);
 DECLARE @FileList TABLE (BackupFile NVARCHAR(255));
 
 IF @RestoreDatabaseName IS NULL
@@ -122,7 +134,9 @@ SET @FileListParamSQL += ')' + CHAR(13) + CHAR(10);
 SET @FileListParamSQL += 'EXEC (''RESTORE FILELISTONLY FROM DISK=''''{Path}'''''')';
 
 SET @sql = REPLACE(@FileListParamSQL, '{Path}', @BackupPathFull + @LastFullBackup);
-PRINT @sql;
+IF @Debug = 2
+	PRINT @sql;
+
 EXEC (@sql);
 
 -- Build SQL for RESTORE HEADERONLY - this will be used a bit further below
@@ -192,11 +206,14 @@ BEGIN
 
   --get the backup completed data so we can apply tlogs from that point forwards                                                   
   SET @sql = REPLACE(@HeadersSQL, '{Path}', @BackupPathFull + @LastFullBackup);
-  PRINT @sql;
+  IF @Debug = 2
+	PRINT @sql;
+  
   EXECUTE (@sql);
 	--DECLARE @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0); Commented out for testing
 	SELECT @BackupDateTime = RIGHT(@LastFullBackup, 19)
 	SELECT @FullLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 1;  
+  IF @Debug = 2
 	PRINT @BackupDateTime                                                
 END;
 ELSE
@@ -232,12 +249,14 @@ BEGIN
 		EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	
   --get the backup completed data so we can apply tlogs from that point forwards                                                   
-  SET @sql = REPLACE(@HeadersSQL, '{Path}', @BackupPathFull + @LastFullBackup);
-  PRINT @sql;
+  SET @sql = REPLACE(@HeadersSQL, '{Path}', @BackupPathDiff + @LastDiffBackup);
+  IF @Debug = 2
+	PRINT @sql;
+  
   EXECUTE (@sql);
 	--DECLARE @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0);
 	SELECT @BackupDateTime = RIGHT(@LastDiffBackup, 19)
-	SELECT @FullLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 1;                                                  
+	SELECT @DiffLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 5;                                                  
 END;
 
 --Clear out table variables for translogs
@@ -263,11 +282,15 @@ BEGIN
 	IF @i = 1
 	BEGIN
     SET @sql = REPLACE(@HeadersSQL, '{Path}', @BackupPathLog + @BackupFile);
-    PRINT @sql;
-    EXECUTE (@sql);
+	IF @Debug = 2
+		PRINT @sql;
+	EXECUTE (@sql);
 		
 		SELECT @LogFirstLSN = CAST(FirstLSN AS NUMERIC(25, 0)), @LogLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 2;
-		IF (@ContinueLogs = 0 AND @LogFirstLSN <= @FullLastLSN AND @FullLastLSN <= @LogLastLSN) OR (@ContinueLogs = 1 AND @LogFirstLSN <= @DatabaseLastLSN AND @DatabaseLastLSN < @LogLastLSN)
+
+		IF (@ContinueLogs = 0 AND @LogFirstLSN <= @FullLastLSN AND @FullLastLSN <= @LogLastLSN AND @RestoreDiff = 0) OR (@ContinueLogs = 1 AND @LogFirstLSN <= @DatabaseLastLSN AND @DatabaseLastLSN < @LogLastLSN AND @RestoreDiff = 0)
+			SET @i = 2;
+		IF (@ContinueLogs = 0 AND @LogFirstLSN <= @DiffLastLSN AND @DiffLastLSN <= @LogLastLSN AND @RestoreDiff = 1) OR (@ContinueLogs = 1 AND @LogFirstLSN <= @DatabaseLastLSN AND @DatabaseLastLSN < @LogLastLSN AND @RestoreDiff = 1)
 			SET @i = 2;
 		DELETE FROM #Headers WHERE BackupType = 2;
 	END;
@@ -275,7 +298,8 @@ BEGIN
 	BEGIN
 		SET @sql = 'RESTORE LOG '+@RestoreDatabaseName+' FROM DISK = '''+@BackupPathLog + @BackupFile+''' WITH NORECOVERY'+CHAR(13);
 		PRINT @sql
-		EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE LOG', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+		IF @Debug = 0
+			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE LOG', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;
 	FETCH NEXT FROM BackupFiles INTO @BackupFile;
 END;
@@ -284,16 +308,25 @@ DEALLOCATE BackupFiles;
 -- put database in a useable state 
 IF @RunRecovery = 1
 BEGIN
-	SET @sql = 'RESTORE DATABASE '+@RestoreDatabaseName+' WITH RECOVERY';
-	EXECUTE sp_executesql @sql;
+	SET @sql = 'RESTORE DATABASE '+@RestoreDatabaseName+' WITH RECOVERY'+CHAR(13);
+	PRINT @sql
+	IF @Debug = 0
+		EXECUTE sp_executesql @sql;
 END;
 	    
  --Run checkdb against this database
 IF @RunCheckDB = 1
-	EXECUTE [dbo].[DatabaseIntegrityCheck] @Databases = @RestoreDatabaseName, @LogToTable = 'Y';
+BEGIN
+	SET @sql = 'EXECUTE [dbo].[DatabaseIntegrityCheck] @Databases = ' + @RestoreDatabaseName + ', @LogToTable = ''Y'''+CHAR(13);
+	PRINT @sql
+	IF @Debug = 0
+		EXECUTE sys.sp_executesql @sql
+END;
  --If test restore then blow the database away (be careful)
 IF @TestRestore = 1
 BEGIN
-	SET @sql = 'DROP DATABASE '+@RestoreDatabaseName;
-	EXECUTE sp_executesql @sql;
+	SET @sql = 'DROP DATABASE '+@RestoreDatabaseName+CHAR(13);
+	PRINT @sql
+	IF @Debug = 0
+		EXECUTE sp_executesql @sql;
 END;

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -33,13 +33,13 @@ IF OBJECT_ID('dbo.sp_DatabaseRestore') IS NULL
 GO
 
 ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
-	  @Database NVARCHAR(128), @RestoreDatabaseName NVARCHAR(128) = NULL, @BackupPathFull NVARCHAR(MAX), @BackupPathLog NVARCHAR(MAX),
-	  @MoveFiles bit = 0, @MoveDataDrive NVARCHAR(260) = NULL, @MoveLogDrive NVARCHAR(260) = NULL, @TestRestore bit = 0, @RunCheckDB bit = 0, 
+	  @Database NVARCHAR(128), @RestoreDatabaseName NVARCHAR(128) = NULL, @BackupPathFull NVARCHAR(MAX), @BackupPathDiff NVARCHAR(MAX), @BackupPathLog NVARCHAR(MAX),
+	  @MoveFiles bit = 0, @MoveDataDrive NVARCHAR(260) = NULL, @MoveLogDrive NVARCHAR(260) = NULL, @TestRestore bit = 0, @RunCheckDB bit = 0, @ContinueDiff bit = 0,
 	  @ContinueLogs bit = 0, @RunRecovery bit = 0
 AS
 SET NOCOUNT ON;
 
-DECLARE @cmd NVARCHAR(4000), @sql NVARCHAR(MAX), @LastFullBackup NVARCHAR(500), @BackupFile NVARCHAR(500);
+DECLARE @cmd NVARCHAR(4000), @sql NVARCHAR(MAX), @LastFullBackup NVARCHAR(500), @LastDiffBackup NVARCHAR(500), @BackupFile NVARCHAR(500), @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0);
 DECLARE @FileList TABLE (BackupFile NVARCHAR(255));
 
 IF @RestoreDatabaseName IS NULL
@@ -174,34 +174,59 @@ BEGIN
 	SELECT @MoveOption = @MoveOption + logicalcmds
 	FROM Files;
 END;
-
 IF @ContinueLogs = 0
 BEGIN
 	SET @sql = 'RESTORE DATABASE '+@RestoreDatabaseName+' FROM DISK = '''+@BackupPathFull + @LastFullBackup+ ''' WITH NORECOVERY, REPLACE' + @MoveOption+CHAR(13);
 	PRINT @sql;
 	EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
-
 	--get the backup completed data so we can apply tlogs from that point forwards
                                                         
   SET @sql = REPLACE(@HeadersSQL, '{Path}', @BackupPathFull + @LastFullBackup);
   PRINT @sql;
   EXECUTE (@sql);
-
-	DECLARE @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0);
-
+	--DECLARE @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0);
 	SELECT @BackupDateTime = RIGHT(@LastFullBackup, 19)
-
-	SELECT @FullLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 1;
-                                                        
+	SELECT @FullLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 1;  
+	PRINT @BackupDateTime                                                
 END;
 ELSE
 BEGIN
 	DECLARE @DatabaseLastLSN NUMERIC(25, 0);
-
 	SELECT @DatabaseLastLSN = CAST(f.redo_start_lsn AS NUMERIC(25, 0))
 	FROM master.sys.databases d
 	JOIN master.sys.master_files f ON d.database_id = f.database_id
 	WHERE d.name = @RestoreDatabaseName AND f.file_id = 1
+END;
+
+--Clear out table variables for differential
+DELETE FROM @FileList;
+
+-- get list of files 
+SET @cmd = 'DIR /b "'+ @BackupPathDiff + '"';
+INSERT INTO @FileList (BackupFile)
+EXEC master.sys.xp_cmdshell @cmd; 
+
+-- select * from @fileList
+-- Find latest diff backup 
+SELECT @LastDiffBackup = MAX(BackupFile)
+FROM @FileList
+WHERE BackupFile LIKE '%.bak'
+    AND
+    BackupFile LIKE '%'+@Database+'%';
+
+IF @ContinueDiff = 1 AND @BackupDateTime < RIGHT(@LastDiffBackup, 19)
+BEGIN
+	SET @sql = 'RESTORE DATABASE '+@RestoreDatabaseName+' FROM DISK = '''+@BackupPathDiff + @LastDiffBackup+ ''' WITH NORECOVERY';
+	PRINT @sql;
+	EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+	--get the backup completed data so we can apply tlogs from that point forwards
+                                                        
+  SET @sql = REPLACE(@HeadersSQL, '{Path}', @BackupPathFull + @LastFullBackup);
+  PRINT @sql;
+  EXECUTE (@sql);
+	--DECLARE @BackupDateTime AS CHAR(15), @FullLastLSN NUMERIC(25, 0);
+	SELECT @BackupDateTime = RIGHT(@LastDiffBackup, 19)
+	SELECT @FullLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 1;                                                  
 END;
 
 --Clear out table variables for translogs
@@ -210,7 +235,6 @@ DELETE FROM @FileList;
 SET @cmd = 'DIR /b "'+ @BackupPathLog + '"';
 INSERT INTO @FileList (BackupFile)
 EXEC master.sys.xp_cmdshell @cmd;
-
 --check for log backups 
 DECLARE BackupFiles CURSOR FOR
 	SELECT BackupFile
@@ -218,11 +242,8 @@ DECLARE BackupFiles CURSOR FOR
 	WHERE BackupFile LIKE '%.trn'
 	  AND BackupFile LIKE '%'+@Database+'%'
 	  AND (@ContinueLogs = 1 OR (@ContinueLogs = 0 AND LEFT(RIGHT(BackupFile, 19), 15) >= @BackupDateTime));
-
 OPEN BackupFiles;
-
 DECLARE @i tinyint = 1, @LogFirstLSN NUMERIC(25, 0), @LogLastLSN NUMERIC(25, 0);
-
 -- Loop through all the files for the database  
 FETCH NEXT FROM BackupFiles INTO @BackupFile;
 WHILE @@FETCH_STATUS = 0
@@ -234,26 +255,20 @@ BEGIN
     EXECUTE (@sql);
 		
 		SELECT @LogFirstLSN = CAST(FirstLSN AS NUMERIC(25, 0)), @LogLastLSN = CAST(LastLSN AS NUMERIC(25, 0)) FROM #Headers WHERE BackupType = 2;
-
 		IF (@ContinueLogs = 0 AND @LogFirstLSN <= @FullLastLSN AND @FullLastLSN <= @LogLastLSN) OR (@ContinueLogs = 1 AND @LogFirstLSN <= @DatabaseLastLSN AND @DatabaseLastLSN < @LogLastLSN)
 			SET @i = 2;
-
 		DELETE FROM #Headers WHERE BackupType = 2;
 	END;
-
 	IF @i = 2
 	BEGIN
 		SET @sql = 'RESTORE LOG '+@RestoreDatabaseName+' FROM DISK = '''+@BackupPathLog + @BackupFile+''' WITH NORECOVERY'+CHAR(13);
 		PRINT @sql
 		EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE LOG', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;
-
 	FETCH NEXT FROM BackupFiles INTO @BackupFile;
 END;
-
 CLOSE BackupFiles;
 DEALLOCATE BackupFiles;  
-
 -- put database in a useable state 
 IF @RunRecovery = 1
 BEGIN
@@ -264,11 +279,9 @@ END;
  --Run checkdb against this database
 IF @RunCheckDB = 1
 	EXECUTE [dbo].[DatabaseIntegrityCheck] @Databases = @RestoreDatabaseName, @LogToTable = 'Y';
-
  --If test restore then blow the database away (be careful)
 IF @TestRestore = 1
 BEGIN
 	SET @sql = 'DROP DATABASE '+@RestoreDatabaseName;
 	EXECUTE sp_executesql @sql;
 END;
-

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -36,6 +36,7 @@ EXEC dbo.sp_DatabaseRestore
 	@ContinueLogs = 0, 
 	@RunRecovery = 1;
 
+-- 
 EXEC dbo.sp_DatabaseRestore 
 	@Database = 'LogShipMe', 
 	@BackupPathFull = '\\StorageServer\LogShipMe\FULL\', 
@@ -243,7 +244,7 @@ WHERE BackupFile LIKE '%.bak'
 
 IF @RestoreDiff = 1 AND @BackupDateTime < RIGHT(@LastDiffBackup, 19)
 BEGIN
-	SET @sql = 'RESTORE DATABASE '+@RestoreDatabaseName+' FROM DISK = '''+@BackupPathDiff + @LastDiffBackup+ ''' WITH NORECOVERY';
+	SET @sql = 'RESTORE DATABASE '+@RestoreDatabaseName+' FROM DISK = '''+@BackupPathDiff + @LastDiffBackup+ ''' WITH NORECOVERY'+CHAR(13);
 	PRINT @sql;
 	IF @Debug = 0
 		EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';


### PR DESCRIPTION
Fixes #814 

Changes proposed in this pull request:

added ContinueDiff bit parameter to signal that the procedure should
check for diffs

added LastDiffBackup variable and moved the BackupFile and
BackupDateTime variables to be global so that they can be used across
the full and diff functions

cut n pasted the full restore feature, modified it to handle diffs and
set conditional logic so that the most recent diff date is checked
against the full backup date, this will hopefully prevent a situation
where there are no diffs or diffs older than the full.

How to test this code:

EXEC dbo.sp_DatabaseRestore 
  @Database = 'YourDBName', 
  @BackupPathFull = '\\YourPath\FULL\', 
  @BackupPathDiff = '\\YourPath\DIFF\',
  @BackupPathLog = '\\YourPath\LOG\', 
  @RestoreDiff = 1,
  @ContinueLogs = 0, 
  @RunRecovery = 1;

Has been tested on (remove any that don't apply):
 - SQL Server 2014
 - SQL Server 2012
