### PR TITLE
Adds debug modes to sp_Blitz

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1,5 +1,5 @@
 IF OBJECT_ID('dbo.sp_Blitz') IS NULL
-  EXEC ('CREATE PROCEDURE dbo.sp_Blitz AS RETURN 0;')
+  EXEC ('CREATE PROCEDURE dbo.sp_Blitz AS RETURN 0;');
 GO
 
 ALTER PROCEDURE [dbo].[sp_Blitz]
@@ -25,6 +25,7 @@ ALTER PROCEDURE [dbo].[sp_Blitz]
     @EmailProfile sysname = NULL ,
     @SummaryMode TINYINT = 0 ,
     @BringThePain TINYINT = 0 ,
+	@Debug TINYINT  = 0,
     @VersionDate DATETIME = NULL OUTPUT
 WITH RECOMPILE
 AS
@@ -108,12 +109,12 @@ AS
 
 
 
-	*/'
+	*/';
 	ELSE IF @OutputType = 'SCHEMA'
 	BEGIN
-		SELECT FieldList = '[Priority] TINYINT, [FindingsGroup] VARCHAR(50), [Finding] VARCHAR(200), [DatabaseName] NVARCHAR(128), [URL] VARCHAR(200), [Details] NVARCHAR(4000), [QueryPlan] NVARCHAR(MAX), [QueryPlanFiltered] NVARCHAR(MAX), [CheckID] INT'
+		SELECT FieldList = '[Priority] TINYINT, [FindingsGroup] VARCHAR(50), [Finding] VARCHAR(200), [DatabaseName] NVARCHAR(128), [URL] VARCHAR(200), [Details] NVARCHAR(4000), [QueryPlan] NVARCHAR(MAX), [QueryPlanFiltered] NVARCHAR(MAX), [CheckID] INT';
 
-	END
+	END;
 	ELSE /* IF @OutputType = 'SCHEMA' */
 	BEGIN
 
@@ -218,12 +219,15 @@ AS
 			AND @SkipChecksSchema IS NOT NULL
 			AND @SkipChecksDatabase IS NOT NULL
 			BEGIN
+				
+				IF @Debug IN (1, 2) RAISERROR('Inserting SkipChecks', 0, 1) WITH NOWAIT;
+				
 				SET @StringToExecute = 'INSERT INTO #SkipChecks(DatabaseName, CheckID, ServerName )
 				SELECT DISTINCT DatabaseName, CheckID, ServerName
 				FROM ' + QUOTENAME(@SkipChecksDatabase) + '.' + QUOTENAME(@SkipChecksSchema) + '.' + QUOTENAME(@SkipChecksTable)
-					+ ' WHERE ServerName IS NULL OR ServerName = SERVERPROPERTY(''ServerName'') OPTION (RECOMPILE);'
-				EXEC(@StringToExecute)
-			END
+					+ ' WHERE ServerName IS NULL OR ServerName = SERVERPROPERTY(''ServerName'') OPTION (RECOMPILE);';
+				EXEC(@StringToExecute);
+			END;
 
 		IF NOT EXISTS ( SELECT  1
 							FROM    #SkipChecks
@@ -235,7 +239,7 @@ AS
 					select @indx = patindex('%\%', @curr_tracefilename) ;
 					set @curr_tracefilename = reverse(@curr_tracefilename) ;
 					set @base_tracefilename = left( @curr_tracefilename,len(@curr_tracefilename) - @indx) + '\log.trc' ;
-			END
+			END;
 
 		/* If the server has any databases on Antiques Roadshow, skip the checks that would break due to CTEs. */
 		IF @CheckUserDatabaseObjects = 1 AND EXISTS(SELECT * FROM sys.databases WHERE compatibility_level < 90)
@@ -245,7 +249,7 @@ AS
 			PRINT 'The database-level checks rely on CTEs, which are not supported in SQL 2000 compat level databases.';
 			PRINT 'Get with the cool kids and switch to a current compatibility level, Grandpa. To find the problems, run:';
 			PRINT 'SELECT * FROM sys.databases WHERE compatibility_level < 90;';
-		END
+		END;
 
 
 		/* --TOURSTOP08-- */
@@ -276,7 +280,7 @@ AS
 						INSERT INTO #SkipChecks (CheckID) VALUES (177);
 						INSERT INTO #SkipChecks (CheckID) VALUES (180); /* 180/181 are maintenance plans */
 						INSERT INTO #SkipChecks (CheckID) VALUES (181);
-			END /* Amazon RDS skipped checks */
+			END; /* Amazon RDS skipped checks */
 
 		/* If the server is ExpressEdition, skip checks that it doesn't allow */
 		IF CAST(SERVERPROPERTY('Edition') AS NVARCHAR(1000)) LIKE N'%Express%'
@@ -286,7 +290,7 @@ AS
 						INSERT INTO #SkipChecks (CheckID) VALUES (61); /* Agent alerts 19-25 */
 						INSERT INTO #SkipChecks (CheckID) VALUES (73); /* Failsafe operator */
 						INSERT INTO #SkipChecks (CheckID) VALUES (96); /* Agent alerts for corruption */
-			END /* Express Edition skipped checks */
+			END; /* Express Edition skipped checks */
 
 
 		/*
@@ -342,7 +346,7 @@ AS
 			  Field VARCHAR(255) ,
 			  Value VARCHAR(255) ,
 			  DbName NVARCHAR(128) NULL
-			)
+			);
 
 
 		IF OBJECT_ID('tempdb..#LogInfo2012') IS NOT NULL
@@ -379,7 +383,7 @@ AS
 			  dbname NVARCHAR(128) ,
 			  objectname NVARCHAR(200) ,
 			  type_desc NVARCHAR(128)
-			)
+			);
 
 		IF OBJECT_ID('tempdb..#TraceStatus') IS NOT NULL
 			DROP TABLE #TraceStatus;
@@ -397,7 +401,7 @@ AS
 			(
 			  drive NVARCHAR ,
 			  SIZE DECIMAL(18, 2)
-			)
+			);
 
 
 		IF OBJECT_ID('tempdb..#dm_exec_query_stats') IS NOT NULL
@@ -446,7 +450,7 @@ AS
 									 NULL ,
 			  [text_filtered] [nvarchar](MAX) COLLATE SQL_Latin1_General_CP1_CI_AS
 											  NULL
-			)
+			);
 
 		IF OBJECT_ID('tempdb..#ErrorLog') IS NOT NULL
 			DROP TABLE #ErrorLog;
@@ -507,32 +511,40 @@ AS
 		INSERT INTO #IgnorableWaits VALUES ('XE_LIVE_TARGET_TVF');
 		INSERT INTO #IgnorableWaits VALUES ('XE_TIMER_EVENT');
         
+		IF @Debug IN (1, 2) RAISERROR('Setting @MsSinceWaitsCleared', 0, 1) WITH NOWAIT;
+
         SELECT @MsSinceWaitsCleared = DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP) * 60000.0
             FROM    sys.databases
-            WHERE   name='tempdb';
+            WHERE   name = 'tempdb';
 
 		/* Have they cleared wait stats? Using a 10% fudge factor */
 		IF @MsSinceWaitsCleared * .9 > (SELECT MAX(wait_time_ms) FROM sys.dm_os_wait_stats WHERE wait_type IN ('SP_SERVER_DIAGNOSTICS_SLEEP', 'QDS_PERSIST_TASK_MAIN_LOOP_SLEEP', 'REQUEST_FOR_DEADLOCK_SEARCH', 'HADR_FILESTREAM_IOMGR_IOCOMPLETION', 'LAZYWRITER_SLEEP', 'SQLTRACE_INCREMENTAL_FLUSH_SLEEP', 'DIRTY_PAGE_POLL', 'LOGMGR_QUEUE'))
 			BEGIN
+				
+				IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 185) WITH NOWAIT;
+
 				SET @MsSinceWaitsCleared = (SELECT MAX(wait_time_ms) FROM sys.dm_os_wait_stats WHERE wait_type IN ('SP_SERVER_DIAGNOSTICS_SLEEP', 'QDS_PERSIST_TASK_MAIN_LOOP_SLEEP', 'REQUEST_FOR_DEADLOCK_SEARCH', 'HADR_FILESTREAM_IOMGR_IOCOMPLETION', 'LAZYWRITER_SLEEP', 'SQLTRACE_INCREMENTAL_FLUSH_SLEEP', 'DIRTY_PAGE_POLL', 'LOGMGR_QUEUE'));
 				IF @MsSinceWaitsCleared = 0 SET @MsSinceWaitsCleared = 1;
 				INSERT  INTO #BlitzResults
-						( CheckID ,
+						(   CheckID ,
 							Priority ,
 							FindingsGroup ,
 							Finding ,
 							URL ,
 							Details
 						)
-					VALUES( 185,
+					VALUES(		185,
 								240,
 								'Wait Stats',
 								'Wait Stats Have Been Cleared',
 								'https://BrentOzar.com/go/waits',
-								'Someone ran DBCC SQLPERF to clear sys.dm_os_wait_stats at approximately: ' + CONVERT(NVARCHAR(100), DATEADD(ms, (-1 * @MsSinceWaitsCleared), GETDATE()), 120))
-			END
+								'Someone ran DBCC SQLPERF to clear sys.dm_os_wait_stats at approximately: ' + CONVERT(NVARCHAR(100), DATEADD(ms, (-1 * @MsSinceWaitsCleared), GETDATE()), 120));
+			END;
 
 		/* @CpuMsSinceWaitsCleared is used for waits stats calculations */
+		
+		IF @Debug IN (1, 2) RAISERROR('Setting @CpuMsSinceWaitsCleared', 0, 1) WITH NOWAIT;
+		
 		SELECT @CpuMsSinceWaitsCleared = @MsSinceWaitsCleared * scheduler_count
 			FROM sys.dm_os_sys_info;
 
@@ -552,16 +564,19 @@ AS
 			SET @CheckUserDatabaseObjects = 0;
 			PRINT 'Running sp_Blitz @CheckUserDatabaseObjects = 1 on a server with 50+ databases may cause temporary insanity for the server and/or user.';
 			PRINT 'If you''re sure you want to do this, run again with the parameter @BringThePain = 1.';
-			END
+			END;
 
 		/* Sanitize our inputs */
 		SELECT
 			@OutputServerName = QUOTENAME(@OutputServerName),
 			@OutputDatabaseName = QUOTENAME(@OutputDatabaseName),
 			@OutputSchemaName = QUOTENAME(@OutputSchemaName),
-			@OutputTableName = QUOTENAME(@OutputTableName)
+			@OutputTableName = QUOTENAME(@OutputTableName);
 
 		/* Get the major and minor build numbers */
+		
+		IF @Debug IN (1, 2) RAISERROR('Getting version information.', 0, 1) WITH NOWAIT;
+		
 		SET @ProductVersion = CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128));
 		SELECT @ProductVersionMajor = SUBSTRING(@ProductVersion, 1,CHARINDEX('.', @ProductVersion) + 1 ),
 			@ProductVersionMinor = PARSENAME(CONVERT(varchar(32), @ProductVersion), 2);
@@ -598,6 +613,9 @@ AS
 						NOT find any problems, we don't save that. We're only
 						saving the problems, not the successful checks.
 						*/
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 1) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -642,7 +660,7 @@ AS
 						- Insert the results into #BlitzResults
 						*/
 
-					END
+					END;
 
 				/*
 				And that's the end of CheckID #1.
@@ -656,6 +674,9 @@ AS
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 2 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 2) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -690,7 +711,7 @@ AS
 																AND b.type = 'L'
 																AND b.backup_finish_date >= DATEADD(dd,
 																  -7, GETDATE()) ); 
-					END
+					END;
 
 
 				/*
@@ -707,6 +728,9 @@ AS
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 							BEGIN
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 8) WITH NOWAIT;
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 							(CheckID, Priority,
 							FindingsGroup,
@@ -717,10 +741,14 @@ AS
 					  ''Security'' AS FindingsGroup,
 					  ''Server Audits Running'' AS Finding,
 					  ''https://BrentOzar.com/go/audits'' AS URL,
-					  (''SQL Server built-in audit functionality is being used by server audit: '' + [name]) AS Details FROM sys.dm_server_audit_status  OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+					  (''SQL Server built-in audit functionality is being used by server audit: '' + [name]) AS Details FROM sys.dm_server_audit_status  OPTION (RECOMPILE);';
+								
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 				/*
 				But what if you need to run a query in every individual database?
@@ -742,6 +770,9 @@ AS
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 93 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 93) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -770,8 +801,8 @@ AS
 												UPPER(LEFT(mf.physical_name COLLATE SQL_Latin1_General_CP1_CI_AS, 3))
 										FROM    sys.master_files AS mf )
 										AND rh.destination_database_name IS NULL
-								GROUP BY UPPER(LEFT(bmf.physical_device_name, 3))
-					END
+								GROUP BY UPPER(LEFT(bmf.physical_device_name, 3));
+					END;
 
 
 					IF NOT EXISTS ( SELECT  1
@@ -781,6 +812,9 @@ AS
 									 FROM   sys.all_objects o
 									 WHERE  o.name = 'dm_database_encryption_keys' )
 						BEGIN
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 119) WITH NOWAIT;
+
 							SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, DatabaseName, URL, Details)
 								SELECT 119 AS CheckID,
 								1 AS Priority,
@@ -791,8 +825,12 @@ AS
 								''The certificate '' + c.name + '' is used to encrypt database '' + db_name(dek.database_id) + ''. Last backup date: '' + COALESCE(CAST(c.pvt_key_last_backup_date AS VARCHAR(100)), ''Never'') AS Details
 								FROM sys.certificates c INNER JOIN sys.dm_database_encryption_keys dek ON c.thumbprint = dek.encryptor_thumbprint
 								WHERE pvt_key_last_backup_date IS NULL OR pvt_key_last_backup_date <= DATEADD(dd, -30, GETDATE())  OPTION (RECOMPILE);';
+							
+							IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+							IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+							
 							EXECUTE(@StringToExecute);
-						END
+						END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -800,6 +838,9 @@ AS
 								WHERE   DatabaseName IS NULL AND CheckID = 3 )
 					BEGIN
 						IF DATEADD(dd, -60, GETDATE()) > (SELECT TOP 1 backup_start_date FROM msdb.dbo.backupset ORDER BY 1)
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 3) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -820,13 +861,16 @@ AS
 										  + CAST(bs.backup_start_date AS VARCHAR(20)) ) AS Details
 								FROM    msdb.dbo.backupset bs
 								ORDER BY backup_set_id ASC;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 186 )
 					BEGIN
 						IF DATEADD(dd, -2, GETDATE()) < (SELECT TOP 1 backup_start_date FROM msdb.dbo.backupset ORDER BY 1)
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 186) WITH NOWAIT;
+							
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  DatabaseName ,
@@ -847,7 +891,7 @@ AS
 											  + CAST(bs.backup_start_date AS VARCHAR(20)) ) AS Details
 									FROM    msdb.dbo.backupset bs
 									ORDER BY backup_set_id ASC;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -859,6 +903,9 @@ AS
 									AND DATEDIFF(SECOND, bs.backup_start_date, bs.backup_finish_date) <= 60 /* Backup took less than 60 seconds */
 									AND bs.backup_finish_date >= DATEADD(DAY, -14, GETDATE()) /* In the last 2 weeks */)
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 178) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -877,13 +924,16 @@ AS
 								WHERE bs.type = 'D'
 								AND bs.backup_size >= 50000000000 /* At least 50GB */
 								AND DATEDIFF(SECOND, bs.backup_start_date, bs.backup_finish_date) <= 60 /* Backup took less than 60 seconds */
-								AND bs.backup_finish_date >= DATEADD(DAY, -14, GETDATE()) /* In the last 2 weeks */
-					END
+								AND bs.backup_finish_date >= DATEADD(DAY, -14, GETDATE()); /* In the last 2 weeks */
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 4 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 4) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -905,12 +955,15 @@ AS
 										AND l.denylogin = 0
 										AND l.name NOT LIKE 'NT SERVICE\%'
 										AND l.name <> 'l_certSignSmDetach'; /* Added in SQL 2016 */
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 5 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 5) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -930,12 +983,15 @@ AS
 								WHERE   l.securityadmin = 1
 										AND l.name <> SUSER_SNAME(0x01)
 										AND l.denylogin = 0;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 104 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 104) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( [CheckID] ,
 								  [Priority] ,
@@ -958,13 +1014,16 @@ AS
 										WHERE   p.[state] IN ( 'G', 'W' )
 												AND p.[class] = 100
 												AND p.[type] = 'CL' )
-										AND pri.[name] NOT LIKE '##%##'
-					END
+										AND pri.[name] NOT LIKE '##%##';
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 6 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 6) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -984,7 +1043,7 @@ AS
 								FROM    msdb.dbo.sysjobs j
 								WHERE   j.enabled = 1
 										AND SUSER_SNAME(j.owner_sid) <> SUSER_SNAME(0x01);
-					END
+					END;
 
 
 				/* --TOURSTOP06-- */
