### PR TITLE
Default @suppress_quotename to true

### DIFF
--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -10,7 +10,7 @@ CREATE PROCEDURE dbo.sp_foreachdb
     @replace_character NCHAR(1) = N'?' ,
     @print_dbname BIT = 0 ,
     @print_command_only BIT = 0 ,
-    @suppress_quotename BIT = 0 ,
+    @suppress_quotename BIT = 1 ,
     @system_only BIT = NULL ,
     @user_only BIT = NULL ,
     @name_pattern NVARCHAR(300) = N'%' ,


### PR DESCRIPTION
Fixes [#536](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/536)

Changes proposed in this pull request:
Bring sp_foreachdb inline with sp_MSforeachdb. Default @suppress_quotename param to true.

How to test this code:
EXEC dbo.sp_foreachdb @command = 'USE [?]; SELECT DB_NAME();' should work the same as
EXEC dbo.sp_MSforeachdb @Command1 = 'USE [?]; SELECT DB_NAME();'

Has been tested on (remove any that don't apply):
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
