### PR TITLE
sp_Blitz - Fix for #962 - Failure of sys.fn_trace_gettable

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -55,6 +55,7 @@ If you want to change anything about a check - the priority, finding, URL, or ID
 | 50 | Reliability | Remote Admin Connections Disabled | https://www.BrentOzar.com/go/dac | 100 |
 | 50 | Reliability | TempDB File Error | https://www.BrentOzar.com/go/tempdboops | 191 |
 | 50 | Reliability | Transaction Log Larger than Data File | https://www.BrentOzar.com/go/biglog | 75 |
+| 50 | Reliability | Default Trace File Error | https://BrentOzar.com/go/defaulttrace | 199 |
 | 100 | In-Memory OLTP (Hekaton) | Transaction Errors | https://www.BrentOzar.com/go/hekaton | 147 |
 | 100 | Features | Missing Features | https://www.BrentOzar.com/ | 189 |
 | 100 | Performance | Change Tracking Enabled | https://www.BrentOzar.com/go/tracking | 112 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3443,8 +3443,8 @@ AS
 								LoginName ,
 								DBUserName
 							)
-							SELECT
-								t.TextData ,
+							SELECT TOP 20000
+								CONVERT(NVARCHAR(4000),t.TextData) ,
 								t.DatabaseName ,
 								t.EventClass ,
 								t.Severity ,

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4447,6 +4447,7 @@ IF @ProductVersionMajor >= 10
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 199 )
+							AND @TraceFileIssue = 0
 					BEGIN
 						  
 						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 199) WITH NOWAIT
@@ -4482,6 +4483,7 @@ IF @ProductVersionMajor >= 10
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 200 )
+							AND @TraceFileIssue = 0
 					BEGIN
 						  
 						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 200) WITH NOWAIT
@@ -4512,6 +4514,7 @@ IF @ProductVersionMajor >= 10
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 201 )
+							AND @TraceFileIssue = 0
 					BEGIN
 						  
 						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 201) WITH NOWAIT
@@ -4542,6 +4545,7 @@ IF @ProductVersionMajor >= 10
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 202 )
+							AND @TraceFileIssue = 0
 					BEGIN
 						  
 						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 202) WITH NOWAIT
@@ -4572,6 +4576,7 @@ IF @ProductVersionMajor >= 10
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 203 )
+							AND @TraceFileIssue = 0
 					BEGIN
 						  
 						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 203) WITH NOWAIT
@@ -4601,6 +4606,7 @@ IF @ProductVersionMajor >= 10
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 204 )
+							AND @TraceFileIssue = 0
 					BEGIN
 						  
 						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 204) WITH NOWAIT

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3496,7 +3496,7 @@ AS
 								                Details
 								            )
 											SELECT
-												'' AS CheckID ,
+												'199' AS CheckID ,
 												'' AS DatabaseName ,
 												50 AS Priority ,
 												'Reliability' AS FindingsGroup ,

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -144,7 +144,8 @@ AS
 			,@NUMANodes int
 			,@MinServerMemory bigint
 			,@MaxServerMemory bigint
-			,@ColumnStoreIndexesInUse bit;
+			,@ColumnStoreIndexesInUse bit
+			,@TraceFileIssue bit;
 
 
 		SET @crlf = NCHAR(13) + NCHAR(10);
@@ -460,6 +461,25 @@ AS
 			  ProcessInfo NVARCHAR(20) ,
 			  [Text] NVARCHAR(1000) 
 			);
+
+		IF OBJECT_ID('tempdb..#fnTraceGettable') IS NOT NULL
+			DROP TABLE #fnTraceGettable;
+		CREATE TABLE #fnTraceGettable
+			(
+			  TextData NVARCHAR(4000) ,
+			  DatabaseName NVARCHAR(256) ,
+			  EventClass INT ,
+			  Severity INT ,
+			  StartTime DATETIME ,
+			  EndTime DATETIME ,
+			  Duration BIGINT ,
+			  NTUserName NVARCHAR(256) ,
+			  NTDomainName NVARCHAR(256) ,
+			  HostName NVARCHAR(256) ,
+			  ApplicationName NVARCHAR(256) ,
+			  LoginName NVARCHAR(256) ,
+			  DBUserName NVARCHAR(256)
+			 );
 
 		IF OBJECT_ID('tempdb..#IgnorableWaits') IS NOT NULL
 			DROP TABLE #IgnorableWaits;