@@ -993,6 +1052,9 @@ AS
 								WHERE   DatabaseName IS NULL AND CheckID = 7 )
 					BEGIN
 						/* --TOURSTOP02-- */
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 7) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -1013,7 +1075,7 @@ AS
 								FROM    master.INFORMATION_SCHEMA.ROUTINES r
 								WHERE   OBJECTPROPERTY(OBJECT_ID(ROUTINE_NAME),
 													   'ExecIsStartup') = 1;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -1023,6 +1085,9 @@ AS
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 10) WITH NOWAIT;
+								
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 							(CheckID,
 							Priority,
@@ -1035,10 +1100,14 @@ AS
 					  ''Performance'' AS FindingsGroup,
 					  ''Resource Governor Enabled'' AS Finding,
 					  ''https://BrentOzar.com/go/rg'' AS URL,
-					  (''Resource Governor is enabled.  Queries may be throttled.  Make sure you understand how the Classifier Function is configured.'') AS Details FROM sys.resource_governor_configuration WHERE is_enabled = 1 OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+					  (''Resource Governor is enabled.  Queries may be throttled.  Make sure you understand how the Classifier Function is configured.'') AS Details FROM sys.resource_governor_configuration WHERE is_enabled = 1 OPTION (RECOMPILE);';
+
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -1047,6 +1116,9 @@ AS
 					BEGIN
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 11) WITH NOWAIT;
+								
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 							(CheckID,
 							Priority,
@@ -1059,16 +1131,23 @@ AS
 					  ''Performance'' AS FindingsGroup,
 					  ''Server Triggers Enabled'' AS Finding,
 					  ''https://BrentOzar.com/go/logontriggers/'' AS URL,
-					  (''Server Trigger ['' + [name] ++ ''] is enabled.  Make sure you understand what that trigger is doing - the less work it does, the better.'') AS Details FROM sys.server_triggers WHERE is_disabled = 0 AND is_ms_shipped = 0  OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+					  (''Server Trigger ['' + [name] ++ ''] is enabled.  Make sure you understand what that trigger is doing - the less work it does, the better.'') AS Details FROM sys.server_triggers WHERE is_disabled = 0 AND is_ms_shipped = 0  OPTION (RECOMPILE);';
+
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 12 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 12) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1091,14 +1170,17 @@ AS
 										AND name NOT IN ( SELECT DISTINCT
 																  DatabaseName
 														  FROM    #SkipChecks 
-														  WHERE CheckID IS NULL OR CheckID = 12)
-					END
+														  WHERE CheckID IS NULL OR CheckID = 12);
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 13 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 13) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1122,7 +1204,7 @@ AS
 																  DatabaseName
 														  FROM    #SkipChecks 
 														  WHERE CheckID IS NULL OR CheckID = 13);
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -1131,6 +1213,9 @@ AS
 					BEGIN
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 14) WITH NOWAIT;
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 							(CheckID,
 							DatabaseName,
@@ -1149,16 +1234,23 @@ AS
 					  FROM sys.databases
 					  WHERE page_verify_option < 2
 					  AND name <> ''tempdb''
-					  and name not in (select distinct DatabaseName from #SkipChecks WHERE CheckID IS NULL OR CheckID = 14) OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+					  and name not in (select distinct DatabaseName from #SkipChecks WHERE CheckID IS NULL OR CheckID = 14) OPTION (RECOMPILE);';
+								
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 15 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 15) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1181,13 +1273,16 @@ AS
 										AND name NOT IN ( SELECT DISTINCT
 																  DatabaseName
 														  FROM    #SkipChecks 
-														  WHERE CheckID IS NULL OR CheckID = 15)
-					END
+														  WHERE CheckID IS NULL OR CheckID = 15);
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 16 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 16) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1210,14 +1305,17 @@ AS
 										AND name NOT IN ( SELECT DISTINCT
 																  DatabaseName
 														  FROM    #SkipChecks 
-														  WHERE CheckID IS NULL OR CheckID = 16)
-					END
+														  WHERE CheckID IS NULL OR CheckID = 16);
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 17 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 17) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1240,14 +1338,17 @@ AS
 										AND name NOT IN ( SELECT DISTINCT
 																  DatabaseName
 														  FROM    #SkipChecks 
-														  WHERE CheckID IS NULL OR CheckID = 17)
-					END
+														  WHERE CheckID IS NULL OR CheckID = 17);
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 18 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 18) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1269,14 +1370,17 @@ AS
 								WHERE   is_parameterization_forced = 1
 										AND name NOT IN ( SELECT  DatabaseName
 														  FROM    #SkipChecks 
-														  WHERE CheckID IS NULL OR CheckID = 18)
-					END
+														  WHERE CheckID IS NULL OR CheckID = 18);
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 20 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 20) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1299,8 +1403,8 @@ AS
 										AND name NOT IN ( SELECT DISTINCT
 																  DatabaseName
 														  FROM    #SkipChecks 
-														  WHERE CheckID IS NULL OR CheckID = 20)
-					END
+														  WHERE CheckID IS NULL OR CheckID = 20);
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -1311,6 +1415,9 @@ AS
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 21) WITH NOWAIT;
+								
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 							(CheckID,
 							DatabaseName,
@@ -1328,15 +1435,22 @@ AS
 					  (''Database ['' + [name] + ''] has Transparent Data Encryption enabled.  Make absolutely sure you have backed up the certificate and private key, or else you will not be able to restore this database.'') AS Details
 					  FROM sys.databases
 					  WHERE is_encrypted = 1
-					  and name not in (select distinct DatabaseName from #SkipChecks WHERE CheckID IS NULL OR CheckID = 21) OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+					  and name not in (select distinct DatabaseName from #SkipChecks WHERE CheckID IS NULL OR CheckID = 21) OPTION (RECOMPILE);';
+								
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 				/*
 				Believe it or not, SQL Server doesn't track the default values
 				for sp_configure options! We'll make our own list here.
 				*/
+
+				IF @Debug IN (1, 2) RAISERROR('Generating default configuration values', 0, 1) WITH NOWAIT;
+
 				INSERT  INTO #ConfigurationDefaults
 				VALUES  ( 'access check cache bucket count', 0, 1001 );
 				INSERT  INTO #ConfigurationDefaults
@@ -1434,7 +1548,7 @@ AS
 							SELECT  'min server memory (MB)' ,
 									CAST(value_in_use AS BIGINT), 1036
 							FROM    sys.configurations
-							WHERE   name = 'min server memory (MB)'
+							WHERE   name = 'min server memory (MB)';
 				ELSE
 					INSERT  INTO #ConfigurationDefaults
 					VALUES  ( 'min server memory (MB)', 0, 1036 );
@@ -1470,12 +1584,12 @@ AS
 					BEGIN
 						INSERT  INTO #ConfigurationDefaults
 						VALUES  ( 'remote login timeout (s)', 20, 1069 );
-					END
+					END;
 				ELSE
 					BEGIN
 						INSERT  INTO #ConfigurationDefaults
 						VALUES  ( 'remote login timeout (s)', 10, 1069 );
-					END
+					END;
 				INSERT  INTO #ConfigurationDefaults
 				VALUES  ( 'remote proc trans', 0, 1050 );
 				INSERT  INTO #ConfigurationDefaults
@@ -1514,6 +1628,9 @@ AS
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 22 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 22) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -1538,17 +1655,23 @@ AS
 										LEFT OUTER JOIN #ConfigurationDefaults cdUsed ON cdUsed.name = cr.name
 																  AND cdUsed.DefaultValue = cr.value_in_use
 								WHERE   cdUsed.name IS NULL;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 190 )
 					BEGIN
-						SELECT @MinServerMemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'min server memory (MB)'
-						SELECT @MaxServerMemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'max server memory (MB)'
+
+						IF @Debug IN (1, 2) RAISERROR('Setting @MinServerMemory and @MaxServerMemory', 0, 1) WITH NOWAIT;
+
+						SELECT @MinServerMemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'min server memory (MB)';
+						SELECT @MaxServerMemory = CAST(value_in_use as BIGINT) FROM sys.configurations WHERE name = 'max server memory (MB)';
 						
 						IF (@MinServerMemory = @MaxServerMemory)
 						BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 190) WITH NOWAIT;
+
 						INSERT INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -1564,9 +1687,9 @@ AS
 										'Non-Dynamic Memory',
 										'https://BrentOzar.com/go/memory',
 										'Minimum Server Memory setting is the same as the Maximum (both set to ' + CAST(@MinServerMemory AS NVARCHAR(50)) + '). This will not allow dynamic memory. Please revise memory settings'
-									)
-						END
-					END
+									);
+						END;
+					END;
 					
 					IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -1574,13 +1697,22 @@ AS
 					BEGIN
 
 						/* Let's set variables so that our query is still SARGable */
-						SET @Processors = (SELECT cpu_count FROM sys.dm_os_sys_info)
+						
+						IF @Debug IN (1, 2) RAISERROR('Setting @Processors.', 0, 1) WITH NOWAIT;
+						
+						SET @Processors = (SELECT cpu_count FROM sys.dm_os_sys_info);
+						
+						IF @Debug IN (1, 2) RAISERROR('Setting @NUMANodes', 0, 1) WITH NOWAIT;
+						
 						SET @NUMANodes = (SELECT COUNT(1)
 											FROM sys.dm_os_performance_counters pc
 											WHERE pc.object_name LIKE '%Buffer Node%'
-												AND counter_name = 'Page life expectancy')
+												AND counter_name = 'Page life expectancy');
 						/* If Cost Threshold for Parallelism is default then flag as a potential issue */
 						/* If MAXDOP is default and processors > 8 or NUMA nodes > 1 then flag as potential issue */
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 188) WITH NOWAIT;
+						
 						INSERT INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -1600,13 +1732,16 @@ AS
 											AND cr.value_in_use = cd.DefaultValue
 								WHERE   cr.name = 'cost threshold for parallelism'
 									OR (cr.name = 'max degree of parallelism' AND (@NUMANodes > 1 OR @Processors > 8));
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 24 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 24) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1629,13 +1764,16 @@ AS
 								WHERE   UPPER(LEFT(physical_name, 1)) = 'C'
 										AND DB_NAME(database_id) IN ( 'master',
 																  'model', 'msdb' );
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 25 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 25) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1659,13 +1797,16 @@ AS
 								FROM    sys.master_files
 								WHERE   UPPER(LEFT(physical_name, 1)) = 'C'
 										AND DB_NAME(database_id) = 'tempdb';
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 26 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 26) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1693,14 +1834,17 @@ AS
 										SELECT DISTINCT
 												DatabaseName
 										FROM    #SkipChecks
-										WHERE CheckID IS NULL OR CheckID = 26 )
-					END
+										WHERE CheckID IS NULL OR CheckID = 26 );
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 27 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 27) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1722,13 +1866,16 @@ AS
 										  + '. Tables in the master database may not be restored in the event of a disaster.' ) AS Details
 								FROM    master.sys.tables
 								WHERE   is_ms_shipped = 0;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 28 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 28) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1750,13 +1897,16 @@ AS
 										  + '. Tables in the msdb database may not be restored in the event of a disaster.' ) AS Details
 								FROM    msdb.sys.tables
 								WHERE   is_ms_shipped = 0 AND name NOT LIKE '%DTA_%';
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 29 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 29) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -1778,7 +1928,7 @@ AS
 										  + '. Tables in the model database are automatically copied into all new databases.' ) AS Details
 								FROM    model.sys.tables
 								WHERE   is_ms_shipped = 0;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -1789,6 +1939,9 @@ AS
 							 FROM   msdb.dbo.sysalerts
 							 WHERE  severity BETWEEN 19 AND 25
 						   ) < 7
+
+						   IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 30) WITH NOWAIT;
+
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -1803,7 +1956,7 @@ AS
 											'Not All Alerts Configured' AS Finding ,
 											'https://BrentOzar.com/go/alert' AS URL ,
 											( 'Not all SQL Server Agent alerts have been configured.  This is a free, easy way to get notified of corruption, job failures, or major outages even before monitoring systems pick it up.' ) AS Details;
-					END
+					END;
 
 
 
@@ -1816,6 +1969,9 @@ AS
 									WHERE   enabled = 1
 											AND COALESCE(has_notification, 0) = 0
 											AND (job_id IS NULL OR job_id = 0x))
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 59) WITH NOWAIT;
+
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -1830,7 +1986,7 @@ AS
 											'Alerts Configured without Follow Up' AS Finding ,
 											'https://BrentOzar.com/go/alert' AS URL ,
 											( 'SQL Server Agent alerts have been configured but they either do not notify anyone or else they do not take any action.  This is a free, easy way to get notified of corruption, job failures, or major outages even before monitoring systems pick it up.' ) AS Details;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -1839,6 +1995,9 @@ AS
 						IF NOT EXISTS ( SELECT  *
 										FROM    msdb.dbo.sysalerts
 										WHERE   message_id IN ( 823, 824, 825 ) )
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 96) WITH NOWAIT;
+							
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -1853,7 +2012,7 @@ AS
 											'No Alerts for Corruption' AS Finding ,
 											'https://BrentOzar.com/go/alert' AS URL ,
 											( 'SQL Server Agent alerts do not exist for errors 823, 824, and 825.  These three errors can give you notification about early hardware failure. Enabling them can prevent you a lot of heartbreak.' ) AS Details;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -1863,6 +2022,9 @@ AS
 						IF NOT EXISTS ( SELECT  *
 										FROM    msdb.dbo.sysalerts
 										WHERE   severity BETWEEN 19 AND 25 )
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 61) WITH NOWAIT;
+							
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -1877,7 +2039,7 @@ AS
 											'No Alerts for Sev 19-25' AS Finding ,
 											'https://BrentOzar.com/go/alert' AS URL ,
 											( 'SQL Server Agent alerts do not exist for severity levels 19 through 25.  These are some very severe SQL Server errors. Knowing that these are happening may let you recover from errors faster.' ) AS Details;
-					END
+					END;
 
 		--check for disabled alerts
 				IF NOT EXISTS ( SELECT  1
@@ -1887,6 +2049,9 @@ AS
 						IF EXISTS ( SELECT  name
 									FROM    msdb.dbo.sysalerts
 									WHERE   enabled = 0 )
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 98) WITH NOWAIT;
+							
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -1903,8 +2068,8 @@ AS
 											( 'The following Alert is disabled, please review and enable if desired: '
 											  + name ) AS Details
 									FROM    msdb.dbo.sysalerts
-									WHERE   enabled = 0
-					END
+									WHERE   enabled = 0;
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -1914,6 +2079,9 @@ AS
 						IF NOT EXISTS ( SELECT  *
 										FROM    msdb.dbo.sysoperators
 										WHERE   enabled = 1 )
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 31) WITH NOWAIT;
+							
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -1928,7 +2096,7 @@ AS
 											'No Operators Configured/Enabled' AS Finding ,
 											'https://BrentOzar.com/go/op' AS URL ,
 											( 'No SQL Server Agent operators (emails) have been configured.  This is a free, easy way to get notified of corruption, job failures, or major outages even before monitoring systems pick it up.' ) AS Details;
-					END
+					END;
 
 
 
@@ -1940,6 +2108,9 @@ AS
 									FROM    sys.all_objects
 									WHERE   name = 'dm_db_mirroring_auto_page_repair' )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 34) WITH NOWAIT;
+								
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 				(CheckID,
 				DatabaseName,
@@ -1964,10 +2135,14 @@ AS
 			WHERE db2.[state] = 1
 			) ) as rp 
 		  INNER JOIN master.sys.databases db ON rp.database_id = db.database_id
-		  WHERE   rp.modification_time >= DATEADD(dd, -30, GETDATE())  OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+		  WHERE   rp.modification_time >= DATEADD(dd, -30, GETDATE())  OPTION (RECOMPILE);';
+
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -1977,6 +2152,9 @@ AS
 									FROM    sys.all_objects
 									WHERE   name = 'dm_hadr_auto_page_repair' )
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 89) WITH NOWAIT;
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 				(CheckID,
 				DatabaseName,
@@ -1995,10 +2173,14 @@ AS
 		  ( ''AlwaysOn has automatically repaired at least one corrupt page in the last 30 days. For more information, query the DMV sys.dm_hadr_auto_page_repair.'' ) AS Details
 		  FROM    sys.dm_hadr_auto_page_repair rp
 		  INNER JOIN master.sys.databases db ON rp.database_id = db.database_id
-		  WHERE   rp.modification_time >= DATEADD(dd, -30, GETDATE()) OPTION (RECOMPILE) ;'
-								EXECUTE(@StringToExecute)
+		  WHERE   rp.modification_time >= DATEADD(dd, -30, GETDATE()) OPTION (RECOMPILE) ;';
+								
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
@@ -2009,6 +2191,9 @@ AS
 									FROM    msdb.sys.all_objects
 									WHERE   name = 'suspect_pages' )
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 90) WITH NOWAIT;
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 				(CheckID,
 				DatabaseName,
@@ -2027,16 +2212,23 @@ AS
 		  ( ''SQL Server has detected at least one corrupt page in the last 30 days. For more information, query the system table msdb.dbo.suspect_pages.'' ) AS Details
 		  FROM    msdb.dbo.suspect_pages sp
 		  INNER JOIN master.sys.databases db ON sp.database_id = db.database_id
-		  WHERE   sp.last_update_date >= DATEADD(dd, -30, GETDATE())  OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+		  WHERE   sp.last_update_date >= DATEADD(dd, -30, GETDATE())  OPTION (RECOMPILE);';
+
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 36 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 36) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2059,12 +2251,15 @@ AS
 																  AND fs.[file_id] = mf.[file_id]
 								WHERE   ( io_stall_read_ms / ( 1.0 + num_of_reads ) ) > 200
 								AND num_of_reads > 100000;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 37 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 37) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2088,7 +2283,7 @@ AS
 								WHERE   ( io_stall_write_ms / ( 1.0
 																+ num_of_writes ) ) > 100
 																AND num_of_writes > 100000;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -2099,6 +2294,9 @@ AS
 							 WHERE  type_desc = 'ROWS'
 						   ) = 1
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 40) WITH NOWAIT;
+
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  DatabaseName ,
@@ -2117,7 +2315,7 @@ AS
 										  'TempDB is only configured with one data file.  More data files are usually required to alleviate SGAM contention.'
 										);
 							END;
-					END
+					END;
 
 						IF ( SELECT COUNT (distinct [size])
 							FROM   tempdb.sys.database_files
@@ -2125,6 +2323,9 @@ AS
 							HAVING MAX((size * 8) / (1024. * 1024)) - MIN((size * 8) / (1024. * 1024)) > 1.
 							) <> 1
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 183) WITH NOWAIT;
+
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  DatabaseName ,
@@ -2148,6 +2349,9 @@ AS
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 44 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 44) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2165,13 +2369,16 @@ AS
 										+ ' instances of order hinting have been recorded since restart.  This means queries are bossing the SQL Server optimizer around, and if they don''t know what they''re doing, this can cause more harm than good.  This can also explain why DBA tuning efforts aren''t working.' AS Details
 								FROM    sys.dm_exec_query_optimizer_info
 								WHERE   counter = 'order hint'
-										AND occurrence > 1000
-					END
+										AND occurrence > 1000;
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 45 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 45) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2189,13 +2396,16 @@ AS
 										+ ' instances of join hinting have been recorded since restart.  This means queries are bossing the SQL Server optimizer around, and if they don''t know what they''re doing, this can cause more harm than good.  This can also explain why DBA tuning efforts aren''t working.' AS Details
 								FROM    sys.dm_exec_query_optimizer_info
 								WHERE   counter = 'join hint'
-										AND occurrence > 1000
-					END
+										AND occurrence > 1000;
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 49 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 49) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2218,8 +2428,8 @@ AS
 										 END AS Details
 								FROM    sys.servers s
 										INNER JOIN sys.linked_logins l ON s.server_id = l.server_id
-								WHERE   s.is_linked = 1
-					END
+								WHERE   s.is_linked = 1;
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -2228,6 +2438,9 @@ AS
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 50) WITH NOWAIT;
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 		  SELECT  50 AS CheckID ,
 		  100 AS Priority ,
@@ -2241,10 +2454,14 @@ AS
 			+ '' megabytes.  SQL Server may drain the system dry of memory, and under certain conditions, this can cause Windows to swap to disk.'' AS Details
 		  FROM    sys.dm_os_sys_memory m
 		  INNER JOIN sys.configurations c ON c.name = ''max server memory (MB)''
-		  WHERE   CAST(m.total_physical_memory_kb AS BIGINT) < ( CAST(c.value_in_use AS BIGINT) * 1024 ) OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+		  WHERE   CAST(m.total_physical_memory_kb AS BIGINT) < ( CAST(c.value_in_use AS BIGINT) * 1024 ) OPTION (RECOMPILE);';
+
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -2253,6 +2470,9 @@ AS
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 51) WITH NOWAIT
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 		  SELECT  51 AS CheckID ,
 		  1 AS Priority ,
@@ -2262,10 +2482,14 @@ AS
 		  ''The server has '' + CAST(( CAST(m.total_physical_memory_kb AS BIGINT) / 1024 ) AS VARCHAR(20)) + '' megabytes of physical memory, but only '' + CAST(( CAST(m.available_physical_memory_kb AS BIGINT) / 1024 ) AS VARCHAR(20))
 			+ '' megabytes are available.  As the server runs out of memory, there is danger of swapping to disk, which will kill performance.'' AS Details
 		  FROM    sys.dm_os_sys_memory m
-		  WHERE   CAST(m.available_physical_memory_kb AS BIGINT) < 262144 OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+		  WHERE   CAST(m.available_physical_memory_kb AS BIGINT) < 262144 OPTION (RECOMPILE);';
+
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
@@ -2274,6 +2498,9 @@ AS
 						IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 159) WITH NOWAIT;
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 		  SELECT DISTINCT 159 AS CheckID ,
 		  1 AS Priority ,
@@ -2282,15 +2509,22 @@ AS
 		  ''https://BrentOzar.com/go/max'' AS URL ,
 		  ''At least one NUMA node is reporting THREAD_RESOURCES_LOW in sys.dm_os_nodes and can no longer create threads.'' AS Details
 		  FROM    sys.dm_os_nodes m
