### PR TITLE
Add standby mode for log restores to sp_DatabaseRestore

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -18,6 +18,7 @@ ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
 	  @StandbyMode BIT = 0,
 	  @StandbyUndoPath NVARCHAR(MAX) = NULL,
 	  @RunRecovery BIT = 0, 
+	  @ForceSimpleRecovery BIT = 0,
 	  @StopAt NVARCHAR(14) = NULL,
 	  @OnlyLogsAfter NVARCHAR(14) = NULL,
 	  @Debug INT = 0, 
@@ -28,8 +29,8 @@ SET NOCOUNT ON;
 
 /*Versioning details*/
 	DECLARE @Version NVARCHAR(30);
-	SET @Version = '5.8';
-	SET @VersionDate = '20171001';
+	SET @Version = '5.9.5';
+	SET @VersionDate = '20171115';
 
 
 IF @Help = 1
@@ -339,6 +340,11 @@ IF (SELECT RIGHT(@BackupPathLog, 1)) <> '\' --Has to end in a '\'
 	END;
 
 /*Move Data File*/
+IF NULLIF(@MoveDataDrive, '') IS NULL
+	BEGIN
+		RAISERROR('Getting default data drive for @MoveDataDrive', 0, 1) WITH NOWAIT;
+		SET @MoveDataDrive = CAST(SERVERPROPERTY('InstanceDefaultDataPath') AS nvarchar(260));
+	END;
 IF (SELECT RIGHT(@MoveDataDrive, 1)) <> '\' --Has to end in a '\'
 	BEGIN
 		RAISERROR('Fixing @MoveDataDrive to add a "\"', 0, 1) WITH NOWAIT;
@@ -346,6 +352,11 @@ IF (SELECT RIGHT(@MoveDataDrive, 1)) <> '\' --Has to end in a '\'
 	END;
 
 /*Move Log File*/
+IF NULLIF(@MoveLogDrive, '') IS NULL
+	BEGIN
+		RAISERROR('Getting default log drive for @@MoveLogDrive', 0, 1) WITH NOWAIT;
+		SET @MoveLogDrive  = CAST(SERVERPROPERTY('InstanceDefaultLogPath') AS nvarchar(260));
+	END;
 IF (SELECT RIGHT(@MoveLogDrive, 1)) <> '\' --Has to end in a '\'
 	BEGIN
 		RAISERROR('Fixing @MoveDataDrive to add a "\"', 0, 1) WITH NOWAIT;
@@ -432,6 +443,18 @@ EXEC master.sys.xp_cmdshell @cmd;
 	
 		END
 
+	IF (
+		SELECT COUNT(*) 
+		FROM @FileList AS fl 
+		WHERE fl.BackupFile = 'The user name or password is incorrect.'
+		) = 1
+	
+		BEGIN
+	
+			RAISERROR('Incorrect user name or password for %s', 16, 1, @BackupPathFull) WITH NOWAIT;
+	
+		END;
+
 /*End folder sanity check*/
 
 -- Find latest full backup 
@@ -439,7 +462,9 @@ SELECT @LastFullBackup = MAX(BackupFile)
 FROM @FileList
 WHERE BackupFile LIKE N'%.bak'
     AND
-    BackupFile LIKE N'%' + @Database + N'%';
+    BackupFile LIKE N'%' + @Database + N'%'
+	AND
+	(@StopAt IS NULL OR REPLACE(LEFT(RIGHT(BackupFile, 19), 15),'_','') <= @StopAt);
 
 	IF @Debug = 1
 	BEGIN
@@ -657,7 +682,9 @@ SELECT @LastDiffBackup = MAX(BackupFile)
 FROM @FileList
 WHERE BackupFile LIKE N'%.bak'
     AND
-    BackupFile LIKE N'%' + @Database + '%';
+    BackupFile LIKE N'%' + @Database + '%'
+	AND
+	(@StopAt IS NULL OR REPLACE(LEFT(RIGHT(BackupFile, 19), 15),'_','') <= @StopAt);
 	
 	--set the @BackupDateTime so that it can be used for comparisons
 	SET @BackupDateTime = REPLACE(@BackupDateTime, '_', '');
@@ -931,7 +958,21 @@ IF @RunRecovery = 1
 		IF @Debug IN (0, 1)
 			EXECUTE sp_executesql @sql;
 	END;
-	    
+
+--- ensure simple recovery model
+IF @ForceSimpleRecovery = 1
+	BEGIN
+		SET @sql = N'ALTER DATABASE ' + @RestoreDatabaseName + N' SET RECOVERY SIMPLE' + NCHAR(13);
+
+			IF @Debug = 1
+			BEGIN
+				IF @sql IS NULL PRINT '@sql is NULL for SET RECOVERY SIMPLE: @RestoreDatabaseName';
+				PRINT @sql;
+			END; 
+
+		IF @Debug IN (0, 1)
+			EXECUTE sp_executesql @sql;
+	END;	    
 
  --Run checkdb against this database
 IF @RunCheckDB = 1

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -385,7 +385,7 @@ IF @BackupPathFull IS NOT NULL
 
 BEGIN
 