@@ -3404,10 +3424,92 @@ AS
 
 
                         /* Reliability - Errors Logged Recently in the Default Trace */
-                        IF NOT EXISTS ( SELECT  1
+                        
+						/* First, let's check that there aren't any issues with the trace files */
+						BEGIN TRY
+						
+						INSERT INTO #fnTraceGettable
+							(	TextData ,
+								DatabaseName ,
+								EventClass ,
+								Severity ,
+								StartTime ,
+								EndTime ,
+								Duration ,
+								NTUserName ,
+								NTDomainName ,
+								HostName ,
+								ApplicationName ,
+								LoginName ,
+								DBUserName
+							)
+							SELECT
+								t.TextData ,
+								t.DatabaseName ,
+								t.EventClass ,
+								t.Severity ,
+								t.StartTime ,
+								t.EndTime ,
+								t.Duration ,
+								t.NTUserName ,
+								t.NTDomainName ,
+								t.HostName ,
+								t.ApplicationName ,
+								t.LoginName ,
+								t.DBUserName
+							FROM sys.fn_trace_gettable(@base_tracefilename, DEFAULT) t
+							WHERE
+							(
+								t.EventClass = 22
+								AND t.Severity >= 17
+								AND t.StartTime > DATEADD(dd, -30, GETDATE())
+							)
+							OR
+							(
+							    t.EventClass IN (92, 93)
+                                AND t.StartTime > DATEADD(dd, -30, GETDATE())
+                                AND t.Duration > 15000000
+							)
+							OR
+							(
+								t.EventClass IN (94, 95, 116)
+							)
+
+							SET @TraceFileIssue = 0
+
+						END TRY
+						BEGIN CATCH
+
+							SET @TraceFileIssue = 1
+						
+						END CATCH
+											
+						IF @TraceFileIssue = 1
+							BEGIN
+								INSERT  INTO #BlitzResults
+								            ( CheckID ,
+								                DatabaseName ,
+								                Priority ,
+								                FindingsGroup ,
+								                Finding ,
+								                URL ,
+								                Details
+								            )
+											SELECT
+												'' AS CheckID ,
+												'' AS DatabaseName ,
+												50 AS Priority ,
+												'Reliability' AS FindingsGroup ,
+												'There Is An Error With The Default Trace' AS Finding ,
+												'https://BrentOzar.com/go/defaulttrace' AS URL ,
+												'Somebody has been messing with your trace files. Check the files are present at ' + @base_tracefilename AS Details
+							END
+						
+						IF NOT EXISTS ( SELECT  1
 				                        FROM    #SkipChecks
 				                        WHERE   DatabaseName IS NULL AND CheckID = 150 )
                             AND @base_tracefilename IS NOT NULL
+							AND @TraceFileIssue = 0
 	                        BEGIN
 
 		                        IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 150) WITH NOWAIT;
@@ -3428,10 +3530,11 @@ AS
 						                        'Errors Logged Recently in the Default Trace' AS Finding ,
 						                        'https://BrentOzar.com/go/defaulttrace' AS URL ,
 						                         CAST(t.TextData AS NVARCHAR(4000)) AS Details
-                                        FROM    sys.fn_trace_gettable(@base_tracefilename, DEFAULT) t
+                                        FROM    #fnTraceGettable t
                                         WHERE t.EventClass = 22
-                                          AND t.Severity >= 17
-                                          AND t.StartTime > DATEADD(dd, -30, GETDATE());
+                                          /* Removed these as they're unnecessary, we filter this when inserting data into #fnTraceGettable */
+										  --AND t.Severity >= 17
+                                          --AND t.StartTime > DATEADD(dd, -30, GETDATE());
 	                        END;
 
 
@@ -3440,6 +3543,7 @@ AS
 				                        FROM    #SkipChecks
 				                        WHERE   DatabaseName IS NULL AND CheckID = 151 )
                             AND @base_tracefilename IS NOT NULL