-		  WHERE   node_state_desc LIKE ''%THREAD_RESOURCES_LOW%'' OPTION (RECOMPILE);'
-								EXECUTE(@StringToExecute)
+		  WHERE   node_state_desc LIKE ''%THREAD_RESOURCES_LOW%'' OPTION (RECOMPILE);';
+
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
+								EXECUTE(@StringToExecute);
 							END;
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 53 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 53) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2306,13 +2540,16 @@ AS
 										'Cluster Node' AS Finding ,
 										'https://BrentOzar.com/go/node' AS URL ,
 										'This is a node in a cluster.' AS Details
-								FROM    sys.dm_os_cluster_nodes
-					END
+								FROM    sys.dm_os_cluster_nodes;
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 55 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 55) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -2336,12 +2573,15 @@ AS
 																  DatabaseName
 														  FROM    #SkipChecks 
 														  WHERE CheckID IS NULL OR CheckID = 55);
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 57 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 57) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2362,7 +2602,7 @@ AS
 										JOIN msdb.dbo.sysjobs j ON jsched.job_id = j.job_id
 								WHERE   sched.freq_type = 64
 								        AND sched.enabled = 1;
-					END
+					END;
 
 
 
@@ -2370,6 +2610,9 @@ AS
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 97 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 97) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2390,13 +2633,16 @@ AS
 										AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Enterprise%'
 										AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Data Center%'
 										AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Developer%'
-										AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Business Intelligence%'
-					END
+										AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Business Intelligence%';
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 154 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 154) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2411,13 +2657,16 @@ AS
 										'32-bit SQL Server Installed' AS Finding ,
 										'https://BrentOzar.com/go/32bit' AS URL ,
 										( 'This server uses the 32-bit x86 binaries for SQL Server instead of the 64-bit x64 binaries. The amount of memory available for query workspace and execution plans is heavily limited.' ) AS Details
-								WHERE   CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%64%'
-					END
+								WHERE   CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%64%';
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 62 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 62) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -2442,13 +2691,16 @@ AS
 																DatabaseName
 													  FROM      #SkipChecks 
 													  WHERE CheckID IS NULL OR CheckID = 62)
-										AND compatibility_level <= 90
-					END
+										AND compatibility_level <= 90;
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 94 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 94) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2474,8 +2726,8 @@ AS
 										AND j.notify_email_operator_id = 0
 										AND j.notify_netsend_operator_id = 0
 										AND j.notify_page_operator_id = 0
-										AND j.category_id <> 100 /* Exclude SSRS category */
-					END
+										AND j.category_id <> 100; /* Exclude SSRS category */
+					END;
 
 
 				IF EXISTS ( SELECT  1
@@ -2486,6 +2738,9 @@ AS
 									 FROM   #SkipChecks
 									 WHERE  DatabaseName IS NULL AND CheckID = 100 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 100) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2499,8 +2754,8 @@ AS
 										'Reliability' AS FindingGroup ,
 										'Remote DAC Disabled' AS Finding ,
 										'https://BrentOzar.com/go/dac' AS URL ,
-										'Remote access to the Dedicated Admin Connection (DAC) is not enabled. The DAC can make remote troubleshooting much easier when SQL Server is unresponsive.'
-					END
+										'Remote access to the Dedicated Admin Connection (DAC) is not enabled. The DAC can make remote troubleshooting much easier when SQL Server is unresponsive.';
+					END;
 
 
 				IF EXISTS ( SELECT  *
@@ -2510,6 +2765,9 @@ AS
 									 FROM   #SkipChecks
 									 WHERE  DatabaseName IS NULL AND CheckID = 101 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 101) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -2523,8 +2781,8 @@ AS
 										'Performance' AS FindingGroup ,
 										'CPU Schedulers Offline' AS Finding ,
 										'https://BrentOzar.com/go/schedulers' AS URL ,
-										'Some CPU cores are not accessible to SQL Server due to affinity masking or licensing problems.'
-					END
+										'Some CPU cores are not accessible to SQL Server due to affinity masking or licensing problems.';
+					END;
 
 
 					IF NOT EXISTS ( SELECT  1
@@ -2532,6 +2790,9 @@ AS
 									WHERE   DatabaseName IS NULL AND CheckID = 110 )
 								AND EXISTS (SELECT * FROM master.sys.all_objects WHERE name = 'dm_os_memory_nodes')
 						BEGIN
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 110) WITH NOWAIT;
+
 							SET @StringToExecute = 'IF EXISTS (SELECT  *
 												FROM sys.dm_os_nodes n
 												INNER JOIN sys.dm_os_memory_nodes m ON n.memory_node_id = m.memory_node_id
@@ -2550,8 +2811,12 @@ AS
 																''Memory Nodes Offline'' AS Finding ,
 																''https://BrentOzar.com/go/schedulers'' AS URL ,
 																''Due to affinity masking or licensing problems, some of the memory may not be available.'' OPTION (RECOMPILE)';
+									
+									IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+									IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+									
 									EXECUTE(@StringToExecute);
-						END
+						END;
 
 
 				IF EXISTS ( SELECT  *
@@ -2561,6 +2826,9 @@ AS
 									 FROM   #SkipChecks
 									 WHERE  DatabaseName IS NULL AND CheckID = 102 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 102) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -2578,8 +2846,8 @@ AS
 										'https://BrentOzar.com/go/repair' AS URL ,
 										'This database may not be online.'
 								FROM    sys.databases
-								WHERE   state > 1
-					END
+								WHERE   state > 1;
+					END;
 
 				IF EXISTS ( SELECT  *
 							FROM    master.sys.extended_procedures )
@@ -2587,6 +2855,9 @@ AS
 									 FROM   #SkipChecks
 									 WHERE  DatabaseName IS NULL AND CheckID = 105 )
 					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 105) WITH NOWAIT;
+
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -2604,8 +2875,8 @@ AS
 										'https://BrentOzar.com/go/clr' AS URL ,
 										'The [' + name
 										+ '] extended stored procedure is in the master database. CLR may be in use, and the master database now needs to be part of your backup/recovery planning.'
-								FROM    master.sys.extended_procedures
-					END
+								FROM    master.sys.extended_procedures;
+					END;
 
 
 
@@ -2613,6 +2884,9 @@ AS
 										 FROM   #SkipChecks
 										 WHERE  DatabaseName IS NULL AND CheckID = 107 )
 						BEGIN
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 107) WITH NOWAIT;
+
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -2631,8 +2905,8 @@ AS
 									WHERE wait_type IN('IO_QUEUE_LIMIT', 'IO_RETRY', 'LOG_RATE_GOVERNOR', 'PREEMPTIVE_DEBUG', 'RESMGR_THROTTLED', 'RESOURCE_SEMAPHORE', 'RESOURCE_SEMAPHORE_QUERY_COMPILE','SE_REPL_CATCHUP_THROTTLE','SE_REPL_COMMIT_ACK','SE_REPL_COMMIT_TURN','SE_REPL_ROLLBACK_ACK','SE_REPL_SLOW_SECONDARY_THROTTLE','THREADPOOL')
 									GROUP BY wait_type
 								    HAVING SUM([wait_time_ms]) > (SELECT 5000 * datediff(HH,create_date,CURRENT_TIMESTAMP) AS hours_since_startup FROM sys.databases WHERE name='tempdb')
-									AND SUM([wait_time_ms]) > 60000
-						END
+									AND SUM([wait_time_ms]) > 60000;
+						END;
 
 
 
@@ -2640,6 +2914,9 @@ AS
 										 FROM   #SkipChecks
 										 WHERE  DatabaseName IS NULL AND CheckID = 121 )
 						BEGIN
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 121) WITH NOWAIT;
+
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -2657,8 +2934,8 @@ AS
 									FROM sys.[dm_os_wait_stats]
 									WHERE wait_type IN ('LCK_M_RS_S', 'LCK_M_RS_U', 'LCK_M_RIn_NL','LCK_M_RIn_S', 'LCK_M_RIn_U','LCK_M_RIn_X', 'LCK_M_RX_S', 'LCK_M_RX_U','LCK_M_RX_X')
 								    HAVING SUM([wait_time_ms]) > (SELECT 5000 * datediff(HH,create_date,CURRENT_TIMESTAMP) AS hours_since_startup FROM sys.databases WHERE name='tempdb')
-									AND SUM([wait_time_ms]) > 60000
-						END
+									AND SUM([wait_time_ms]) > 60000;
+						END;
 
 
 
@@ -2667,6 +2944,9 @@ AS
 										 FROM   #SkipChecks
 										 WHERE  DatabaseName IS NULL AND CheckID = 162 )
 						BEGIN
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 162) WITH NOWAIT;
+
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -2687,7 +2967,7 @@ AS
 									GROUP BY w.wait_type
 								    HAVING SUM([wait_time_ms]) > (SELECT 5000 * datediff(HH,create_date,CURRENT_TIMESTAMP) AS hours_since_startup FROM sys.databases WHERE name='tempdb')
 									AND SUM([wait_time_ms]) > 60000;
-						END
+						END;
 
 
 
@@ -2696,6 +2976,9 @@ AS
 										 FROM   #SkipChecks
 										 WHERE  DatabaseName IS NULL AND CheckID = 111 )
 						BEGIN
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 111) WITH NOWAIT;
+
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -2720,9 +3003,9 @@ AS
 											AND NOT EXISTS(SELECT * FROM msdb.dbo.restorehistory rh
 											INNER JOIN msdb.dbo.backupset bs ON rh.backup_set_id = bs.backup_set_id
 											WHERE d.[name] COLLATE SQL_Latin1_General_CP1_CI_AS = rh.destination_database_name COLLATE SQL_Latin1_General_CP1_CI_AS
-											AND rh.restore_date >= DATEADD(dd, -2, GETDATE()))
+											AND rh.restore_date >= DATEADD(dd, -2, GETDATE()));
 
-						END
+						END;
 
 
 						IF NOT EXISTS ( SELECT  1
@@ -2730,6 +3013,9 @@ AS
 										WHERE   DatabaseName IS NULL AND CheckID = 112 )
 									AND EXISTS (SELECT * FROM master.sys.all_objects WHERE name = 'change_tracking_databases')
 							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 112) WITH NOWAIT;
+
 								SET @StringToExecute = 'INSERT INTO #BlitzResults
 									(CheckID,
 									Priority,
@@ -2743,8 +3029,12 @@ AS
 							  ''Change Tracking Enabled'' AS Finding,
 							  ''https://BrentOzar.com/go/tracking'' AS URL,
 							  ( d.[name] + '' has change tracking enabled. This is not a default setting, and it has some performance overhead. It keeps track of changes to rows in tables that have change tracking turned on.'' ) AS Details FROM sys.change_tracking_databases AS ctd INNER JOIN sys.databases AS d ON ctd.database_id = d.database_id OPTION (RECOMPILE)';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+										
 										EXECUTE(@StringToExecute);
-							END
+							END;
 
 
 						IF NOT EXISTS ( SELECT 1
@@ -2752,6 +3042,9 @@ AS
 										 WHERE  DatabaseName IS NULL AND CheckID = 116 )
 									AND EXISTS (SELECT * FROM msdb.sys.all_columns WHERE name = 'compressed_backup_size')
 						BEGIN
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 116) WITH NOWAIT
+
 							SET @StringToExecute = 'INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -2768,15 +3061,22 @@ AS
 											''Uncompressed full backups have happened recently, and backup compression is not turned on at the server level. Backup compression is included with SQL Server 2008R2 & newer, even in Standard Edition. We recommend turning backup compression on by default so that ad-hoc backups will get compressed.''
 											FROM sys.configurations
 											WHERE configuration_id = 1579 AND CAST(value_in_use AS INT) = 0
-                                            AND EXISTS (SELECT * FROM msdb.dbo.backupset WHERE backup_size = compressed_backup_size AND type = ''D'' AND backup_finish_date >= DATEADD(DD, -14, GETDATE())) OPTION (RECOMPILE);'
+                                            AND EXISTS (SELECT * FROM msdb.dbo.backupset WHERE backup_size = compressed_backup_size AND type = ''D'' AND backup_finish_date >= DATEADD(DD, -14, GETDATE())) OPTION (RECOMPILE);';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+										
 										EXECUTE(@StringToExecute);
-						END
+						END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 117 )
 									AND EXISTS (SELECT * FROM master.sys.all_objects WHERE name = 'dm_exec_query_resource_semaphores')
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 117) WITH NOWAIT;
+								
 								SET @StringToExecute = 'IF 0 < (SELECT SUM([forced_grant_count]) FROM sys.dm_exec_query_resource_semaphores WHERE [forced_grant_count] IS NOT NULL)
 								INSERT INTO #BlitzResults
 									(CheckID,
@@ -2791,9 +3091,13 @@ AS
 							  ''Memory Pressure Affecting Queries'' AS Finding,
 							  ''https://BrentOzar.com/go/grants'' AS URL,
 							  CAST(SUM(forced_grant_count) AS NVARCHAR(100)) + '' forced grants reported in the DMV sys.dm_exec_query_resource_semaphores, indicating memory pressure has affected query runtimes.''
-							  FROM sys.dm_exec_query_resource_semaphores WHERE [forced_grant_count] IS NOT NULL OPTION (RECOMPILE);'
+							  FROM sys.dm_exec_query_resource_semaphores WHERE [forced_grant_count] IS NOT NULL OPTION (RECOMPILE);';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+										
 										EXECUTE(@StringToExecute);
-							END
+							END;
 
 
 
@@ -2801,6 +3105,9 @@ AS
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 124 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 124) WITH NOWAIT;
+								
 								INSERT INTO #BlitzResults
 									(CheckID,
 									Priority,
@@ -2816,11 +3123,14 @@ AS
 									AND RTRIM(p.instance_name) = '_Total'
 									AND p.cntr_value > 0
 									AND (1.0 * p.cntr_value / NULLIF(datediff(DD,create_date,CURRENT_TIMESTAMP),0)) > 10;
-							END
+							END;
 
 
 						IF DATEADD(mi, -15, GETDATE()) < (SELECT TOP 1 creation_time FROM sys.dm_exec_query_stats ORDER BY creation_time)
 						BEGIN
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 125) WITH NOWAIT;
+							
 							INSERT INTO #BlitzResults
 								(CheckID,
 								Priority,
@@ -2831,11 +3141,14 @@ AS
 							SELECT TOP 1 125, 10, 'Performance', 'Plan Cache Erased Recently', 'https://BrentOzar.com/askbrent/plan-cache-erased-recently/',
 								'The oldest query in the plan cache was created at ' + CAST(creation_time AS NVARCHAR(50)) + '. Someone ran DBCC FREEPROCCACHE, restarted SQL Server, or it is under horrific memory pressure.'
 							FROM sys.dm_exec_query_stats WITH (NOLOCK)
-							ORDER BY creation_time	
+							ORDER BY creation_time;	
 						END;
 
 						IF EXISTS (SELECT * FROM sys.configurations WHERE name = 'priority boost' AND (value = 1 OR value_in_use = 1))
 						BEGIN
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 126) WITH NOWAIT;
+							
 							INSERT INTO #BlitzResults
 								(CheckID,
 								Priority,
@@ -2844,7 +3157,7 @@ AS
 								URL,
 								Details)
 							VALUES(126, 5, 'Reliability', 'Priority Boost Enabled', 'https://BrentOzar.com/go/priorityboost/',
-								'Priority Boost sounds awesome, but it can actually cause your SQL Server to crash.')
+								'Priority Boost sounds awesome, but it can actually cause your SQL Server to crash.');
 						END;
 
 						IF NOT EXISTS ( SELECT  1
@@ -2858,6 +3171,9 @@ AS
 							   (@ProductVersionMajor = 10 AND @ProductVersionMinor < 6000) OR
 							   (@ProductVersionMajor = 9 /*AND @ProductVersionMinor <= 5000*/)
 								BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 128) WITH NOWAIT;
+								
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(128, 20, 'Reliability', 'Unsupported Build of SQL Server', 'https://BrentOzar.com/go/unsupported',
 										'Version ' + CAST(@ProductVersionMajor AS VARCHAR(100)) + '.' + 
@@ -2877,6 +3193,9 @@ AS
 							   (@ProductVersionMajor = 11 AND @ProductVersionMinor = 5058) OR
 							   (@ProductVersionMajor = 12 AND @ProductVersionMinor >= 2000 AND @ProductVersionMinor <= 2342)
 								BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 129) WITH NOWAIT;
+								
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(129, 20, 'Reliability', 'Dangerous Build of SQL Server (Corruption)', 'http://sqlperformance.com/2014/06/sql-indexes/hotfix-sql-2012-rebuilds',
 										'There are dangerous known bugs with version ' + CAST(@ProductVersionMajor AS VARCHAR(100)) + '.' + CAST(@ProductVersionMinor AS VARCHAR(100)) + '. Check the URL for details and apply the right service pack or hotfix.');
@@ -2898,6 +3217,9 @@ AS
 							   (@ProductVersionMajor = 12 AND @ProductVersionMinor >= 2000 AND @ProductVersionMinor <= 2253) OR
 							   (@ProductVersionMajor = 12 AND @ProductVersionMinor >= 2300 AND @ProductVersionMinor <= 2370)
 								BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 157) WITH NOWAIT;
+								
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(157, 20, 'Reliability', 'Dangerous Build of SQL Server (Security)', 'https://technet.microsoft.com/en-us/library/security/MS14-044',
 										'There are dangerous known bugs with version ' + CAST(@ProductVersionMajor AS VARCHAR(100)) + '.' + CAST(@ProductVersionMinor AS VARCHAR(100)) + '. Check the URL for details and apply the right service pack or hotfix.');
@@ -2912,6 +3234,9 @@ AS
 							BEGIN
 							IF (@ProductVersionMajor = 13 AND @ProductVersionMinor < 4001 AND @@VERSION LIKE '%Standard Edition%') 
 								BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 189) WITH NOWAIT;
+								
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(189, 100, 'Features', 'Missing Features', 'https://blogs.msdn.microsoft.com/sqlreleaseservices/sql-server-2016-service-pack-1-sp1-released/',
 										'SQL 2016 Standard Edition is being used but not Service Pack 1. Check the URL for a list of Enterprise Features that are included in Standard Edition as of SP1.');
@@ -2927,7 +3252,10 @@ AS
 					                        FROM   sys.all_objects o
 					                        WHERE  o.name = 'dm_db_xtp_table_memory_stats' )
 	                        BEGIN
-		                        SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 145) WITH NOWAIT;
+								
+								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			                        SELECT 145 AS CheckID,
 			                        10 AS Priority,
 			                        ''Performance'' AS FindingsGroup,
@@ -2939,8 +3267,12 @@ AS
                                     GROUP BY c.value_in_use
                                     HAVING CAST(value_in_use AS DECIMAL(38,2)) * .25 < SUM(mem.pages_kb / 1024.0)
                                       OR SUM(mem.pages_kb / 1024.0) > 250000 OPTION (RECOMPILE)';
-		                        EXECUTE(@StringToExecute);
-	                        END
+		                        
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
+	                        END;
 
 
                         /* Performance - In-Memory OLTP (Hekaton) In Use */
@@ -2951,7 +3283,10 @@ AS
 					                        FROM   sys.all_objects o
 					                        WHERE  o.name = 'dm_db_xtp_table_memory_stats' )
 	                        BEGIN
-		                        SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 146) WITH NOWAIT;
+								
+								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			                        SELECT 146 AS CheckID,
 			                        200 AS Priority,
 			                        ''Performance'' AS FindingsGroup,
