### PR TITLE
Check for wrong credentials

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -424,6 +424,18 @@ EXEC master.sys.xp_cmdshell @cmd;
 	
 		END
 
+	IF (
+		SELECT COUNT(*) 
+		FROM @FileList AS fl 
+		WHERE fl.BackupFile = 'The user name or password is incorrect.'
+		) = 1
+	
+		BEGIN
+	
+			RAISERROR('Incorrect user name or password for %s', 16, 1, @BackupPathFull) WITH NOWAIT;
+	
+		END;
+
 /*End folder sanity check*/
 
 -- Find latest full backup 


### PR DESCRIPTION
When running `xp_cmdshell` on a UNC path that requires a user name and password, you may get this return code if they'r wrong.

Fixes #1242

Changes proposed in this pull request:
Add a check to both procs for this returned text

How to test this code:
Map a path with an incorrect u/p and try to `dir` it.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016

Offloading checks to person facing the issue -- I don't think I have a good setup.
