### PR TITLE
Remove faulty where clause

### DIFF
--- a/sp_AllNightLog.sql
+++ b/sp_AllNightLog.sql
@@ -1163,7 +1163,6 @@ IF @Restore = 1
 												    rw.is_started = 0
 												AND rw.is_completed = 1
 												AND rw.last_log_restore_start_time < DATEADD(SECOND, (@rto * -1), GETDATE()) 
-                                                AND rw.error_number > 0 /* negative numbers indicate human attention required */
                                                 AND (rw.error_number IS NULL OR rw.error_number > 0) /* negative numbers indicate human attention required */
 											  )
 										OR    


### PR DESCRIPTION
Would make it look like there was nothing to restore if there were no errors.

Fixes #1243

Changes proposed in this pull request:
Remove where clause that prevented restores

How to test this code:
Hopefully you won't have to

Has been tested on (remove any that don't apply):
 - SQL Server 2016
 
Offloading testing to client facing issue.