@@ -2962,8 +3297,12 @@ AS
                                     WHERE c.name = ''max server memory (MB)''
                                     GROUP BY c.value_in_use
                                     HAVING SUM(mem.pages_kb / 1024.0) > 10 OPTION (RECOMPILE)';
-		                        EXECUTE(@StringToExecute);
-	                        END
+		                        
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
+	                        END;
 
                         /* In-Memory OLTP (Hekaton) - Transaction Errors */
                         IF NOT EXISTS ( SELECT  1
@@ -2973,7 +3312,10 @@ AS
 					                        FROM   sys.all_objects o
 					                        WHERE  o.name = 'dm_xtp_transaction_stats' )
 	                        BEGIN
-		                        SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 147) WITH NOWAIT
+								
+								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			                        SELECT 147 AS CheckID,
 			                        100 AS Priority,
 			                        ''In-Memory OLTP (Hekaton)'' AS FindingsGroup,
@@ -2984,9 +3326,13 @@ AS
                                     WHERE validation_failures <> 0
                                             OR dependencies_failed <> 0
                                             OR write_conflicts <> 0
-                                            OR unique_constraint_violations <> 0 OPTION (RECOMPILE);'
-		                        EXECUTE(@StringToExecute);
-	                        END
+                                            OR unique_constraint_violations <> 0 OPTION (RECOMPILE);';
+		                        
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
+	                        END;
 
 
 
@@ -2995,7 +3341,10 @@ AS
 				                        FROM    #SkipChecks
 				                        WHERE   DatabaseName IS NULL AND CheckID = 148 )
 	                        BEGIN
-		                        INSERT  INTO #BlitzResults
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 148) WITH NOWAIT;
+								
+								INSERT  INTO #BlitzResults
 				                        ( CheckID ,
 					                        DatabaseName ,
 					                        Priority ,
@@ -3017,15 +3366,18 @@ AS
 						                        AND d.name NOT IN ( SELECT DISTINCT
 													                        DatabaseName
 											                        FROM    #SkipChecks 
-																	WHERE CheckID IS NULL OR CheckID = 148)
-	                        END
+																	WHERE CheckID IS NULL OR CheckID = 148);
+	                        END;
 
                         /* Reliability - Database Files Stored in Azure */
                         IF NOT EXISTS ( SELECT  1
 				                        FROM    #SkipChecks
 				                        WHERE   DatabaseName IS NULL AND CheckID = 149 )
 	                        BEGIN
-		                        INSERT  INTO #BlitzResults
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 149) WITH NOWAIT;
+								
+								INSERT  INTO #BlitzResults
 				                        ( CheckID ,
 					                        DatabaseName ,
 					                        Priority ,
@@ -3047,8 +3399,8 @@ AS
 						                        AND d.name NOT IN ( SELECT DISTINCT
 													                        DatabaseName
 											                        FROM    #SkipChecks 
-																	WHERE CheckID IS NULL OR CheckID = 149)
-	                        END
+																	WHERE CheckID IS NULL OR CheckID = 149);
+	                        END;
 
 
                         /* Reliability - Errors Logged Recently in the Default Trace */
@@ -3058,7 +3410,9 @@ AS
                             AND @base_tracefilename IS NOT NULL
 	                        BEGIN
 
-		                        INSERT  INTO #BlitzResults
+		                        IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 150) WITH NOWAIT;
+								
+								INSERT  INTO #BlitzResults
 				                        ( CheckID ,
 					                        DatabaseName ,
 					                        Priority ,
@@ -3077,8 +3431,8 @@ AS
                                         FROM    sys.fn_trace_gettable(@base_tracefilename, DEFAULT) t
                                         WHERE t.EventClass = 22
                                           AND t.Severity >= 17
-                                          AND t.StartTime > DATEADD(dd, -30, GETDATE())
-	                        END
+                                          AND t.StartTime > DATEADD(dd, -30, GETDATE());
+	                        END;
 
 
                         /* Performance - File Growths Slow */
@@ -3087,7 +3441,10 @@ AS
 				                        WHERE   DatabaseName IS NULL AND CheckID = 151 )
                             AND @base_tracefilename IS NOT NULL
 	                        BEGIN
-		                        INSERT  INTO #BlitzResults
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 151) WITH NOWAIT;
+								
+								INSERT  INTO #BlitzResults
 				                        ( CheckID ,
 					                        DatabaseName ,
 					                        Priority ,
@@ -3108,8 +3465,8 @@ AS
                                           AND t.StartTime > DATEADD(dd, -30, GETDATE())
                                           AND t.Duration > 15000000
                                         GROUP BY t.DatabaseName
-                                        HAVING COUNT(*) > 1
-	                        END
+                                        HAVING COUNT(*) > 1;
+	                        END;
 
 
                         /* Performance - Many Plans for One Query */
@@ -3118,7 +3475,10 @@ AS
 				                        WHERE   DatabaseName IS NULL AND CheckID = 160 )
                             AND EXISTS (SELECT * FROM sys.all_columns WHERE name = 'query_hash')
 	                        BEGIN
-		                        SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 160) WITH NOWAIT;
+								
+								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			                        SELECT TOP 1 160 AS CheckID,
 			                        100 AS Priority,
 			                        ''Performance'' AS FindingsGroup,
@@ -3131,8 +3491,12 @@ AS
                                     GROUP BY qs.query_hash, pa.value
                                     HAVING COUNT(DISTINCT plan_handle) > 50
 									ORDER BY COUNT(DISTINCT plan_handle) DESC OPTION (RECOMPILE);';
-		                        EXECUTE(@StringToExecute);
-	                        END
+		                        
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
+	                        END;
 
 
                         /* Performance - High Number of Cached Plans */
@@ -3140,7 +3504,10 @@ AS
 				                        FROM    #SkipChecks
 				                        WHERE   DatabaseName IS NULL AND CheckID = 161 )
 	                        BEGIN
-		                        SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 161) WITH NOWAIT;
+								
+								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			                        SELECT TOP 1 161 AS CheckID,
 			                        100 AS Priority,
 			                        ''Performance'' AS FindingsGroup,
@@ -3151,8 +3518,12 @@ AS
 			                        INNER JOIN sys.dm_os_memory_cache_counters cc ON ht.name = cc.name AND ht.type = cc.type
 			                        where ht.name IN ( ''SQL Plans'' , ''Object Plans'' , ''Bound Trees'' )
 			                        AND cc.entries_count >= (3 * ht.buckets_count) OPTION (RECOMPILE)';
-		                        EXECUTE(@StringToExecute);
-	                        END
+		                        
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
+	                        END;
 
 
 						/* Performance - Too Much Free Memory */
@@ -3160,6 +3531,9 @@ AS
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 165 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 165) WITH NOWAIT;
+								
 								INSERT INTO #BlitzResults
 									(CheckID,
 									Priority,
@@ -3176,9 +3550,9 @@ AS
 									AND cFree.counter_name = N'Free Memory (KB)                                                                                                                '
 									AND CAST(cTotal.cntr_value AS BIGINT) > 20480000000
 									AND CAST(cTotal.cntr_value AS BIGINT) * .3 <= CAST(cFree.cntr_value AS BIGINT)
-                                    AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Standard%'
+                                    AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Standard%';
 
-							END
+							END;
 
 
                         /* Outdated sp_Blitz - sp_Blitz is Over 6 Months Old */
@@ -3187,7 +3561,10 @@ AS
 				                        WHERE   DatabaseName IS NULL AND CheckID = 155 )
 				           AND DATEDIFF(MM, @VersionDate, GETDATE()) > 6
 	                        BEGIN
-		                        INSERT  INTO #BlitzResults
+		                        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 155) WITH NOWAIT;
+								
+								INSERT  INTO #BlitzResults
 				                        ( CheckID ,
 					                        Priority ,
 					                        FindingsGroup ,
@@ -3200,14 +3577,17 @@ AS
 						                        'Outdated sp_Blitz' AS FindingsGroup ,
 						                        'sp_Blitz is Over 6 Months Old' AS Finding ,
 						                        'http://FirstResponderKit.org/' AS URL ,
-						                        'Some things get better with age, like fine wine and your T-SQL. However, sp_Blitz is not one of those things - time to go download the current one.' AS Details
-	                        END
+						                        'Some things get better with age, like fine wine and your T-SQL. However, sp_Blitz is not one of those things - time to go download the current one.' AS Details;
+	                        END;
 
 
 						/* Populate a list of database defaults. I'm doing this kind of oddly -
 						    it reads like a lot of work, but this way it compiles & runs on all
 						    versions of SQL Server.
 						*/
+						
+						IF @Debug IN (1, 2) RAISERROR('Generating database defaults.', 0, 1) WITH NOWAIT;
+						
 						INSERT INTO #DatabaseDefaults
 						  SELECT 'is_supplemental_logging_enabled', 0, 131, 210, 'Supplemental Logging Enabled', 'https://BrentOzar.com/go/dbdefaults', NULL
 						  FROM sys.all_columns 
@@ -3269,12 +3649,14 @@ AS
 
 						DECLARE DatabaseDefaultsLoop CURSOR FOR
 						  SELECT name, DefaultValue, CheckID, Priority, Finding, URL, Details
-						  FROM #DatabaseDefaults
+						  FROM #DatabaseDefaults;
 
-						OPEN DatabaseDefaultsLoop
-						FETCH NEXT FROM DatabaseDefaultsLoop into @CurrentName, @CurrentDefaultValue, @CurrentCheckID, @CurrentPriority, @CurrentFinding, @CurrentURL, @CurrentDetails
+						OPEN DatabaseDefaultsLoop;
+						FETCH NEXT FROM DatabaseDefaultsLoop into @CurrentName, @CurrentDefaultValue, @CurrentCheckID, @CurrentPriority, @CurrentFinding, @CurrentURL, @CurrentDetails;
 						WHILE @@FETCH_STATUS = 0
 						BEGIN 
+
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, @CurrentCheckID) WITH NOWAIT;
 
 							/* Target Recovery Time (142) can be either 0 or 60 due to a number of bugs */
 						    IF @CurrentCheckID = 142
@@ -3287,12 +3669,16 @@ AS
 								   SELECT ' + CAST(@CurrentCheckID AS NVARCHAR(200)) + ', d.[name], ' + CAST(@CurrentPriority AS NVARCHAR(200)) + ', ''Non-Default Database Config'', ''' + @CurrentFinding + ''',''' + @CurrentURL + ''',''' + COALESCE(@CurrentDetails, 'This database setting is not the default.') + '''
 									FROM sys.databases d
 									WHERE d.database_id > 4 AND (d.[' + @CurrentName + '] <> ' + @CurrentDefaultValue + ' OR d.[' + @CurrentName + '] IS NULL) OPTION (RECOMPILE);';
-						    EXEC (@StringToExecute);
+						    
+							IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+							IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+							
+							EXEC (@StringToExecute);
 
-						FETCH NEXT FROM DatabaseDefaultsLoop into @CurrentName, @CurrentDefaultValue, @CurrentCheckID, @CurrentPriority, @CurrentFinding, @CurrentURL, @CurrentDetails 
-						END
+						FETCH NEXT FROM DatabaseDefaultsLoop into @CurrentName, @CurrentDefaultValue, @CurrentCheckID, @CurrentPriority, @CurrentFinding, @CurrentURL, @CurrentDetails; 
+						END;
 
-						CLOSE DatabaseDefaultsLoop
+						CLOSE DatabaseDefaultsLoop;
 						DEALLOCATE DatabaseDefaultsLoop;
 							
 
@@ -3306,6 +3692,9 @@ IF @ProductVersionMajor >= 10
 											FROM    sys.all_objects
 											WHERE   name = 'dm_server_services' )
 									BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 167) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3326,7 +3715,7 @@ IF @ProductVersionMajor >= 10
 							[sys].[dm_server_services]
 						  WHERE [status_desc] <> 'Running'
 						  AND [servicename] LIKE 'SQL Server Agent%'
-						  AND CAST(SERVERPROPERTY('Edition') AS VARCHAR(1000)) NOT LIKE '%xpress%'
+						  AND CAST(SERVERPROPERTY('Edition') AS VARCHAR(1000)) NOT LIKE '%xpress%';
 
 					END; 
 				END;
@@ -3341,6 +3730,9 @@ IF @ProductVersionMajor >= 10
 											FROM    sys.all_objects
 											WHERE   name = 'dm_server_services' )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 168) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3360,7 +3752,7 @@ IF @ProductVersionMajor >= 10
 						  FROM
 							[sys].[dm_server_services]
 						  WHERE [status_desc] <> 'Running'
-						  AND [servicename] LIKE 'SQL Full-text Filter Daemon Launcher%'
+						  AND [servicename] LIKE 'SQL Full-text Filter Daemon Launcher%';
 
 					END;
 					END; 
@@ -3376,6 +3768,9 @@ IF @ProductVersionMajor >= 10
 											FROM    sys.all_objects
 											WHERE   name = 'dm_server_services' )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 169) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3396,7 +3791,7 @@ IF @ProductVersionMajor >= 10
 							[sys].[dm_server_services]
 						  WHERE [service_account] LIKE 'NT Service%'
 						  AND [servicename] LIKE 'SQL Server%'
-						  AND [servicename] NOT LIKE 'SQL Server Agent%'
+						  AND [servicename] NOT LIKE 'SQL Server Agent%';
 
 					END;
 					END;
@@ -3412,6 +3807,9 @@ IF @ProductVersionMajor >= 10
 											FROM    sys.all_objects
 											WHERE   name = 'dm_server_services' )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 170) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3431,7 +3829,7 @@ IF @ProductVersionMajor >= 10
 						  FROM
 							[sys].[dm_server_services]
 						  WHERE [service_account] LIKE 'NT Service%'
-						  AND [servicename] LIKE 'SQL Server Agent%'
+						  AND [servicename] LIKE 'SQL Server Agent%';
 
 					END; 
 					END;
@@ -3448,6 +3846,9 @@ IF @ProductVersionMajor >= 10
 											WHERE   name = 'dm_server_memory_dumps' )
 					BEGIN
 						IF 5 <= (SELECT COUNT(*) FROM [sys].[dm_server_memory_dumps] WHERE [creation_time] >= DATEADD(year, -1, GETDATE()))
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 171) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3481,6 +3882,9 @@ IF @ProductVersionMajor >= 10
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 173 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 173) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3500,9 +3904,9 @@ IF @ProductVersionMajor >= 10
 							' the good folks at Microsoft might get upset with you. Better start counting those cores.'
 							   ) AS [Details]
 							WHERE CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) LIKE '%Developer%'
-							OR CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) LIKE '%Evaluation%'
+							OR CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) LIKE '%Evaluation%';
 
-					END
+					END;
 
 /*Checks to see if Buffer Pool Extensions are in use*/
 			IF @ProductVersionMajor >= 12  
@@ -3510,6 +3914,9 @@ IF @ProductVersionMajor >= 10
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 174 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 174) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3536,15 +3943,18 @@ IF @ProductVersionMajor >= 10
 								'. Did you know that BPEs only provide single threaded access 8KB (one page) at a time?'	
 							   ) AS [Details]
 							 FROM sys.dm_os_buffer_pool_extension_configuration
-							 WHERE [state_description] <> 'BUFFER POOL EXTENSION DISABLED'
+							 WHERE [state_description] <> 'BUFFER POOL EXTENSION DISABLED';
 
-					END
+					END;
 
 /*Check for too many tempdb files*/
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 175 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 175) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -3565,7 +3975,7 @@ IF @ProductVersionMajor >= 10
 								  FROM sys.[master_files] AS [mf] 
 								  WHERE [mf].[database_id] = 2 AND [mf].[type] = 0
 								  HAVING COUNT_BIG(*) > 16; 
-					END	
+					END;	
 
 			IF NOT EXISTS ( SELECT  1
 											FROM    #SkipChecks
@@ -3575,6 +3985,9 @@ IF @ProductVersionMajor >= 10
 														WHERE   name = 'dm_xe_sessions' )
 								BEGIN
 								BEGIN
+									
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 176) WITH NOWAIT;
+									
 									INSERT  INTO #BlitzResults
 											( CheckID ,
 											  DatabaseName ,
@@ -3597,8 +4010,8 @@ IF @ProductVersionMajor >= 10
 												('system_health', 'sp_server_diagnostics session', 'hkenginexesession', 'telemetry_xevents')
 												AND name NOT LIKE '%$A%'
 											  HAVING COUNT_BIG(*) >= 2; 
-								END	
-								END
+								END;	
+								END;
 			
 			/*Harmful startup parameter*/
 			IF NOT EXISTS ( SELECT  1
@@ -3610,6 +4023,9 @@ IF @ProductVersionMajor >= 10
 														WHERE   name = 'dm_server_registry' )
 			
 								BEGIN
+									
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 177) WITH NOWAIT;
+									
 									INSERT  INTO #BlitzResults
 											( CheckID ,
 											  DatabaseName ,
@@ -3632,8 +4048,8 @@ IF @ProductVersionMajor >= 10
 													WHERE
 													[dsr].[registry_key] LIKE N'%MSSQLServer\Parameters'
 													AND [dsr].[value_data] = '-x';; 
-								END		
-								END
+								END;		
+								END;
 			
 			
 			/* Reliability - Dangerous Third Party Modules - 179 */
@@ -3641,6 +4057,9 @@ IF @ProductVersionMajor >= 10
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 179 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 179) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3660,9 +4079,9 @@ IF @ProductVersionMajor >= 10
 							WHERE UPPER(name) LIKE UPPER('%\ENTAPI.DLL') /* McAfee VirusScan Enterprise */
 							OR UPPER(name) LIKE UPPER('%\HIPI.DLL') OR UPPER(name) LIKE UPPER('%\HcSQL.dll') OR UPPER(name) LIKE UPPER('%\HcApi.dll') OR UPPER(name) LIKE UPPER('%\HcThe.dll') /* McAfee Host Intrusion */
 							OR UPPER(name) LIKE UPPER('%\SOPHOS_DETOURED.DLL') OR UPPER(name) LIKE UPPER('%\SOPHOS_DETOURED_x64.DLL') OR UPPER(name) LIKE UPPER('%\SWI_IFSLSP_64.dll') /* Sophos AV */
-							OR UPPER(name) LIKE UPPER('%\PIOLEDB.DLL') OR UPPER(name) LIKE UPPER('%\PISDK.DLL') /* OSISoft PI data access */
+							OR UPPER(name) LIKE UPPER('%\PIOLEDB.DLL') OR UPPER(name) LIKE UPPER('%\PISDK.DLL'); /* OSISoft PI data access */
 
-					END
+					END;
 
 			/*Find shrink database tasks*/
 
@@ -3671,7 +4090,9 @@ IF @ProductVersionMajor >= 10
 											WHERE   DatabaseName IS NULL AND CheckID = 180 )
 							AND CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) LIKE '1%' /* Only run on 2008+ */
 					BEGIN
-						;
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 180) WITH NOWAIT;
+					
 						WITH XMLNAMESPACES ('www.microsoft.com/SqlServer/Dts' AS [dts])
 						,[maintenance_plan_steps] AS (
 							SELECT [name]
@@ -3719,9 +4140,9 @@ IF @ProductVersionMajor >= 10
                     		AND step.step_id = sjh.step_id
                     		AND sjh.run_date IN (SELECT max(sjh2.run_date) FROM msdb.dbo.sysjobhistory AS sjh2 WHERE sjh2.job_id = j.job_id) -- get the latest entry date
                     		AND sjh.run_time IN (SELECT max(sjh3.run_time) FROM msdb.dbo.sysjobhistory AS sjh3 WHERE sjh3.job_id = j.job_id AND sjh3.run_date = sjh.run_date) -- get the latest entry time
-						WHERE [c].[value]('(@dts:ObjectName)', 'VARCHAR(128)') = 'Shrink Database Task'
+						WHERE [c].[value]('(@dts:ObjectName)', 'VARCHAR(128)') = 'Shrink Database Task';
 
-						END
+						END;
 
 
 		/*Find repetitive maintenance tasks*/
@@ -3730,7 +4151,8 @@ IF @ProductVersionMajor >= 10
 										WHERE   DatabaseName IS NULL AND CheckID = 181 )
 						AND CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion')) LIKE '1%' /* Only run on 2008+ */
 				BEGIN
