### PR TITLE
Issue 1208

### DIFF
--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -4423,6 +4423,14 @@ SELECT '#stored_proc_info' AS table_name, *
 FROM #stored_proc_info AS spi
 OPTION(RECOMPILE);
 
+SELECT '#conversion_info' AS table_name, *
+FROM #conversion_info AS ci
+OPTION ( RECOMPILE );
+
+SELECT '#variable_info' AS table_name, *
+FROM #variable_info AS vi
+OPTION ( RECOMPILE );
+
 END; 
 
 END TRY


### PR DESCRIPTION
Fixes #1159 and #1208 
This is a big rewrite of the implicit conversion section. I'm using a couple extra temp tables rather than trying to do everything across some CTEs. This makes debugging/troubleshooting easier, and also allows me to hit XML less, and use computed columns for the CHARINDEX calculations. I'm also doing the IC section and the cached parameter section across two updates, so that showing cached parameters for procs doesn't rely on there being implicit conversion in them.


How to test this code:
Can reference code from #1159 or write any statement/proc where implicit conversion is an issue.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016

Will test the rest in AWS