### PR TITLE
#1043 sp_Blitz don't warn on SA-owned endpoints

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6022,7 +6022,7 @@ IF @ProductVersionMajor >= 10
                         ) AS [Details]
 					FROM sys.database_mirroring_endpoints ep
 					LEFT OUTER JOIN sys.dm_server_services s ON SUSER_NAME(ep.principal_id) = s.service_account
-					WHERE s.service_account IS NULL;
+					WHERE s.service_account IS NULL AND ep.principal_id <> 1;
     		END;
 
 		/*Check for the last good DBCC CHECKDB date */


### PR DESCRIPTION
I think principal_id should always be 1 for SA (even if they’ve renamed
SA.) Closes #1043.