-						;
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 181) WITH NOWAIT;
+
 						WITH XMLNAMESPACES ('www.microsoft.com/SqlServer/Dts' AS [dts])
 						,[maintenance_plan_steps] AS (
 							SELECT [name]
@@ -3764,9 +4186,9 @@ IF @ProductVersionMajor >= 10
 						'The maintenance plan ' + [m].[name] + ' is doing repetitive work on indexes and statistics. Perhaps it''s time to try something more modern?' AS [Details]
 						FROM [mp_steps_pretty] m
 						WHERE m.[maintenance_plan_steps] LIKE '%Rebuild%Reorganize%'
-						OR m.[maintenance_plan_steps] LIKE '%Rebuild%Update%'
+						OR m.[maintenance_plan_steps] LIKE '%Rebuild%Update%';
 
-						END
+						END;
 			
 
 			/* Reliability - No Failover Cluster Nodes Available - 184 */
@@ -3776,7 +4198,9 @@ IF @ProductVersionMajor >= 10
 				AND CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128)) NOT LIKE '10%'
 				AND CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128)) NOT LIKE '9%'
 					BEGIN
-		                        SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+		                        IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 184) WITH NOWAIT;
+								
+								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			                        							SELECT TOP 1
 							  184 AS CheckID ,
 							  20 AS Priority ,
@@ -3789,8 +4213,12 @@ IF @ProductVersionMajor >= 10
 							  FROM sys.dm_os_cluster_nodes
 							) a
 							WHERE [available_nodes] < 1 OPTION (RECOMPILE)';
-		                        EXECUTE(@StringToExecute);
-					END
+		                        
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
+								EXECUTE(@StringToExecute);
+					END;
 
 		/* Reliability - TempDB File Error */
 		IF NOT EXISTS ( SELECT  1
@@ -3798,6 +4226,9 @@ IF @ProductVersionMajor >= 10
 										WHERE   DatabaseName IS NULL AND CheckID = 191 )
 			AND (SELECT COUNT(*) FROM sys.master_files WHERE database_id = 2) <> (SELECT COUNT(*) FROM tempdb.sys.database_files)
 				BEGIN
+					
+					IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 191) WITH NOWAIT
+					
 					INSERT    INTO [#BlitzResults]
 							( [CheckID] ,
 								[Priority] ,
@@ -3812,8 +4243,8 @@ IF @ProductVersionMajor >= 10
 						'Reliability' AS [FindingsGroup] ,
 						'TempDB File Error' AS [Finding] ,
 						'https://BrentOzar.com/go/tempdboops' AS [URL] , 
-						'Mismatch between the number of TempDB files in sys.master_files versus tempdb.sys.database_files' AS [Details]
-				END
+						'Mismatch between the number of TempDB files in sys.master_files versus tempdb.sys.database_files' AS [Details];
+				END;
 
 /*Perf - Odd number of cores in a socket*/
 		IF NOT EXISTS ( SELECT  1
@@ -3830,7 +4261,9 @@ IF @ProductVersionMajor >= 10
 		                HAVING  ( COUNT(cpu_id) + 2 ) % 2 = 1 )
 		   BEGIN
 		
-		         INSERT INTO #BlitzResults
+		         IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 198) WITH NOWAIT
+				 
+				 INSERT INTO #BlitzResults
 		                (
 		                  CheckID,
 		                  DatabaseName,
@@ -3907,6 +4340,9 @@ IF @ProductVersionMajor >= 10
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 199 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 199) WITH NOWAIT
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3930,15 +4366,18 @@ IF @ProductVersionMajor >= 10
 			N'DBCC CLEANTABLE', N'DBCC CHECKPRIMARYFILE', N'DBCC OPENTRAN', 'DBCC SHOWFILESTATS' --Weird but okay
 													)
 			AND d.dbcc_event_full_upper NOT IN('DBCC SQLPERF(NETSTATS)', 'DBCC SQLPERF(LOGSPACE)')
-			HAVING COUNT(*) > 0
+			HAVING COUNT(*) > 0;
 			
-				END
+				END;
 
 			/*Check for someone running drop clean buffers*/
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 200 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 200) WITH NOWAIT
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3957,15 +4396,18 @@ IF @ProductVersionMajor >= 10
 					FROM    #dbcc_events_from_trace d
 					WHERE d.dbcc_event_full_upper = N'DBCC DROPCLEANBUFFERS'
 					GROUP BY COALESCE(d.nt_user_name, d.login_name)
-					HAVING COUNT(*) > 0
+					HAVING COUNT(*) > 0;
 
-					END 
+					END; 
 
 			/*Check for someone running free proc cache*/
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 201 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 201) WITH NOWAIT
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -3984,15 +4426,18 @@ IF @ProductVersionMajor >= 10
 					FROM    #dbcc_events_from_trace d
 					WHERE d.dbcc_event_full_upper = N'DBCC FREEPROCCACHE'
 					GROUP BY COALESCE(d.nt_user_name, d.login_name)
-					HAVING COUNT(*) > 0
+					HAVING COUNT(*) > 0;
 
-					END
+					END;
 
 			/*Check for someone clearing wait stats*/
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 202 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 202) WITH NOWAIT
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -4011,15 +4456,18 @@ IF @ProductVersionMajor >= 10
 					FROM    #dbcc_events_from_trace d
 					WHERE d.dbcc_event_full_upper = N'DBCC SQLPERF(''SYS.DM_OS_WAIT_STATS'',CLEAR)'
 					GROUP BY COALESCE(d.nt_user_name, d.login_name)
-					HAVING COUNT(*) > 0
+					HAVING COUNT(*) > 0;
 
-					END
+					END;
 
 			/*Check for someone writing to pages. Yeah, right?*/
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 203 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 203) WITH NOWAIT
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -4038,14 +4486,17 @@ IF @ProductVersionMajor >= 10
 						FROM    #dbcc_events_from_trace d
 						WHERE d.dbcc_event_trunc_upper = N'DBCC WRITEPAGE'
 						GROUP BY COALESCE(d.nt_user_name, d.login_name)
-						HAVING COUNT(*) > 0
+						HAVING COUNT(*) > 0;
 
-						END
+						END;
 
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 204 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 204) WITH NOWAIT
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -4065,9 +4516,9 @@ IF @ProductVersionMajor >= 10
 						FROM    #dbcc_events_from_trace d
 						WHERE d.dbcc_event_trunc_upper LIKE N'DBCC SHRINK%'
 						GROUP BY COALESCE(d.nt_user_name, d.login_name)
-						HAVING COUNT(*) > 0
+						HAVING COUNT(*) > 0;
 
-						END
+						END;
 
 
 /*End: checking default trace for odd DBCC activity*/
@@ -4078,6 +4529,9 @@ IF @ProductVersionMajor >= 10
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 205 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 205) WITH NOWAIT
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -4101,13 +4555,15 @@ IF @ProductVersionMajor >= 10
 						FROM sys.fn_trace_gettable( @base_tracefilename, DEFAULT) AS t
 						WHERE t.EventClass IN (94, 95)
 						GROUP BY t.DatabaseName
-						HAVING AVG(DATEDIFF(SECOND, t.StartTime, t.EndTime)) > 5
+						HAVING AVG(DATEDIFF(SECOND, t.StartTime, t.EndTime)) > 5;
 				
-				END
+				END;
 
 
 				IF @CheckUserDatabaseObjects = 1
 					BEGIN
+
+					IF @Debug IN (1, 2) RAISERROR('Starting @CheckUserDatabaseObjects section.', 0, 1) WITH NOWAIT
 
                         /*
                         But what if you need to run a query in every individual database?
@@ -4125,8 +4581,11 @@ IF @ProductVersionMajor >= 10
 								        FROM    #SkipChecks
 								        WHERE   DatabaseName IS NULL AND CheckID = 99 )
 					        BEGIN
-						        EXEC dbo.sp_MSforeachdb 'USE [?];  IF EXISTS (SELECT * FROM  sys.tables WITH (NOLOCK) WHERE name = ''sysmergepublications'' ) IF EXISTS ( SELECT * FROM sysmergepublications WITH (NOLOCK) WHERE retention = 0)   INSERT INTO #BlitzResults (CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details) SELECT DISTINCT 99, DB_NAME(), 110, ''Performance'', ''Infinite merge replication metadata retention period'', ''https://BrentOzar.com/go/merge'', (''The ['' + DB_NAME() + ''] database has merge replication metadata retention period set to infinite - this can be the case of significant performance issues.'')';
-					        END
+						        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 99) WITH NOWAIT;
+								
+								EXEC dbo.sp_MSforeachdb 'USE [?];  IF EXISTS (SELECT * FROM  sys.tables WITH (NOLOCK) WHERE name = ''sysmergepublications'' ) IF EXISTS ( SELECT * FROM sysmergepublications WITH (NOLOCK) WHERE retention = 0)   INSERT INTO #BlitzResults (CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details) SELECT DISTINCT 99, DB_NAME(), 110, ''Performance'', ''Infinite merge replication metadata retention period'', ''https://BrentOzar.com/go/merge'', (''The ['' + DB_NAME() + ''] database has merge replication metadata retention period set to infinite - this can be the case of significant performance issues.'')';
+					        END;
 				        /*
 				        Note that by using sp_MSforeachdb, we're running the query in all
 				        databases. We're not checking #SkipChecks here for each database to
@@ -4142,6 +4601,9 @@ IF @ProductVersionMajor >= 10
                             AND EXISTS(SELECT * FROM sys.all_objects WHERE name = 'database_query_store_options')
 							BEGIN
 								/* --TOURSTOP03-- */
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 163) WITH NOWAIT;
+
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 			                            INSERT INTO #BlitzResults
 			                            (CheckID,
@@ -4160,7 +4622,7 @@ IF @ProductVersionMajor >= 10
 		                              (''The new SQL Server 2016 Query Store feature has not been enabled on this database.'')
 		                              FROM [?].sys.database_query_store_options WHERE desired_state = 0 
 									  AND ''?'' NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''DWConfiguration'', ''DWDiagnostics'', ''DWQueue'', ''ReportServer'', ''ReportServerTempDB'') OPTION (RECOMPILE)';
-							END
+							END;
 
 						
 							IF @ProductVersionMajor >= 13 AND @ProductVersionMinor < 2149 --CU1 has the fix in it
@@ -4170,7 +4632,10 @@ IF @ProductVersionMajor >= 10
 							AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Enterprise%'
 							AND CAST(SERVERPROPERTY('edition') AS VARCHAR(100)) NOT LIKE '%Developer%'
 							BEGIN 
-			                SET @StringToExecute = 'INSERT INTO #BlitzResults
+			                
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 182) WITH NOWAIT;
+							
+							SET @StringToExecute = 'INSERT INTO #BlitzResults
 													(CheckID,
 													DatabaseName,
 													Priority,
@@ -4187,15 +4652,22 @@ IF @ProductVersionMajor >= 10
 													''https://BrentOzar.com/go/cleanup'',
 													(''SQL 2016 RTM has a bug involving dumps that happen every time Query Store cleanup jobs run. This is fixed in CU1 and later: https://sqlserverupdates.com/sql-server-2016-updates/'')
 													FROM    sys.databases AS d
-													WHERE   d.is_query_store_on = 1 OPTION (RECOMPILE);'
-							EXECUTE(@StringToExecute)
-							END
+													WHERE   d.is_query_store_on = 1 OPTION (RECOMPILE);';
+							
+							IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+							IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+							
+							EXECUTE(@StringToExecute);
+							END;
 
 				        IF NOT EXISTS ( SELECT  1
 								        FROM    #SkipChecks
 								        WHERE   DatabaseName IS NULL AND CheckID = 41 )
 					        BEGIN
-						        EXEC dbo.sp_MSforeachdb 'use [?];
+						        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 41) WITH NOWAIT;
+								
+								EXEC dbo.sp_MSforeachdb 'use [?];
 		                              INSERT INTO #BlitzResults
 		                              (CheckID,
 		                              DatabaseName,
@@ -4215,13 +4687,16 @@ IF @ProductVersionMajor >= 10
 			                            AND ''?'' <> ''[tempdb]''
 		                              GROUP BY LEFT(physical_name, 1)
 		                              HAVING COUNT(*) > 1 OPTION (RECOMPILE);';
-					        END
+					        END;
 
 				        IF NOT EXISTS ( SELECT  1
 								        FROM    #SkipChecks
 								        WHERE   DatabaseName IS NULL AND CheckID = 42 )
 					        BEGIN
-						        EXEC dbo.sp_MSforeachdb 'use [?];
+						        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 42) WITH NOWAIT;
+								
+								EXEC dbo.sp_MSforeachdb 'use [?];
 			                            INSERT INTO #BlitzResults
 			                            (CheckID,
 			                            DatabaseName,
@@ -4241,13 +4716,16 @@ IF @ProductVersionMajor >= 10
 			                            WHERE type_desc = ''ROWS''
 			                            GROUP BY data_space_id
 			                            HAVING COUNT(DISTINCT growth) > 1 OR COUNT(DISTINCT is_percent_growth) > 1 OPTION (RECOMPILE);';
-					        END
+					        END;
 
 
 				            IF NOT EXISTS ( SELECT  1
 								            FROM    #SkipChecks
 								            WHERE   DatabaseName IS NULL AND CheckID = 82 )
 					            BEGIN
+
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 82) WITH NOWAIT;
+
 						            EXEC sp_MSforeachdb 'use [?];
 		                                INSERT INTO #BlitzResults
 		                                (CheckID,
@@ -4265,7 +4743,7 @@ IF @ProductVersionMajor >= 10
 		                                ''The ['' + DB_NAME() + ''] database file '' + f.physical_name + '' has grown to '' + CAST((f.size * 8 / 1000000) AS NVARCHAR(10)) + '' GB, and is using percent filegrowth settings. This can lead to slow performance during growths if Instant File Initialization is not enabled.''
 		                                FROM    [?].sys.database_files f
 		                                WHERE   is_percent_growth = 1 and size > 128000  OPTION (RECOMPILE);';
-					            END
+					            END;
 
 
 
@@ -4274,6 +4752,9 @@ IF @ProductVersionMajor >= 10
 								            FROM    #SkipChecks
 								            WHERE   DatabaseName IS NULL AND CheckID = 158 )
 					            BEGIN
+
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 158) WITH NOWAIT;
+
 						            EXEC sp_MSforeachdb 'use [?];
 		                                INSERT INTO #BlitzResults
 		                                (CheckID,
@@ -4291,7 +4772,7 @@ IF @ProductVersionMajor >= 10
 		                                ''The ['' + DB_NAME() + ''] database file '' + f.physical_name + '' is using 1MB filegrowth settings, but it has grown to '' + CAST((f.size * 8 / 1000000) AS NVARCHAR(10)) + '' GB. Time to up the growth amount.''
 		                                FROM    [?].sys.database_files f
                                         WHERE is_percent_growth = 0 and growth=128 and size > 128000  OPTION (RECOMPILE);';
-					            END
+					            END;
 
 
 
@@ -4302,7 +4783,10 @@ IF @ProductVersionMajor >= 10
 						        IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 							        AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 							        BEGIN
-								        EXEC dbo.sp_MSforeachdb 'USE [?]; INSERT INTO #BlitzResults
+								        
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 33) WITH NOWAIT;
+										
+										EXEC dbo.sp_MSforeachdb 'USE [?]; INSERT INTO #BlitzResults
 					                                (CheckID,
 					                                DatabaseName,
 					                                Priority,
@@ -4319,7 +4803,7 @@ IF @ProductVersionMajor >= 10
 		                                  (''The ['' + DB_NAME() + ''] database is using '' + feature_name + ''.  If this database is restored onto a Standard Edition server, the restore will fail on versions prior to 2016 SP1.'')
 		                                  FROM [?].sys.dm_db_persisted_sku_features OPTION (RECOMPILE);';
 							        END;
-					        END
+					        END;
 
 
 				        IF NOT EXISTS ( SELECT  1
@@ -4327,7 +4811,10 @@ IF @ProductVersionMajor >= 10
 								        WHERE   DatabaseName IS NULL AND CheckID = 19 )
 					        BEGIN
 						        /* Method 1: Check sys.databases parameters */
-						        INSERT  INTO #BlitzResults
+						        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 19) WITH NOWAIT;
+								
+								INSERT  INTO #BlitzResults
 								        ( CheckID ,
 								          DatabaseName ,
 								          Priority ,
@@ -4374,7 +4861,7 @@ IF @ProductVersionMajor >= 10
 							          FROM [?].sys.tables
 							          WHERE name = ''dbo.MSreplication_objects'' AND ''?'' <> ''master'' OPTION (RECOMPILE)';
 
-					        END
+					        END;
 
 
 
@@ -4382,6 +4869,9 @@ IF @ProductVersionMajor >= 10
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 32 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 32) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 			INSERT INTO #BlitzResults
 			(CheckID,
@@ -4401,12 +4891,15 @@ IF @ProductVersionMajor >= 10
 			FROM [?].sys.triggers t INNER JOIN [?].sys.objects o ON t.parent_id = o.object_id
 			INNER JOIN [?].sys.schemas s ON o.schema_id = s.schema_id WHERE t.is_ms_shipped = 0 AND DB_NAME() != ''ReportServer''
 			HAVING SUM(1) > 0 OPTION (RECOMPILE)';
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 38 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 38) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 			INSERT INTO #BlitzResults
 			(CheckID,
@@ -4429,13 +4922,16 @@ IF @ProductVersionMajor >= 10
 		  LEFT OUTER JOIN [?].sys.dm_db_index_usage_stats ius ON i.object_id = ius.object_id AND i.index_id = ius.index_id AND ius.database_id = sd.database_id
 		  WHERE i.type_desc = ''HEAP'' AND COALESCE(ius.user_seeks, ius.user_scans, ius.user_lookups, ius.user_updates) IS NOT NULL
 		  AND sd.name <> ''tempdb'' AND sd.name <> ''DWDiagnostics'' AND o.is_ms_shipped = 0 AND o.type <> ''S'' OPTION (RECOMPILE)';
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 164 )
                             AND EXISTS(SELECT * FROM sys.all_objects WHERE name = 'fn_validate_plan_guide')
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 164) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 			INSERT INTO #BlitzResults
 			(CheckID,
@@ -4453,12 +4949,15 @@ IF @ProductVersionMajor >= 10
 		  ''https://BrentOzar.com/go/misguided'',
 		  (''The ['' + DB_NAME() + ''] database has plan guides that are no longer valid, so the queries involved may be failing silently.'')
 		  FROM [?].sys.plan_guides g CROSS APPLY fn_validate_plan_guide(g.plan_guide_id) OPTION (RECOMPILE)';
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 39 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 39) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 			INSERT INTO #BlitzResults
 			(CheckID,
@@ -4481,12 +4980,15 @@ IF @ProductVersionMajor >= 10
 		  LEFT OUTER JOIN [?].sys.dm_db_index_usage_stats ius ON i.object_id = ius.object_id AND i.index_id = ius.index_id AND ius.database_id = sd.database_id
 		  WHERE i.type_desc = ''HEAP'' AND COALESCE(ius.user_seeks, ius.user_scans, ius.user_lookups, ius.user_updates) IS NULL
 		  AND sd.name <> ''tempdb'' AND sd.name <> ''DWDiagnostics'' AND o.is_ms_shipped = 0 AND o.type <> ''S'' OPTION (RECOMPILE)';
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 46 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 46) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 		  INSERT INTO #BlitzResults
 				(CheckID,
@@ -4505,12 +5007,15 @@ IF @ProductVersionMajor >= 10
 		  (''The index ['' + DB_NAME() + ''].['' + s.name + ''].['' + o.name + ''].['' + i.name + ''] is a leftover hypothetical index from the Index Tuning Wizard or Database Tuning Advisor.  This index is not actually helping performance and should be removed.'')
 		  from [?].sys.indexes i INNER JOIN [?].sys.objects o ON i.object_id = o.object_id INNER JOIN [?].sys.schemas s ON o.schema_id = s.schema_id
 		  WHERE i.is_hypothetical = 1 OPTION (RECOMPILE);';
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 47 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 47) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 		  INSERT INTO #BlitzResults
 				(CheckID,
@@ -4529,13 +5034,16 @@ IF @ProductVersionMajor >= 10
 		  (''The index ['' + DB_NAME() + ''].['' + s.name + ''].['' + o.name + ''].['' + i.name + ''] is disabled.  This index is not actually helping performance and should either be enabled or removed.'')
 		  from [?].sys.indexes i INNER JOIN [?].sys.objects o ON i.object_id = o.object_id INNER JOIN [?].sys.schemas s ON o.schema_id = s.schema_id
 		  WHERE i.is_disabled = 1 OPTION (RECOMPILE);';
-							END
+							END;
 
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 48 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 48) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 		  INSERT INTO #BlitzResults
 				(CheckID,
@@ -4554,12 +5062,15 @@ IF @ProductVersionMajor >= 10
 		  (''The ['' + DB_NAME() + ''] database has foreign keys that were probably disabled, data was changed, and then the key was enabled again.  Simply enabling the key is not enough for the optimizer to use this key - we have to alter the table using the WITH CHECK CHECK CONSTRAINT parameter.'')
 		  from [?].sys.foreign_keys i INNER JOIN [?].sys.objects o ON i.parent_object_id = o.object_id INNER JOIN [?].sys.schemas s ON o.schema_id = s.schema_id
 		  WHERE i.is_not_trusted = 1 AND i.is_not_for_replication = 0 AND i.is_disabled = 0 AND ''?'' NOT IN (''master'', ''model'', ''msdb'', ''ReportServer'', ''ReportServerTempDB'') OPTION (RECOMPILE);';
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 56 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 56) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 		  INSERT INTO #BlitzResults
 				(CheckID,
@@ -4579,7 +5090,7 @@ IF @ProductVersionMajor >= 10
 		  from [?].sys.check_constraints i INNER JOIN [?].sys.objects o ON i.parent_object_id = o.object_id
 		  INNER JOIN [?].sys.schemas s ON o.schema_id = s.schema_id
 		  WHERE i.is_not_trusted = 1 AND i.is_not_for_replication = 0 AND i.is_disabled = 0 OPTION (RECOMPILE);';
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
@@ -4588,6 +5099,9 @@ IF @ProductVersionMajor >= 10
 								IF @@VERSION NOT LIKE '%Microsoft SQL Server 2000%'
 									AND @@VERSION NOT LIKE '%Microsoft SQL Server 2005%'
 									BEGIN
+										
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 95) WITH NOWAIT;
+										
 										EXEC dbo.sp_MSforeachdb 'USE [?];
 			INSERT INTO #BlitzResults
 				  (CheckID,
@@ -4604,14 +5118,17 @@ IF @ProductVersionMajor >= 10
 			''Plan Guides Enabled'' AS Finding,
 			''https://BrentOzar.com/go/guides'' AS URL,
 			(''Database ['' + DB_NAME() + ''] has query plan guides so a query will always get a specific execution plan. If you are having trouble getting query performance to improve, it might be due to a frozen plan. Review the DMV sys.plan_guides to learn more about the plan guides in place on this server.'') AS Details
-			FROM [?].sys.plan_guides WHERE is_disabled = 0 OPTION (RECOMPILE);'
+			FROM [?].sys.plan_guides WHERE is_disabled = 0 OPTION (RECOMPILE);';
 									END;
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 60 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 60) WITH NOWAIT;
+								
 								EXEC sp_MSforeachdb 'USE [?];
 		  INSERT INTO #BlitzResults
 				(CheckID,
@@ -4630,7 +5147,7 @@ IF @ProductVersionMajor >= 10
 		  ''The ['' + DB_NAME() + ''] database has objects with fill factor < 80%. This can cause memory and storage performance problems, but may also prevent page splits.''
 		  FROM    [?].sys.indexes
 		  WHERE   fill_factor <> 0 AND fill_factor < 80 AND is_disabled = 0 AND is_hypothetical = 0 OPTION (RECOMPILE);';
-							END
+							END;
 
 
 
@@ -4638,7 +5155,10 @@ IF @ProductVersionMajor >= 10
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 78 )
 							BEGIN
-                                EXECUTE master.sys.sp_MSforeachdb 'USE [?]; 
+                                
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 78) WITH NOWAIT;
+								
+								EXECUTE master.sys.sp_MSforeachdb 'USE [?]; 
                                     INSERT INTO #Recompile 
                                     SELECT DBName = DB_Name(), SPName = SO.name, SM.is_recompiled, ISR.SPECIFIC_SCHEMA 
                                     FROM sys.sql_modules AS SM 
@@ -4646,7 +5166,7 @@ IF @ProductVersionMajor >= 10
                                     LEFT OUTER JOIN dbo.sysobjects AS SO ON SM.object_id = SO.id and type = ''P'' 
                                     LEFT OUTER JOIN INFORMATION_SCHEMA.ROUTINES AS ISR on ISR.Routine_Name = SO.name AND ISR.SPECIFIC_CATALOG = DB_Name()
                                     WHERE SM.is_recompiled=1  OPTION (RECOMPILE); /* oh the rich irony of recompile here */
-                                    ' 
+                                    '; 
                                 INSERT INTO #BlitzResults
 													(Priority,
 													FindingsGroup,
@@ -4662,9 +5182,9 @@ IF @ProductVersionMajor >= 10
                                     URL = 'https://BrentOzar.com/go/recompile',
                                     Details = '[' + DBName + '].[' + SPSchema + '].[' + ProcName + '] has WITH RECOMPILE in the stored procedure code, which may cause increased CPU usage due to constant recompiles of the code.',
                                     CheckID = '78'
-                                FROM #Recompile AS TR WHERE ProcName NOT LIKE 'sp_AskBrent%' AND ProcName NOT LIKE 'sp_Blitz%' 
+                                FROM #Recompile AS TR WHERE ProcName NOT LIKE 'sp_AskBrent%' AND ProcName NOT LIKE 'sp_Blitz%'; 
                                 DROP TABLE #Recompile;
-                            END
+                            END;
 
 
 
@@ -4672,8 +5192,11 @@ IF @ProductVersionMajor >= 10
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 86 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 86) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?]; INSERT INTO #BlitzResults (CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details) SELECT DISTINCT 86, DB_NAME(), 230, ''Security'', ''Elevated Permissions on a Database'', ''https://BrentOzar.com/go/elevated'', (''In ['' + DB_NAME() + ''], user ['' + u.name + '']  has the role ['' + g.name + ''].  This user can perform tasks beyond just reading and writing data.'') FROM [?].dbo.sysmembers m inner join [?].dbo.sysusers u on m.memberuid = u.uid inner join sysusers g on m.groupuid = g.uid where u.name <> ''dbo'' and g.name in (''db_owner'' , ''db_accessadmin'' , ''db_securityadmin'' , ''db_ddladmin'') OPTION (RECOMPILE);';
-							END
+							END;
 
 
 							/*Check for non-aligned indexes in partioned databases*/
@@ -4682,6 +5205,9 @@ IF @ProductVersionMajor >= 10
 														FROM    #SkipChecks
 														WHERE   DatabaseName IS NULL AND CheckID = 72 )
 											BEGIN
+												
+												IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 72) WITH NOWAIT;
+												
 												EXEC dbo.sp_MSforeachdb 'USE [?];
 								insert into #partdb(dbname, objectname, type_desc)
 								SELECT distinct db_name(DB_ID()) as DBName,o.name Object_Name,ds.type_desc
@@ -4696,7 +5222,7 @@ IF @ProductVersionMajor >= 10
 									SELECT a.object_id from
 									  (SELECT ob.object_id, ds.type_desc from sys.objects ob JOIN sys.indexes ind on ind.object_id = ob.object_id join sys.data_spaces ds on ds.data_space_id = ind.data_space_id
 									  GROUP BY ob.object_id, ds.type_desc ) a group by a.object_id having COUNT (*) > 1
-								  )  OPTION (RECOMPILE);'
+								  )  OPTION (RECOMPILE);';
 												INSERT  INTO #BlitzResults
 														( CheckID ,
 														  DatabaseName ,
@@ -4720,15 +5246,18 @@ IF @ProductVersionMajor >= 10
 																AND dbname NOT IN ( SELECT DISTINCT
 																						  DatabaseName
 																					FROM  #SkipChecks 
-																					WHERE CheckID IS NULL OR CheckID = 72)
-												DROP TABLE #partdb
-											END
+																					WHERE CheckID IS NULL OR CheckID = 72);
+												DROP TABLE #partdb;
+											END;
 
 
 					IF NOT EXISTS ( SELECT  1
 									FROM    #SkipChecks
 									WHERE   DatabaseName IS NULL AND CheckID = 113 )
 									BEGIN
+							  
+							  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 113) WITH NOWAIT;
+							  
 							  EXEC dbo.sp_MSforeachdb 'USE [?];
 							  INSERT INTO #BlitzResults
 									(CheckID,
@@ -4746,12 +5275,15 @@ IF @ProductVersionMajor >= 10
 							  ''https://BrentOzar.com/go/fulltext'',
 							  (''At least one full text index in this database has not been crawled in the last week.'')
 							  from [?].sys.fulltext_indexes i WHERE change_tracking_state_desc <> ''AUTO'' AND i.is_enabled = 1 AND i.crawl_end_date < DATEADD(dd, -7, GETDATE())  OPTION (RECOMPILE);';
-												END
+												END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 115 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 115) WITH NOWAIT;
+								
 								EXEC dbo.sp_MSforeachdb 'USE [?];
 		  INSERT INTO #BlitzResults
 				(CheckID,
@@ -4769,19 +5301,22 @@ IF @ProductVersionMajor >= 10
 		  ''https://BrentOzar.com/go/makeparallel'',
 		  (''['' + DB_NAME() + ''] has a make_parallel function, indicating that an advanced developer may be manhandling SQL Server into forcing queries to go parallel.'')
 		  from [?].INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_NAME = ''make_parallel'' AND ROUTINE_TYPE = ''FUNCTION'' OPTION (RECOMPILE);';
-							END
+							END;
 
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 122 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 122) WITH NOWAIT;
+								
 								/* SQL Server 2012 and newer uses temporary stats for AlwaysOn Availability Groups, and those show up as user-created */
 								IF EXISTS (SELECT *
 									  FROM sys.all_columns c
 									  INNER JOIN sys.all_objects o ON c.object_id = o.object_id
 									  WHERE c.name = 'is_temporary' AND o.name = 'stats')
-
+										
 										EXEC dbo.sp_MSforeachdb 'USE [?];
 												INSERT INTO #BlitzResults
 													(CheckID,
@@ -4822,7 +5357,7 @@ IF @ProductVersionMajor >= 10
                                                 HAVING SUM(1) > 0 OPTION (RECOMPILE);';
 
 
-							END /* IF NOT EXISTS ( SELECT  1 */
+							END; /* IF NOT EXISTS ( SELECT  1 */
 
 
 		        /*Check for high VLF count: this will omit any database snapshots*/
@@ -4834,7 +5369,10 @@ IF @ProductVersionMajor >= 10
 						        IF @ProductVersionMajor >= 11
 
 							        BEGIN
-								        EXEC sp_MSforeachdb N'USE [?];
+								        
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d] (2012 version of Log Info).', 0, 1, 69) WITH NOWAIT;
+										
+										EXEC sp_MSforeachdb N'USE [?];
 		                                      INSERT INTO #LogInfo2012
 		                                      EXEC sp_executesql N''DBCC LogInfo() WITH NO_INFOMSGS'';
 		                                      IF    @@ROWCOUNT > 999
@@ -4858,12 +5396,15 @@ IF @ProductVersionMajor >= 10
 			                                    WHERE EXISTS (SELECT name FROM master.sys.databases
 					                                    WHERE source_database_id is null)  OPTION (RECOMPILE);
 		                                      END
-		                                    TRUNCATE TABLE #LogInfo2012;'
+		                                    TRUNCATE TABLE #LogInfo2012;';
 								        DROP TABLE #LogInfo2012;
-							        END
+							        END;
 						        ELSE
 							        BEGIN
-								        EXEC sp_MSforeachdb N'USE [?];
+								        
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d] (pre-2012 version of Log Info).', 0, 1, 69) WITH NOWAIT;
+										
+										EXEC sp_MSforeachdb N'USE [?];
 		                                      INSERT INTO #LogInfo
 		                                      EXEC sp_executesql N''DBCC LogInfo() WITH NO_INFOMSGS'';
 		                                      IF    @@ROWCOUNT > 999
@@ -4887,18 +5428,21 @@ IF @ProductVersionMajor >= 10
 			                                    WHERE EXISTS (SELECT name FROM master.sys.databases
 			                                    WHERE source_database_id is null) OPTION (RECOMPILE);
 		                                      END
-		                                      TRUNCATE TABLE #LogInfo;'
+		                                      TRUNCATE TABLE #LogInfo;';
 								        DROP TABLE #LogInfo;
-							        END
-					        END
+							        END;
+					        END;
 
 
 				        IF NOT EXISTS ( SELECT  1
 								        FROM    #SkipChecks
 								        WHERE   DatabaseName IS NULL AND CheckID = 80 )
 					        BEGIN
-						        EXEC dbo.sp_MSforeachdb 'USE [?]; INSERT INTO #BlitzResults (CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details) SELECT DISTINCT 80, DB_NAME(), 170, ''Reliability'', ''Max File Size Set'', ''https://BrentOzar.com/go/maxsize'', (''The ['' + DB_NAME() + ''] database file '' + name + '' has a max file size set to '' + CAST(CAST(max_size AS BIGINT) * 8 / 1024 AS VARCHAR(100)) + ''MB. If it runs out of space, the database will stop working even though there may be drive space available.'') FROM sys.database_files WHERE max_size <> 268435456 AND max_size <> -1 AND type <> 2 AND name <> ''DWDiagnostics''  OPTION (RECOMPILE);';
-					        END
+						        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 80) WITH NOWAIT;
+								
+								EXEC dbo.sp_MSforeachdb 'USE [?]; INSERT INTO #BlitzResults (CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details) SELECT DISTINCT 80, DB_NAME(), 170, ''Reliability'', ''Max File Size Set'', ''https://BrentOzar.com/go/maxsize'', (''The ['' + DB_NAME() + ''] database file '' + name + '' has a max file size set to '' + CAST(CAST(max_size AS BIGINT) * 8 / 1024 AS VARCHAR(100)) + ''MB. If it runs out of space, the database will stop working even though there may be drive space available.'') FROM sys.database_files WHERE max_size <> 268435456 AND max_size <> -1 AND type <> 2 AND name <> ''DWDiagnostics''  OPTION (RECOMPILE);';
+					        END;
 
 	
 						/* Check if columnstore indexes are in use - for Github issue #615 */
@@ -4907,14 +5451,20 @@ IF @ProductVersionMajor >= 10
 								        WHERE   DatabaseName IS NULL AND CheckID = 74 ) /* Trace flags */
 					        BEGIN
 								TRUNCATE TABLE #TemporaryDatabaseResults;
-						        EXEC dbo.sp_MSforeachdb 'USE [?]; IF EXISTS(SELECT * FROM sys.indexes WHERE type IN (5,6)) INSERT INTO #TemporaryDatabaseResults (DatabaseName, Finding) VALUES (DB_NAME(), ''Yup'') OPTION (RECOMPILE);';
+						        
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 74) WITH NOWAIT;
+								
+								EXEC dbo.sp_MSforeachdb 'USE [?]; IF EXISTS(SELECT * FROM sys.indexes WHERE type IN (5,6)) INSERT INTO #TemporaryDatabaseResults (DatabaseName, Finding) VALUES (DB_NAME(), ''Yup'') OPTION (RECOMPILE);';
 								IF EXISTS (SELECT * FROM #TemporaryDatabaseResults) SET @ColumnStoreIndexesInUse = 1;
-					        END
+					        END;
 
 
 						/* Non-Default Database Scoped Config - Github issue #598 */
 				        IF EXISTS ( SELECT * FROM sys.all_objects WHERE [name] = 'database_scoped_configurations' )
 					        BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d] through [%d].', 0, 1, 194, 197) WITH NOWAIT;
+								
 								INSERT INTO #DatabaseScopedConfigurationDefaults (configuration_id, [name], default_value, default_value_for_secondary, CheckID)
 									SELECT 1, 'MAXDOP', 0, NULL, 194
 									UNION ALL
@@ -4931,12 +5481,12 @@ IF @ProductVersionMajor >= 10
 									LEFT OUTER JOIN #SkipChecks sk ON (sk.CheckID IS NULL OR def.CheckID = sk.CheckID) AND (sk.DatabaseName IS NULL OR sk.DatabaseName = DB_NAME())
 									WHERE def.configuration_id IS NULL AND sk.CheckID IS NULL ORDER BY 1
 									 OPTION (RECOMPILE);';
-					        END
+					        END;
 
 
 
 	
-					END /* IF @CheckUserDatabaseObjects = 1 */
+					END; /* IF @CheckUserDatabaseObjects = 1 */
 
 				IF @CheckProcedureCache = 1
 					BEGIN
@@ -4945,6 +5495,9 @@ IF @ProductVersionMajor >= 10
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 35 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 35) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -4970,7 +5523,7 @@ IF @ProductVersionMajor >= 10
 																  name = 'optimize for ad hoc workloads'
 																  AND value_in_use = 0 )
 										HAVING  COUNT(*) > 1;
-							END
+							END;
 
 
 		  /* Set up the cache tables. Different on 2005 since it doesn't support query_hash, query_plan_hash. */
@@ -4987,9 +5540,9 @@ IF @ProductVersionMajor >= 10
 			  SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time]
 			  FROM queries qs
 			  LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-			  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+			  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 								IF @CheckProcedureCacheFilter = 'Reads'
 									OR @CheckProcedureCacheFilter IS NULL
@@ -5002,9 +5555,9 @@ IF @ProductVersionMajor >= 10
 		  SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time]
 		  FROM queries qs
 		  LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 								IF @CheckProcedureCacheFilter = 'ExecCount'
 									OR @CheckProcedureCacheFilter IS NULL
@@ -5017,9 +5570,9 @@ IF @ProductVersionMajor >= 10
 		  SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time]
 		  FROM queries qs
 		  LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 								IF @CheckProcedureCacheFilter = 'Duration'
 									OR @CheckProcedureCacheFilter IS NULL
