### PR TITLE
Read only databases incorrectly listed as not having had a DBCC CHECKDB - #1207

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6254,6 +6254,9 @@ IF @ProductVersionMajor >= 10
 																FROM
 																  #SkipChecks 
 																WHERE CheckID IS NULL OR CheckID = 68)
+											AND DB2.DbName NOT IN ( SELECT  name
+                                                                    FROM    sys.databases
+                                                                    WHERE   is_read_only = 1)
 											AND CONVERT(DATETIME, DB2.Value, 121) < DATEADD(DD,
 																  -14,
 																  CURRENT_TIMESTAMP);


### PR DESCRIPTION
Fixes #1207  .

Changes proposed in this pull request:
Updated 'Last good DBCC CHECKDB over 2 weeks old' to exclude read only databases.

How to test this code:
- Run against an instance that contains a read only database which has been in this state for > 2 weeks and check it doesn't appear on the list.
- Run against an instance that hasn't had a successful DBCC CHECKDB for at least 2 weeks, ensure it displays an error.

Has been tested on (remove any that don't apply):
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