--- get list of files 
+-- Get list of files 
 SET @cmd = N'DIR /b "' + @BackupPathFull + N'"';
 
 			IF @Debug = 1
@@ -600,7 +600,7 @@ ELSE
 	
 	END;
 
---Clear out table variables for differential
+-- Clear out table variables for differential
 DELETE FROM @FileList;
 
 END
@@ -610,7 +610,7 @@ IF @BackupPathDiff IS NOT NULL
 
 BEGIN 
 
--- get list of files 
+-- Get list of files 
 SET @cmd = N'DIR /b "'+ @BackupPathDiff + N'"';
 
 	IF @Debug = 1
@@ -728,7 +728,7 @@ IF @RestoreDiff = 1 AND @BackupDateTime < @LastDiffBackupDateTime
 		WHERE BackupType = 5;                                                  
 	END;
 
---Clear out table variables for translogs
+-- Clear out table variables for translogs
 DELETE FROM @FileList;
    
  END      
@@ -817,7 +817,7 @@ END
 
 
 
---check for log backups
+-- Check for log backups
 IF(@StopAt IS NULL AND @OnlyLogsAfter IS NULL)
 	BEGIN 
 		DECLARE BackupFiles CURSOR FOR
@@ -944,7 +944,7 @@ DEALLOCATE BackupFiles;
 
 END
 
--- put database in a useable state 
+-- Put database in a useable state 
 IF @RunRecovery = 1
 	BEGIN
 		SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' WITH RECOVERY' + NCHAR(13);
@@ -959,7 +959,7 @@ IF @RunRecovery = 1
 			EXECUTE sp_executesql @sql;
 	END;
 
---- ensure simple recovery model
+-- Ensure simple recovery model
 IF @ForceSimpleRecovery = 1
 	BEGIN
 		SET @sql = N'ALTER DATABASE ' + @RestoreDatabaseName + N' SET RECOVERY SIMPLE' + NCHAR(13);
@@ -974,7 +974,7 @@ IF @ForceSimpleRecovery = 1
 			EXECUTE sp_executesql @sql;
 	END;	    
 
- --Run checkdb against this database
+ -- Run checkdb against this database
 IF @RunCheckDB = 1
 	BEGIN
 		SET @sql = N'EXECUTE [dbo].[DatabaseIntegrityCheck] @Databases = ' + @RestoreDatabaseName + N', @LogToTable = ''Y''' + NCHAR(13);
@@ -989,7 +989,7 @@ IF @RunCheckDB = 1
 			EXECUTE sys.sp_executesql @sql;
 	END;
 
- --If test restore then blow the database away (be careful)
+ -- If test restore then blow the database away (be careful)
 IF @TestRestore = 1
 	BEGIN
 		SET @sql = N'DROP DATABASE ' + @RestoreDatabaseName + NCHAR(13);
@@ -1004,4 +1004,6 @@ IF @TestRestore = 1
 			EXECUTE sp_executesql @sql;
 
 	END;
+
+GO
 


### PR DESCRIPTION
Changes proposed in this pull request:

The following parameters are used to restore databases in standby mode.

@StandbyMode = 1
@StandbyUndoPath = 'PathToWriteUndoFileTo'

How to test this code:

Generate a Full backup with Ola Hallengrens scripts. Restore that backup with the following:

EXEC dbo.sp_DatabaseRestore 
	@Database = ''LogShipMe'', 
	@BackupPathFull = ''\\StorageServer\LogShipMe\FULL\'', 
	@BackupPathLog = ''\\StorageServer\LogShipMe\LOG\'',
	@StandbyMode = 1,
	@StandbyUndoPath = ''D:\Data\'',
	@ContinueLogs = 0, 
	@RunRecovery = 0,
	@Debug = 0;

Generate some log backups with Ola Hallengrens scripts. Restore the log backups with:

EXEC dbo.sp_DatabaseRestore 
	@Database = ''LogShipMe'', 
	@BackupPathFull = ''\\StorageServer\LogShipMe\FULL\'', 
	@BackupPathLog = ''\\StorageServer\LogShipMe\LOG\'',
	@StandbyMode = 1,
	@StandbyUndoPath = ''D:\Data\'',
	@ContinueLogs = 1, 
	@RunRecovery = 0,
	@Debug = 0;

This should put the database in standby mode and allow reads.

The @ContinueLogs param needs to be 0 if the database you are restoring doesn't exists and 1 if it does.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
