### PR TITLE
fixed database name contains space character. e.g sharepoint databases

### DIFF
--- a/AGDatabaseRestoreOP.sql
+++ b/AGDatabaseRestoreOP.sql
@@ -1,0 +1,62 @@
+USE [master]
+GO
+
+/****** Object:  StoredProcedure [dbo].[AGDatabaseRestoreOP]    Script Date: 8/15/2017 7:15:08 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+--example
+--exec [dbo].[AGDatabaseRestoreOP] 'Db Name', '//sqlbackup/dev'
+
+CREATE procedure [dbo].[AGDatabaseRestoreOP](
+    @DbName NVARCHAR(4000),
+	@OlaBackupPath nvarchar(200)
+)
+AS
+BEGIN
+declare @AgName varchar(100)
+declare @ClusterName varchar(50)
+declare @FullPathForRestore nvarchar(max)
+
+select @ClusterName=cluster_name from sys.dm_hadr_cluster
+
+SELECT
+@AgName=AG.name 
+FROM master.sys.availability_groups AS AG
+LEFT OUTER JOIN master.sys.dm_hadr_availability_group_states as agstates   ON AG.group_id = agstates.group_id
+INNER JOIN master.sys.availability_replicas AS AR    ON AG.group_id = AR.group_id
+INNER JOIN master.sys.dm_hadr_availability_replica_states AS arstates   ON AR.replica_id = arstates.replica_id AND arstates.is_local = 1
+INNER JOIN master.sys.dm_hadr_database_replica_cluster_states AS dbcs   ON arstates.replica_id = dbcs.replica_id
+where dbcs.database_name=@DbName
+
+
+IF(RIGHT(@OlaBackupPath,1)<>'\')
+BEGIN
+	set @OlaBackupPath=@OlaBackupPath+'\';
+END
+
+set @FullPathForRestore = ''''+@OlaBackupPath+@ClusterName+'$'+@AgName+'\'+@DbName;
+
+Declare @str nvarchar(max)='
+EXEC dbo.DatabaseRestore 
+  @Database = '''+@DbName+''', 
+  @BackupPathFull = '+@FullPathForRestore+'\FULL\'', 
+  @BackupPathDiff = '+@FullPathForRestore+'\DIFF\'', 
+  @BackupPathLog = '+@FullPathForRestore+'\LOG\'', 
+  @RestoreDiff = 1,   @ContinueLogs = 0,   @RunRecovery = 0;'
+ 
+exec(@str)
+
+DECLARE @sql nvarchar(max)='ALTER DATABASE ['+@DbName+'] SET HADR AVAILABILITY GROUP = ['+@AgName+']'+CHAR(13);
+
+EXECUTE  [dbo].[CommandExecute] @Command = @sql, @CommandType = 'SET HADR AG', @Mode = 1, @DatabaseName = @DbName, @LogToTable = 'Y', @Execute = 'Y';
+
+
+END
+
+GO
+
+

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -498,7 +498,7 @@ IF @ContinueLogs = 0
 
 		RAISERROR('@ContinueLogs set to 0', 0, 1) WITH NOWAIT;
 	
-		SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @BackupPathFull + @LastFullBackup + N''' WITH NORECOVERY, REPLACE' + @MoveOption + NCHAR(13);
+		SET @sql = N'RESTORE DATABASE [' + @RestoreDatabaseName + N'] FROM DISK = ''' + @BackupPathFull + @LastFullBackup + N''' WITH NORECOVERY, REPLACE' + @MoveOption + NCHAR(13);
 		
 		IF @Debug = 1
 		BEGIN
@@ -623,7 +623,7 @@ WHERE BackupFile LIKE N'%.bak'
 
 IF @RestoreDiff = 1 AND @BackupDateTime < @LastDiffBackupDateTime
 	BEGIN
-		SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @BackupPathDiff + @LastDiffBackup + N''' WITH NORECOVERY' + NCHAR(13);
+		SET @sql = N'RESTORE DATABASE [' + @RestoreDatabaseName + N'] FROM DISK = ''' + @BackupPathDiff + @LastDiffBackup + N''' WITH NORECOVERY' + NCHAR(13);
 		
 		IF @Debug = 1
 		BEGIN
@@ -824,7 +824,7 @@ FETCH NEXT FROM BackupFiles INTO @BackupFile;
 
 				RAISERROR('@i set to 2, restoring logs', 0, 1) WITH NOWAIT;
 				
-				SET @sql = N'RESTORE LOG ' + @RestoreDatabaseName + N' FROM DISK = ''' + @BackupPathLog + @BackupFile + N''' WITH NORECOVERY' + NCHAR(13);
+				SET @sql = N'RESTORE LOG [' + @RestoreDatabaseName + N'] FROM DISK = ''' + @BackupPathLog + @BackupFile + N''' WITH NORECOVERY' + NCHAR(13);
 				
 					IF @Debug = 1
 					BEGIN


### PR DESCRIPTION
added [ and ] characters after restore command  e.g db name: PerformancePoint Service Application_cc66cddb06f04cfaaceb78ef22c92204

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB
