### PR TITLE
1255 Add context_info to output of sp_BlitzWho

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -354,6 +354,7 @@ SELECT @StringToExecute = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 						END
 						+' 
 			            s.status ,
+                     CONVERT(VARCHAR(128), r.context_info)  AS [context_info],
 			            ISNULL(SUBSTRING(dest.text,
 			                             ( query_stats.statement_start_offset / 2 ) + 1,
 			                             ( ( CASE query_stats.statement_end_offset


### PR DESCRIPTION
Enhancement to add the context_info field to the output
of sp_BlitzWho.  Field is obtained from the sys.dm_exec_requests
view.  CONVERT(VARCHAR(128), r.context_info)  AS [context_info]
was added to line 357.

Tested on SQL Server 2014 and 2016.

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB
