### PR TITLE
Support prefix or suffix database selection by pattern

### DIFF
--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -106,9 +106,9 @@ AS
                    THEN ' AND name NOT IN (' + @exlist + ')'
                    ELSE ''
               END + CASE WHEN @name_pattern <> N'%'
-                         THEN ' AND name LIKE N''%' + REPLACE(@name_pattern,
+                         THEN ' AND name LIKE N''' + REPLACE(@name_pattern,
                                                               '''', '''''')
-                              + '%'''
+                              + ''''
                          ELSE ''
                     END + CASE WHEN @dblist IS NOT NULL
                                THEN ' AND name IN (' + @dblist + ')'


### PR DESCRIPTION
Fixes #1077

Changes proposed in this pull request:
 - Don't automatically pre-pend and post-pend `%` to the supplied `@name_pattern` (and leave it to the user to decide)

How to test this code:
 - Install `sp_foreachdb`
 - Create databases with names `C12345`, `ABC12345`, and `C12345DEF`
 - Execute `sp_foreachdb` with a `@name_pattern` parameter `'C[0-9][0-9][0-9][0-9][0-9]'`
    + Verify only `C12345` is matched
 - Execute `sp_foreachdb` with a `@name_pattern` parameter `'C[0-9][0-9][0-9][0-9][0-9]%'`
    + Verify only `C12345`, and `C12345DEF` are matched
 - Execute `sp_foreachdb` with a `@name_pattern` parameter `'%C[0-9][0-9][0-9][0-9][0-9]'`
    + Verify only `C12345`, and `ABC12345` are matched
 - Execute `sp_foreachdb` without a `@name_pattern` parameter
    + Verify all three databases are matched
 - Drop the databases 😸 

Has been tested on:
 - SQL Server 2014