+							AND @TraceFileIssue = 0
 	                        BEGIN
 		                        
 								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 151) WITH NOWAIT;
@@ -3460,10 +3564,11 @@ AS
 						                        'File Growths Slow' AS Finding ,
 						                        'https://BrentOzar.com/go/filegrowth' AS URL ,
 						                        CAST(COUNT(*) AS NVARCHAR(100)) + ' growths took more than 15 seconds each. Consider setting file autogrowth to a smaller increment.' AS Details
-                                        FROM    sys.fn_trace_gettable(@base_tracefilename, DEFAULT) t
+                                        FROM    #fnTraceGettable t
                                         WHERE t.EventClass IN (92, 93)
-                                          AND t.StartTime > DATEADD(dd, -30, GETDATE())
-                                          AND t.Duration > 15000000
+                                          /* Removed these as they're unnecessary, we filter this when inserting data into #fnTraceGettable */
+										  --AND t.StartTime > DATEADD(dd, -30, GETDATE())
+                                          --AND t.Duration > 15000000
                                         GROUP BY t.DatabaseName
                                         HAVING COUNT(*) > 1;
 	                        END;
@@ -4296,6 +4401,8 @@ IF @ProductVersionMajor >= 10
 /*Begin: checking default trace for odd DBCC activity*/
 		
 		--Grab relevant event data
+		IF @TraceFileIssue = 0
+		BEGIN
 		SELECT UPPER(
 					REPLACE(
 						SUBSTRING(CONVERT(NVARCHAR(MAX), t.TextData), 0, 
@@ -4331,9 +4438,10 @@ IF @ProductVersionMajor >= 10
 			t.LoginName [login_name], 
 			t.DBUserName AS [db_user_name]
 		 	INTO #dbcc_events_from_trace
-		    FROM sys.fn_trace_gettable( @base_tracefilename, DEFAULT) AS t
+		    FROM #fnTraceGettable AS t
 			WHERE t.EventClass = 116
-			OPTION(RECOMPILE);
+			OPTION(RECOMPILE)
+			END;
 
 			/*Overall count of DBCC events excluding silly stuff*/
 			IF NOT EXISTS ( SELECT  1
@@ -4528,6 +4636,7 @@ IF @ProductVersionMajor >= 10
 			IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 205 )
+						AND @TraceFileIssue = 0
 					BEGIN
 						  
 						  IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 205) WITH NOWAIT
@@ -4552,7 +4661,7 @@ IF @ProductVersionMajor >= 10
 														+ ' that lasted on average ' 
 															+ CONVERT(NVARCHAR(10), AVG(DATEDIFF(SECOND, t.StartTime, t.EndTime)))
 																+ ' seconds.' AS Details
-						FROM sys.fn_trace_gettable( @base_tracefilename, DEFAULT) AS t
+						FROM #fnTraceGettable AS t
 						WHERE t.EventClass IN (94, 95)
 						GROUP BY t.DatabaseName
 						HAVING AVG(DATEDIFF(SECOND, t.StartTime, t.EndTime)) > 5;


### PR DESCRIPTION
Fixes #962  .

Changes proposed in this pull request:
 - Added in a new temp table #fnTraceGettable so that we're not pulling data multiple times from sys.fn_trace_gettable
 - Also added @TraceFileIssue for error checking
 - Added a try/catch block to insert data into #fnTraceGettable from sys.fn_trace_gettable using default trace file. If this succeedes then set @TraceFileIssue = 0, if it fails set @TraceFileIssue = 1
 - Checks that used to use sys.fn_trace_gettable now use #fnTraceGettable.
 - Skip any checks that depend on #fnTraceGettable if @TraceFileIssue = 1
How to test this code:
 - On line 242 where we set @base_tracefilename, break the file name (e.g. change "+ '\log.trc' ;" to "+ '\log. trc' ;") by adding a space
 - Once that trace file name is broken then execute sp_Blitz, you should then get a new lvl 50 error for CheckID 199 that states there has been a problem with the log files.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance (12.0.5203.0 - SQL 2014 SP2-GDR Enterprise Edition)
 - SQL Server 2014 (Non Case-sensitive)
