### PR TITLE
Fixes Issue #923

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -312,7 +312,8 @@ IF @ContinueLogs = 0
 	BEGIN
 	
 		SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @BackupPathFull + @LastFullBackup + N''' WITH NORECOVERY, REPLACE' + @MoveOption + NCHAR(13);
-		PRINT @sql;
+		IF @Debug = 1
+			PRINT @sql;
 		
 		IF @Debug = 0
 			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
@@ -372,7 +373,8 @@ WHERE BackupFile LIKE '%.bak'
 IF @RestoreDiff = 1 AND @BackupDateTime < @LastDiffBackupDateTime
 	BEGIN
 		SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @BackupPathDiff + @LastDiffBackup + N''' WITH NORECOVERY' + NCHAR(13);
-		PRINT @sql;
+		IF @Debug = 1
+			PRINT @sql;
 		
 		IF @Debug = 0
 			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
@@ -464,10 +466,11 @@ FETCH NEXT FROM BackupFiles INTO @BackupFile;
 			BEGIN
 				
 				SET @sql = N'RESTORE LOG ' + @RestoreDatabaseName + N' FROM DISK = ''' + @BackupPathLog + @BackupFile + N''' WITH NORECOVERY' + NCHAR(13);
-				PRINT @sql;
+				IF @Debug = 1
+					PRINT @sql;
 				
-					IF @Debug = 0
-						EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE LOG', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+				IF @Debug = 0
+					EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE LOG', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 			END;
 			
 			FETCH NEXT FROM BackupFiles INTO @BackupFile;
@@ -482,7 +485,8 @@ DEALLOCATE BackupFiles;
 IF @RunRecovery = 1
 	BEGIN
 		SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' WITH RECOVERY' + NCHAR(13);
-		PRINT @sql;
+		IF @Debug = 1
+			PRINT @sql;
 		IF @Debug = 0
 			EXECUTE sp_executesql @sql;
 	END;
@@ -492,7 +496,8 @@ IF @RunRecovery = 1
 IF @RunCheckDB = 1
 	BEGIN
 		SET @sql = N'EXECUTE [dbo].[DatabaseIntegrityCheck] @Databases = ' + @RestoreDatabaseName + N', @LogToTable = ''Y''' + NCHAR(13);
-		PRINT @sql;
+		IF @Debug = 1
+			PRINT @sql;
 		IF @Debug = 0
 			EXECUTE sys.sp_executesql @sql;
 	END;
@@ -501,7 +506,8 @@ IF @RunCheckDB = 1
 IF @TestRestore = 1
 	BEGIN
 		SET @sql = N'DROP DATABASE ' + @RestoreDatabaseName + NCHAR(13);
-		PRINT @sql;
+		IF @Debug = 1
+			PRINT @sql;
 		IF @Debug = 0
 			EXECUTE sp_executesql @sql;
 	END;


### PR DESCRIPTION
After reviewing it seems like I missed quite a few places where this
should have gone.  Fixed them and now debug 0 executes, debug 1 prints
commands for the doubtful dba and debug 2 prints the other stuff one
might use during development

Fixes #923 

Changes proposed in this pull request:
Reworked dem debug statements so they actually work 

How to test this code:
You can test via the automated test script in the SQL-Server-First-Responder-Kit\Documentation\Development folder

Has been tested on (remove any that don't apply):
 - SQL Server 2014