@@ -5032,9 +5585,9 @@ IF @ProductVersionMajor >= 10
 			SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time]
 			FROM queries qs
 			LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-			WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+			WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 							END;
 						IF @ProductVersionMajor >= 10
@@ -5050,9 +5603,9 @@ IF @ProductVersionMajor >= 10
 		  SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time],qs.[query_hash],qs.[query_plan_hash]
 		  FROM queries qs
 		  LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 								IF @CheckProcedureCacheFilter = 'Reads'
 									OR @CheckProcedureCacheFilter IS NULL
@@ -5065,9 +5618,9 @@ IF @ProductVersionMajor >= 10
 		  SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time],qs.[query_hash],qs.[query_plan_hash]
 		  FROM queries qs
 		  LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 								IF @CheckProcedureCacheFilter = 'ExecCount'
 									OR @CheckProcedureCacheFilter IS NULL
@@ -5080,9 +5633,9 @@ IF @ProductVersionMajor >= 10
 		  SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time],qs.[query_hash],qs.[query_plan_hash]
 		  FROM queries qs
 		  LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 								IF @CheckProcedureCacheFilter = 'Duration'
 									OR @CheckProcedureCacheFilter IS NULL
@@ -5095,9 +5648,9 @@ IF @ProductVersionMajor >= 10
 		  SELECT qs.[sql_handle],qs.[statement_start_offset],qs.[statement_end_offset],qs.[plan_generation_num],qs.[plan_handle],qs.[creation_time],qs.[last_execution_time],qs.[execution_count],qs.[total_worker_time],qs.[last_worker_time],qs.[min_worker_time],qs.[max_worker_time],qs.[total_physical_reads],qs.[last_physical_reads],qs.[min_physical_reads],qs.[max_physical_reads],qs.[total_logical_writes],qs.[last_logical_writes],qs.[min_logical_writes],qs.[max_logical_writes],qs.[total_logical_reads],qs.[last_logical_reads],qs.[min_logical_reads],qs.[max_logical_reads],qs.[total_clr_time],qs.[last_clr_time],qs.[min_clr_time],qs.[max_clr_time],qs.[total_elapsed_time],qs.[last_elapsed_time],qs.[min_elapsed_time],qs.[max_elapsed_time],qs.[query_hash],qs.[query_plan_hash]
 		  FROM queries qs
 		  LEFT OUTER JOIN #dm_exec_query_stats qsCaught ON qs.sql_handle = qsCaught.sql_handle AND qs.plan_handle = qsCaught.plan_handle AND qs.statement_start_offset = qsCaught.statement_start_offset
-		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);'
-										EXECUTE(@StringToExecute)
-									END
+		  WHERE qsCaught.sql_handle IS NULL OPTION (RECOMPILE);';
+										EXECUTE(@StringToExecute);
+									END;
 
 		/* Populate the query_plan_filtered field. Only works in 2005SP2+, but we're just doing it in 2008 to be safe. */
 								UPDATE  #dm_exec_query_stats
@@ -5106,7 +5659,7 @@ IF @ProductVersionMajor >= 10
 										CROSS APPLY sys.dm_exec_text_query_plan(qs.plan_handle,
 																  qs.statement_start_offset,
 																  qs.statement_end_offset)
-										AS qp
+										AS qp;
 
 							END;
 
@@ -5127,12 +5680,12 @@ IF @ProductVersionMajor >= 10
 						FROM    #dm_exec_query_stats qs
 								CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
 								CROSS APPLY sys.dm_exec_query_plan(qs.plan_handle)
-								AS qp
+								AS qp;
 
 		/* Dump instances of our own script. We're not trying to tune ourselves. */
 						DELETE  #dm_exec_query_stats
 						WHERE   text LIKE '%sp_Blitz%'
-								OR text LIKE '%#BlitzResults%'
+								OR text LIKE '%#BlitzResults%';
 
 		/* Look for implicit conversions */
 
@@ -5140,6 +5693,9 @@ IF @ProductVersionMajor >= 10
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 63 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 63) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -5162,13 +5718,16 @@ IF @ProductVersionMajor >= 10
 										WHERE   COALESCE(qs.query_plan_filtered,
 														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%CONVERT_IMPLICIT%'
 												AND COALESCE(qs.query_plan_filtered,
-															 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%PhysicalOp="Index Scan"%'
-							END
+															 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%PhysicalOp="Index Scan"%';
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 64 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 64) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -5189,14 +5748,17 @@ IF @ProductVersionMajor >= 10
 												qs.query_plan_filtered
 										FROM    #dm_exec_query_stats qs
 										WHERE   COALESCE(qs.query_plan_filtered,
-														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%<PlanAffectingConvert ConvertIssue="Cardinality Estimate" Expression="CONVERT_IMPLICIT%'
-							END
+														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%<PlanAffectingConvert ConvertIssue="Cardinality Estimate" Expression="CONVERT_IMPLICIT%';
+							END;
 
 							/* @cms4j, 29.11.2013: Look for RID or Key Lookups */
 							IF NOT EXISTS ( SELECT  1
 											FROM    #SkipChecks
 											WHERE   DatabaseName IS NULL AND CheckID = 118 )
 								BEGIN
+									
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 118) WITH NOWAIT;
+									
 									INSERT  INTO #BlitzResults
 											( CheckID ,
 											  Priority ,
@@ -5217,8 +5779,8 @@ IF @ProductVersionMajor >= 10
 													qs.query_plan_filtered
 											FROM    #dm_exec_query_stats qs
 											WHERE   COALESCE(qs.query_plan_filtered,
-															 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%Lookup="1"%'
-								END /* @cms4j, 29.11.2013: Look for RID or Key Lookups */
+															 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%Lookup="1"%';
+								END; /* @cms4j, 29.11.2013: Look for RID or Key Lookups */
 
 
 						/* Look for missing indexes */
@@ -5226,6 +5788,9 @@ IF @ProductVersionMajor >= 10
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 65 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 65) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -5246,14 +5811,17 @@ IF @ProductVersionMajor >= 10
 												qs.query_plan_filtered
 										FROM    #dm_exec_query_stats qs
 										WHERE   COALESCE(qs.query_plan_filtered,
-														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%MissingIndexGroup%'
-							END
+														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%MissingIndexGroup%';
+							END;
 
 						/* Look for cursors */
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 66 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 66) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -5274,8 +5842,8 @@ IF @ProductVersionMajor >= 10
 												qs.query_plan_filtered
 										FROM    #dm_exec_query_stats qs
 										WHERE   COALESCE(qs.query_plan_filtered,
-														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%<StmtCursor%'
-							END
+														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%<StmtCursor%';
+							END;
 
 		/* Look for scalar user-defined functions */
 
@@ -5283,6 +5851,9 @@ IF @ProductVersionMajor >= 10
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 67 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 67) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -5303,10 +5874,10 @@ IF @ProductVersionMajor >= 10
 												qs.query_plan_filtered
 										FROM    #dm_exec_query_stats qs
 										WHERE   COALESCE(qs.query_plan_filtered,
-														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%<UserDefinedFunction%'
-							END
+														 CAST(qs.query_plan AS NVARCHAR(MAX))) LIKE '%<UserDefinedFunction%';
+							END;
 
-					END /* IF @CheckProcedureCache = 1 */
+					END; /* IF @CheckProcedureCache = 1 */
 									  
 		/*Check to see if the HA endpoint account is set at the same as the SQL Server Service Account*/
 		IF @ProductVersionMajor >= 10
@@ -5316,7 +5887,10 @@ IF @ProductVersionMajor >= 10
 
 		IF SERVERPROPERTY('IsHadrEnabled') = 1
     		BEGIN
-                INSERT    INTO [#BlitzResults]
+                
+				IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 187) WITH NOWAIT;
+				
+				INSERT    INTO [#BlitzResults]
                                	( [CheckID] ,
                                 [Priority] ,
                                 [FindingsGroup] ,
@@ -5334,13 +5908,16 @@ IF @ProductVersionMajor >= 10
 					FROM sys.database_mirroring_endpoints ep
 					LEFT OUTER JOIN sys.dm_server_services s ON SUSER_NAME(ep.principal_id) = s.service_account
 					WHERE s.service_account IS NULL;
-    		END
+    		END;
 
 		/*Check for the last good DBCC CHECKDB date */
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 68 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 68) WITH NOWAIT;
+						
 						EXEC sp_MSforeachdb N'USE [?];
 						INSERT #DBCCs
 							(ParentObject,
@@ -5388,8 +5965,8 @@ IF @ProductVersionMajor >= 10
 																WHERE CheckID IS NULL OR CheckID = 68)
 											AND CONVERT(DATETIME, DB2.Value, 121) < DATEADD(DD,
 																  -14,
-																  CURRENT_TIMESTAMP)
-					END
+																  CURRENT_TIMESTAMP);
+					END;
 
 
 
@@ -5401,6 +5978,9 @@ IF @ProductVersionMajor >= 10
 				BEGIN
 					IF @@SERVERNAME IS NULL
 						BEGIN
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 70) WITH NOWAIT;
+							
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -5414,7 +5994,7 @@ IF @ProductVersionMajor >= 10
 											'Informational' AS FindingsGroup ,
 											'@@Servername Not Set' AS Finding ,
 											'https://BrentOzar.com/go/servername' AS URL ,
-											'@@Servername variable is null. You can fix it by executing: "sp_addserver ''<LocalServerName>'', local"' AS Details
+											'@@Servername variable is null. You can fix it by executing: "sp_addserver ''<LocalServerName>'', local"' AS Details;
 						END;
 
 					IF  /* @@SERVERNAME IS set */
@@ -5429,6 +6009,9 @@ IF @ProductVersionMajor >= 10
 						/* @@SERVERNAME is different than the computer name */
 						@@SERVERNAME <> CAST(ISNULL(SERVERPROPERTY('ComputerNamePhysicalNetBIOS'),@@SERVERNAME) AS NVARCHAR) )
 						 BEGIN
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 70) WITH NOWAIT;
+							
 							INSERT  INTO #BlitzResults
 									( CheckID ,
 									  Priority ,
@@ -5442,16 +6025,18 @@ IF @ProductVersionMajor >= 10
 											'Configuration' AS FindingsGroup ,
 											'@@Servername Not Correct' AS Finding ,
 											'https://BrentOzar.com/go/servername' AS URL ,
-											'The @@Servername is different than the computer name, which may trigger certificate errors.' AS Details
+											'The @@Servername is different than the computer name, which may trigger certificate errors.' AS Details;
 						END;
 
-				END
+				END;
 		/*Check to see if a failsafe operator has been configured*/
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 73 )
 					BEGIN
 
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 73) WITH NOWAIT;
+						
 						DECLARE @AlertInfo TABLE
 							(
 							  FailSafeOperator NVARCHAR(255) ,
@@ -5463,9 +6048,9 @@ IF @ProductVersionMajor >= 10
 							  PagerSubjectTemplate NVARCHAR(255) ,
 							  PagerSendSubjectOnly NVARCHAR(255) ,
 							  ForwardAlways INT
-							)
+							);
 						INSERT  INTO @AlertInfo
-								EXEC [master].[dbo].[sp_MSgetalertinfo] @includeaddresses = 0
+								EXEC [master].[dbo].[sp_MSgetalertinfo] @includeaddresses = 0;
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -5482,16 +6067,19 @@ IF @ProductVersionMajor >= 10
 										( 'No failsafe operator is configured on this server.  This is a good idea just in-case there are issues with the [msdb] database that prevents alerting.' ) AS Details
 								FROM    @AlertInfo
 								WHERE   FailSafeOperator IS NULL;
-					END
+					END;
 
 /*Identify globally enabled trace flags*/
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 74 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 74) WITH NOWAIT;
+						
 						INSERT  INTO #TraceStatus
 								EXEC ( ' DBCC TRACESTATUS(-1) WITH NO_INFOMSGS'
-									)
+									);
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -5520,14 +6108,17 @@ IF @ProductVersionMajor >= 10
                                              WHEN [T].[TraceFlag] = '8017' AND (CAST(SERVERPROPERTY('Edition') AS NVARCHAR(1000)) NOT LIKE N'%Express%') THEN ' 8017 is enabled globally. Using this Trace Flag disables creation schedulers for all logical processors. Not good.'
 											 ELSE [T].[TraceFlag] + ' is enabled globally.' END 
 										AS Details
-								FROM    #TraceStatus T
-					END
+								FROM    #TraceStatus T;
+					END;
 
 		/*Check for transaction log file larger than data file */
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 75 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 75) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -5561,14 +6152,17 @@ IF @ProductVersionMajor >= 10
 										AND a.database_id IN (
 										SELECT  database_id
 										FROM    sys.databases
-										WHERE   source_database_id IS NULL )
-					END
+										WHERE   source_database_id IS NULL );
+					END;
 
 		/*Check for collation conflicts between user databases and tempdb */
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 76 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 76) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -5598,13 +6192,16 @@ IF @ProductVersionMajor >= 10
 																  sys.databases
 																WHERE
 																  name = 'tempdb'
-															  )
-					END
+															  );
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 77 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 77) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  DatabaseName ,
@@ -5629,13 +6226,16 @@ IF @ProductVersionMajor >= 10
 																  AND dSnap.name NOT IN (
 																  SELECT DISTINCT DatabaseName
 																  FROM #SkipChecks 
-																  WHERE CheckID = 77 OR CheckID IS NULL)
-					END
+																  WHERE CheckID = 77 OR CheckID IS NULL);
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 79 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 79) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -5672,13 +6272,16 @@ IF @ProductVersionMajor >= 10
 										    AND sjh.run_date IN (SELECT max(sjh2.run_date) FROM msdb.dbo.sysjobhistory AS sjh2 WHERE sjh2.job_id = j.job_id) -- get the latest entry date
 										    AND sjh.run_time IN (SELECT max(sjh3.run_time) FROM msdb.dbo.sysjobhistory AS sjh3 WHERE sjh3.job_id = j.job_id AND sjh3.run_date = sjh.run_date) -- get the latest entry time
 								WHERE   step.command LIKE N'%SHRINKDATABASE%'
-										OR step.command LIKE N'%SHRINKFILE%'
-					END
+										OR step.command LIKE N'%SHRINKFILE%';
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 81 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 81) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -5700,12 +6303,15 @@ IF @ProductVersionMajor >= 10
 								FROM    sys.configurations cr
 								WHERE   cr.value <> cr.value_in_use
                                  AND NOT (cr.name = 'min server memory (MB)' AND cr.value IN (0,16) AND cr.value_in_use IN (0,16));
-					END
+					END;
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 123 )
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 123) WITH NOWAIT;
+						
 						INSERT  INTO #BlitzResults
 								( CheckID ,
 								  Priority ,
@@ -5723,7 +6329,7 @@ IF @ProductVersionMajor >= 10
 								FROM    msdb.dbo.sysjobactivity
 								WHERE start_execution_date > DATEADD(dd, -14, GETDATE())
 								GROUP BY start_execution_date HAVING COUNT(*) > 1;
-					END
+					END;
 
 
 				IF @CheckServerInfo = 1
@@ -5740,6 +6346,9 @@ IF @ProductVersionMajor >= 10
 											WHERE   name = 'dm_os_windows_info' )
 
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 172) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -5764,7 +6373,7 @@ IF @ProductVersionMajor >= 10
 								ELSE 'I have no idea which version of Windows you''re on. Sorry.'
 								END
 							   ) AS [Details]
-							 FROM [sys].[dm_os_windows_info] [owi]
+							 FROM [sys].[dm_os_windows_info] [owi];
 
 					END;
 					END;
@@ -5778,6 +6387,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 166 )
 					BEGIN
+						  
+						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 166) WITH NOWAIT;
+						  
 						  INSERT    INTO [#BlitzResults]
 									( [CheckID] ,
 									  [Priority] ,
@@ -5814,6 +6426,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											WHERE   o.name = 'dm_os_sys_info'
 													AND c.name = 'sql_memory_model' )
 							BEGIN
+										
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 166) WITH NOWAIT;
+										
 										SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			SELECT  166 AS CheckID ,
 			250 AS Priority ,
@@ -5822,8 +6437,12 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 			''https://BrentOzar.com/go/lpim'' AS URL ,
 			''Memory Model: '' + CAST(sql_memory_model_desc AS NVARCHAR(100))
 			FROM sys.dm_os_sys_info WHERE sql_memory_model <> 1 OPTION (RECOMPILE);';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+
 										EXECUTE(@StringToExecute);
-									END
+									END;
 
 
 
@@ -5836,6 +6455,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									WHERE   DatabaseName IS NULL AND CheckID = 184 )
 							AND (@ProductVersionMajor >= 13) OR (@ProductVersionMajor = 12 AND @ProductVersionMinor >= 5000)
 						BEGIN
+							
+							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 184) WITH NOWAIT;
+							
 							INSERT INTO #ErrorLog
 							EXEC sys.xp_readerrorlog 0, 1, N'Database Instant File Initialization: enabled';
 
@@ -5854,7 +6476,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												'Server Info' AS [FindingsGroup] ,
 												'Instant File Initialization Enabled' AS [Finding] ,
 												'https://BrentOzar.com/go/instant' AS [URL] ,
-												'The service account has the Perform Volume Maintenance Tasks permission.'
+												'The service account has the Perform Volume Maintenance Tasks permission.';
 						END; 
 
 			/* Server Info - Instant File Initialization Not Enabled - Check 192 - SQL Server 2016 SP1 and newer */
@@ -5867,6 +6489,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											WHERE   o.name = 'dm_server_services'
 													AND c.name = 'instant_file_initialization_enabled' )
 							BEGIN
+										
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 192) WITH NOWAIT;
+										
 										SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			SELECT  192 AS CheckID ,
 			50 AS Priority ,
@@ -5875,8 +6500,12 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 			''https://BrentOzar.com/go/instant'' AS URL ,
 			''Consider enabling IFI for faster restores and data file growths.''
 			FROM sys.dm_server_services WHERE instant_file_initialization_enabled <> ''Y'' AND filename LIKE ''%sqlservr.exe%'' OPTION (RECOMPILE);';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+										
 										EXECUTE(@StringToExecute);
-									END
+									END;
 
 
 
@@ -5886,6 +6515,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									FROM    #SkipChecks
 									WHERE   DatabaseName IS NULL AND CheckID = 130 )
 						BEGIN
+									
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 130) WITH NOWAIT;
+									
 									INSERT  INTO #BlitzResults
 											( CheckID ,
 											  Priority ,
@@ -5913,6 +6545,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											FROM    sys.all_objects
 											WHERE   name = 'dm_server_services' )
 									BEGIN
+										
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 83) WITH NOWAIT;
+										
 										SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 				SELECT  83 AS CheckID ,
 				250 AS Priority ,
@@ -5920,10 +6555,14 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 				''Services'' AS Finding ,
 				'''' AS URL ,
 				N''Service: '' + servicename + N'' runs under service account '' + service_account + N''. Last startup time: '' + COALESCE(CAST(CAST(last_startup_time AS DATETIME) AS VARCHAR(50)), ''not shown.'') + ''. Startup type: '' + startup_type_desc + N'', currently '' + status_desc + ''.''
-				FROM sys.dm_server_services OPTION (RECOMPILE);'
+				FROM sys.dm_server_services OPTION (RECOMPILE);';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+										
 										EXECUTE(@StringToExecute);
-									END
-							END
+									END;
+							END;
 
 			/* Check 84 - SQL Server 2012 */
 						IF NOT EXISTS ( SELECT  1
@@ -5936,6 +6575,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											WHERE   o.name = 'dm_os_sys_info'
 													AND c.name = 'physical_memory_kb' )
 									BEGIN
+										
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 84) WITH NOWAIT;
+										
 										SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			SELECT  84 AS CheckID ,
 			250 AS Priority ,
@@ -5944,8 +6586,12 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 			'''' AS URL ,
 			''Logical processors: '' + CAST(cpu_count AS VARCHAR(50)) + ''. Physical memory: '' + CAST( CAST(ROUND((physical_memory_kb / 1024.0 / 1024), 1) AS INT) AS VARCHAR(50)) + ''GB.''
 			FROM sys.dm_os_sys_info OPTION (RECOMPILE);';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+										
 										EXECUTE(@StringToExecute);
-									END
+									END;
 
 			/* Check 84 - SQL Server 2008 */
 								IF EXISTS ( SELECT  *
@@ -5954,6 +6600,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											WHERE   o.name = 'dm_os_sys_info'
 													AND c.name = 'physical_memory_in_bytes' )
 									BEGIN
+										
+										IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 84) WITH NOWAIT;
+										
 										SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 			SELECT  84 AS CheckID ,
 			250 AS Priority ,
@@ -5962,15 +6611,22 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 			'''' AS URL ,
 			''Logical processors: '' + CAST(cpu_count AS VARCHAR(50)) + ''. Physical memory: '' + CAST( CAST(ROUND((physical_memory_in_bytes / 1024.0 / 1024 / 1024), 1) AS INT) AS VARCHAR(50)) + ''GB.''
 			FROM sys.dm_os_sys_info OPTION (RECOMPILE);';
+										
+										IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+										IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+										
 										EXECUTE(@StringToExecute);
-									END
-							END
+									END;
+							END;
 
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 85 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 85) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -5995,14 +6651,17 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 																0) AS VARCHAR(100))
 												+ N'. AlwaysOn Mgr Status: '
 												+ CAST(COALESCE(SERVERPROPERTY('HadrManagerStatus'),
-																0) AS VARCHAR(100))
-							END
+																0) AS VARCHAR(100));
+							END;
 
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 88 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 88) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -6018,13 +6677,16 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												'' AS URL ,
 												CAST(create_date AS VARCHAR(100))
 										FROM    sys.databases
-										WHERE   database_id = 2
-							END
+										WHERE   database_id = 2;
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 91 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 91) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -6039,18 +6701,21 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												'Server Last Restart' AS Finding ,
 												'' AS URL ,
 												CAST(DATEADD(SECOND, (ms_ticks/1000)*(-1), GETDATE()) AS nvarchar(25))
-										FROM sys.dm_os_sys_info
-							END
+										FROM sys.dm_os_sys_info;
+							END;
 
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 92 )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 92) WITH NOWAIT;
+								
 								INSERT  INTO #driveInfo
 										( drive, SIZE )
-										EXEC master..xp_fixeddrives
-
+										EXEC master..xp_fixeddrives;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -6067,9 +6732,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												CAST(i.SIZE AS VARCHAR)
 												+ 'MB free on ' + i.drive
 												+ ' drive' AS Details
-										FROM    #driveInfo AS i
-								DROP TABLE #driveInfo
-							END
+										FROM    #driveInfo AS i;
+								DROP TABLE #driveInfo;
+							END;
 
 
 						IF NOT EXISTS ( SELECT  1
@@ -6081,6 +6746,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 										 WHERE  o.name = 'dm_os_sys_info'
 												AND c.name = 'virtual_machine_type_desc' )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 103) WITH NOWAIT;
+								
 								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									SELECT 103 AS CheckID,
 									250 AS Priority,
@@ -6090,8 +6758,12 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									''Type: ('' + virtual_machine_type_desc + '')'' AS Details
 									FROM sys.dm_os_sys_info
 									WHERE virtual_machine_type <> 0 OPTION (RECOMPILE);';
+								
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
 								EXECUTE(@StringToExecute);
-							END
+							END;
 
 						IF NOT EXISTS ( SELECT  1
 										FROM    #SkipChecks
@@ -6105,6 +6777,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 										 WHERE  o.name = 'dm_os_nodes'
                                 	 		AND c.name = 'processor_group' )
 							BEGIN
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 114) WITH NOWAIT;
+								
 								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 										SELECT  114 AS CheckID ,
 												250 AS Priority ,
@@ -6123,9 +6798,13 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 										AND dos.status = ''VISIBLE OFFLINE''
 										) oac
 										WHERE n.node_state_desc NOT LIKE ''%DAC%''
-										ORDER BY n.node_id OPTION (RECOMPILE);'
+										ORDER BY n.node_id OPTION (RECOMPILE);';
+								
+								IF @Debug = 2 AND @StringToExecute IS NOT NULL PRINT @StringToExecute;
+								IF @Debug = 2 AND @StringToExecute IS NULL PRINT '@StringToExecute has gone NULL, for some reason.';
+								
 								EXECUTE(@StringToExecute);
-							END
+							END;
 
 
 							IF NOT EXISTS ( SELECT  1
@@ -6135,6 +6814,8 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
                                 AND DATALENGTH( COALESCE( @base_tracefilename, '' ) ) > DATALENGTH('.TRC')
 							BEGIN
 
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 106) WITH NOWAIT;
+								
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -6154,8 +6835,8 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												+('. The default trace files are located in: '+left( @curr_tracefilename,len(@curr_tracefilename) - @indx)
 												) as Details
 										FROM    ::fn_trace_gettable( @base_tracefilename, default )
-										WHERE EventClass BETWEEN 65500 and 65600
-							END /* CheckID 106 */
+										WHERE EventClass BETWEEN 65500 and 65600;
+							END; /* CheckID 106 */
 
 
 							IF NOT EXISTS ( SELECT  1
@@ -6168,6 +6849,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											AND i.wait_type IS NULL)
 									BEGIN
 									/* Check for waits that have had more than 10% of the server's wait time */
+									
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 152) WITH NOWAIT;
+									
 									WITH os(wait_type, waiting_tasks_count, wait_time_ms, max_wait_time_ms, signal_wait_time_ms)
 									AS
 									(SELECT ws.wait_type, waiting_tasks_count, wait_time_ms, max_wait_time_ms, signal_wait_time_ms
@@ -6210,11 +6894,14 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 													ELSE 0 END AS NVARCHAR(40)) + N' ms average wait time.'
 											FROM    os
 											ORDER BY SUM(os.wait_time_ms / 1000.0 / 60 / 60) OVER (PARTITION BY os.wait_type) DESC;
-									END /* IF EXISTS (SELECT * FROM sys.dm_os_wait_stats WHERE wait_time_ms > 0 AND waiting_tasks_count > 0) */
+									END; /* IF EXISTS (SELECT * FROM sys.dm_os_wait_stats WHERE wait_time_ms > 0 AND waiting_tasks_count > 0) */
 
 								/* If no waits were found, add a note about that */
 								IF NOT EXISTS (SELECT * FROM #BlitzResults WHERE CheckID IN (107, 108, 109, 121, 152, 162))
 								BEGIN
+									
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 153) WITH NOWAIT;
+									
 									INSERT  INTO #BlitzResults
 											( CheckID ,
 											  Priority ,
@@ -6224,11 +6911,11 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											  Details
 											)
 										VALUES (153, 240, 'Wait Stats', 'No Significant Waits Detected', 'https://BrentOzar.com/go/waits', 'This server might be just sitting around idle, or someone may have cleared wait stats recently.');
-								END
-							END /* CheckID 152 */    
+								END;
+							END; /* CheckID 152 */    
 
-					END /* IF @CheckServerInfo = 1 */
-			END /* IF ( ( SERVERPROPERTY('ServerName') NOT IN ( SELECT ServerName */
+					END; /* IF @CheckServerInfo = 1 */
+			END; /* IF ( ( SERVERPROPERTY('ServerName') NOT IN ( SELECT ServerName */
 
 
 				/* Delete priorites they wanted to skip. */
@@ -6256,7 +6943,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 						DELETE r FROM #BlitzResults r
 							INNER JOIN #SkipChecks c ON r.DatabaseName = c.DatabaseName and r.CheckID = c.CheckID
 												  AND (ServerName IS NULL OR ServerName = SERVERPROPERTY('ServerName'));
-					END
+					END;
 
 				/* Add summary mode */
 				IF @SummaryMode > 0
@@ -6271,9 +6958,10 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 					  FROM #BlitzResults br
 					  WHERE EXISTS (SELECT * FROM #BlitzResults brLower WHERE br.FindingsGroup = brLower.FindingsGroup AND br.Finding = brLower.Finding AND br.Priority = brLower.Priority AND br.ID > brLower.ID);
 
-					END
+					END;
 
 			/* Add credits for the nice folks who put so much time into building and maintaining this for free: */
+				
 				INSERT  INTO #BlitzResults
 						( CheckID ,
 						  Priority ,
@@ -6326,6 +7014,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 						  
 				IF @EmailRecipients IS NOT NULL
 					BEGIN
+					
+					IF @Debug IN (1, 2) RAISERROR('Sending an email.', 0, 1) WITH NOWAIT;
+					
 					/* Database mail won't work off a local temp table. I'm not happy about this hacky workaround either. */
 					IF (OBJECT_ID('tempdb..##BlitzResults', 'U') IS NOT NULL) DROP TABLE ##BlitzResults;
 					SELECT * INTO ##BlitzResults FROM #BlitzResults;
@@ -6361,34 +7052,37 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 							@query_result_separator = @query_result_separator,
 							@query = @StringToExecute;
 					IF (OBJECT_ID('tempdb..##BlitzResults', 'U') IS NOT NULL) DROP TABLE ##BlitzResults;
-				END
+				END;
 
 				/* Checks if @OutputServerName is populated with a valid linked server, and that the database name specified is valid */
-				DECLARE @ValidOutputServer BIT
-				DECLARE @ValidOutputLocation BIT
-				DECLARE @LinkedServerDBCheck NVARCHAR(2000)
-				DECLARE @ValidLinkedServerDB INT
-				DECLARE @tmpdbchk table (cnt int)
+				DECLARE @ValidOutputServer BIT;
+				DECLARE @ValidOutputLocation BIT;
+				DECLARE @LinkedServerDBCheck NVARCHAR(2000);
+				DECLARE @ValidLinkedServerDB INT;
+				DECLARE @tmpdbchk table (cnt int);
 				IF @OutputServerName IS NOT NULL
 					BEGIN
+						
+						IF @Debug IN (1, 2) RAISERROR('Outputting to a remote server.', 0, 1) WITH NOWAIT;
+						
 						IF EXISTS (SELECT server_id FROM sys.servers WHERE QUOTENAME([name]) = @OutputServerName)
 							BEGIN
-								SET @LinkedServerDBCheck = 'SELECT 1 WHERE EXISTS (SELECT * FROM '+@OutputServerName+'.master.sys.databases WHERE QUOTENAME([name]) = '''+@OutputDatabaseName+''')'
-								INSERT INTO @tmpdbchk EXEC sys.sp_executesql @LinkedServerDBCheck
-								SET @ValidLinkedServerDB = (SELECT COUNT(*) FROM @tmpdbchk)
+								SET @LinkedServerDBCheck = 'SELECT 1 WHERE EXISTS (SELECT * FROM '+@OutputServerName+'.master.sys.databases WHERE QUOTENAME([name]) = '''+@OutputDatabaseName+''')';
+								INSERT INTO @tmpdbchk EXEC sys.sp_executesql @LinkedServerDBCheck;
+								SET @ValidLinkedServerDB = (SELECT COUNT(*) FROM @tmpdbchk);
 								IF (@ValidLinkedServerDB > 0)
 									BEGIN
-										SET @ValidOutputServer = 1
-										SET @ValidOutputLocation = 1
-									END
+										SET @ValidOutputServer = 1;
+										SET @ValidOutputLocation = 1;
+									END;
 								ELSE
-									RAISERROR('The specified database was not found on the output server', 16, 0)
-							END
+									RAISERROR('The specified database was not found on the output server', 16, 0);
+							END;
 						ELSE
 							BEGIN
-								RAISERROR('The specified output server was not found', 16, 0)
-							END
-					END
+								RAISERROR('The specified output server was not found', 16, 0);
+							END;
+					END;
 				ELSE
 					BEGIN
 						IF @OutputDatabaseName IS NOT NULL
@@ -6398,8 +7092,8 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								 FROM   sys.databases
 								 WHERE  QUOTENAME([name]) = @OutputDatabaseName)
 							BEGIN
-								SET @ValidOutputLocation = 1
-							END
+								SET @ValidOutputLocation = 1;
+							END;
 						ELSE IF @OutputDatabaseName IS NOT NULL
 							AND @OutputSchemaName IS NOT NULL
 							AND @OutputTableName IS NOT NULL
@@ -6407,13 +7101,13 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								 FROM   sys.databases
 								 WHERE  QUOTENAME([name]) = @OutputDatabaseName)
 							BEGIN
-								RAISERROR('The specified output database was not found on this server', 16, 0)
-							END
+								RAISERROR('The specified output database was not found on this server', 16, 0);
+							END;
 						ELSE
 							BEGIN
-								SET @ValidOutputLocation = 0 
-							END
-					END
+								SET @ValidOutputLocation = 0; 
+							END;
+					END;
 
 				/* @OutputTableName lets us export the results to a permanent table */
 				IF @ValidOutputLocation = 1
@@ -6443,18 +7137,18 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								QueryPlan [XML] NULL ,
 								QueryPlanFiltered [NVARCHAR](MAX) NULL,
 								CheckID INT ,
-								CONSTRAINT [PK_' + CAST(NEWID() AS CHAR(36)) + '] PRIMARY KEY CLUSTERED (ID ASC));'
+								CONSTRAINT [PK_' + CAST(NEWID() AS CHAR(36)) + '] PRIMARY KEY CLUSTERED (ID ASC));';
 						IF @ValidOutputServer = 1
 							BEGIN
-								SET @StringToExecute = REPLACE(@StringToExecute,''''+@OutputSchemaName+'''',''''''+@OutputSchemaName+'''''')
-								SET @StringToExecute = REPLACE(@StringToExecute,''''+@OutputTableName+'''',''''''+@OutputTableName+'''''')
-								SET @StringToExecute = REPLACE(@StringToExecute,'[XML]','[NVARCHAR](MAX)')
+								SET @StringToExecute = REPLACE(@StringToExecute,''''+@OutputSchemaName+'''',''''''+@OutputSchemaName+'''''');
+								SET @StringToExecute = REPLACE(@StringToExecute,''''+@OutputTableName+'''',''''''+@OutputTableName+'''''');
+								SET @StringToExecute = REPLACE(@StringToExecute,'[XML]','[NVARCHAR](MAX)');
 								EXEC('EXEC('''+@StringToExecute+''') AT ' + @OutputServerName);
-							END   
+							END;   
 						ELSE
 							BEGIN
 								EXEC(@StringToExecute);
-							END
+							END;
 						IF @ValidOutputServer = 1
 							BEGIN
 								SET @StringToExecute = N' IF EXISTS(SELECT * FROM '
@@ -6471,7 +7165,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								+ ''', SYSDATETIMEOFFSET(), CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details, CAST(QueryPlan AS NVARCHAR(MAX)), QueryPlanFiltered FROM #BlitzResults ORDER BY Priority , FindingsGroup , Finding , Details';
 
 								EXEC(@StringToExecute);
-							END   
+							END;   
 						ELSE
 							BEGIN
 								SET @StringToExecute = N' IF EXISTS(SELECT * FROM '
@@ -6486,14 +7180,14 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								+ ''', SYSDATETIMEOFFSET(), CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details, QueryPlan, QueryPlanFiltered FROM #BlitzResults ORDER BY Priority , FindingsGroup , Finding , Details';
 								
 								EXEC(@StringToExecute);
-							END
-					END
+							END;
+					END;
 				ELSE IF (SUBSTRING(@OutputTableName, 2, 2) = '##')
 					BEGIN
 						IF @ValidOutputServer = 1
 							BEGIN
-								RAISERROR('Due to the nature of temporary tables, outputting to a linked server requires a permanent table.', 16, 0)
-							END
+								RAISERROR('Due to the nature of temporary tables, outputting to a linked server requires a permanent table.', 16, 0);
+							END;
 						ELSE
 							BEGIN
 								SET @StringToExecute = N' IF (OBJECT_ID(''tempdb..'
@@ -6521,12 +7215,12 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									+ ''', SYSDATETIMEOFFSET(), CheckID, DatabaseName, Priority, FindingsGroup, Finding, URL, Details, QueryPlan, QueryPlanFiltered FROM #BlitzResults ORDER BY Priority , FindingsGroup , Finding , Details';
 							
 									EXEC(@StringToExecute);
-							END
-					END
+							END;
+					END;
 				ELSE IF (SUBSTRING(@OutputTableName, 2, 1) = '#')
 					BEGIN
-						RAISERROR('Due to the nature of Dymamic SQL, only global (i.e. double pound (##)) temp tables are supported for @OutputTableName', 16, 0)
-					END
+						RAISERROR('Due to the nature of Dymamic SQL, only global (i.e. double pound (##)) temp tables are supported for @OutputTableName', 16, 0);
+					END;
 
 
 				DECLARE @separator AS VARCHAR(1);
@@ -6538,8 +7232,8 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 				IF @OutputType = 'COUNT'
 					BEGIN
 						SELECT  COUNT(*) AS Warnings
-						FROM    #BlitzResults
-					END
+						FROM    #BlitzResults;
+					END;
 				ELSE
 					IF @OutputType IN ( 'CSV', 'RSV' )
 						BEGIN
@@ -6558,7 +7252,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									Finding ,
 									DatabaseName ,
 									Details;
-						END
+						END;
 					ELSE IF @OutputXMLasNVARCHAR = 1 AND @OutputType <> 'NONE'
 						BEGIN
 							SELECT  [Priority] ,
@@ -6576,7 +7270,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									Finding ,
 									DatabaseName ,
 									Details;
-						END
+						END;
 					ELSE IF @OutputType = 'MARKDOWN'
 						BEGIN
 							WITH Results AS (SELECT row_number() OVER (ORDER BY Priority, FindingsGroup, Finding, DatabaseName, Details) AS rownum, * 
@@ -6597,7 +7291,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 							  LEFT OUTER JOIN Results rPrior ON r.rownum = rPrior.rownum + 1
 							  LEFT OUTER JOIN Results rNext ON r.rownum = rNext.rownum - 1
 							ORDER BY r.rownum FOR XML PATH(N'');
-						END
+						END;
 					ELSE IF @OutputType <> 'NONE'
 						BEGIN
 							/* --TOURSTOP05-- */
@@ -6616,7 +7310,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									Finding ,
 									DatabaseName ,
 									Details;
-						END
+						END;
 
 				DROP TABLE #BlitzResults;
 
@@ -6669,9 +7363,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 							   WHEN 'EXECCOUNT' THEN execution_count
 							   WHEN 'DURATION' THEN total_elapsed_time
 							   ELSE total_worker_time
-							 END DESC
+							 END DESC;
 
-	END /* ELSE -- IF @OutputType = 'SCHEMA' */
+	END; /* ELSE -- IF @OutputType = 'SCHEMA' */
 
     SET NOCOUNT OFF;
 GO


### PR DESCRIPTION
Closes #1008

--Print only CheckIds
`EXEC dbo.sp_Blitz @CheckUserDatabaseObjects = 1, @CheckServerInfo = 1, @Debug = 1`

--Print CheckIds and any dynamic SQL used in a variable. Some of these are not printed because they're passed in as strings to MS_foreachdb.
`EXEC dbo.sp_Blitz @CheckUserDatabaseObjects = 1, @CheckServerInfo = 1, @Debug = 2`