### PR TITLE
#1005 sp_AllNightLog - make ChangeBackupType db-driven

### DIFF
--- a/sp_AllNightLog_Setup.sql
+++ b/sp_AllNightLog_Setup.sql
@@ -455,6 +455,9 @@ BEGIN
 															  VALUES (''all'', ''log backup path'', ''The path to which Log Backups should go.'', ''' + @BackupPath + ''');									
 									
 											INSERT dbo.backup_configuration (database_name, configuration_name, configuration_description, configuration_setting) 
+															  VALUES (''all'', ''change backup type'', ''For Ola Hallengren DatabaseBackup @ChangeBackupType param: Y = escalate to fulls, MSDB = escalate by checking msdb backup history.'', ''MSDB'');									
+									
+											INSERT dbo.backup_configuration (database_name, configuration_name, configuration_description, configuration_setting) 
 															  VALUES (''all'', ''encrypt'', ''For Ola Hallengren DatabaseBackup: Y = encrypt the backup. N (default) = do not encrypt.'', NULL);									
 									
 											INSERT dbo.backup_configuration (database_name, configuration_name, configuration_description, configuration_setting) 


### PR DESCRIPTION
By default, we now use DatabaseBackup.@ChangeBackupType = ‘MSDB’, which
does a full backup if one isn’t in msdb backup history. Closes #1005.