### PR TITLE
Adds schema prefix

### DIFF
--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -1713,7 +1713,8 @@ RAISERROR(N'Collecting worker metrics', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 SELECT ' + QUOTENAME(@DatabaseName, '''') + N' AS database_name, wp.plan_id, wp.query_id,
-       object_name(qsq.object_id, DB_ID(' + QUOTENAME(@DatabaseName, '''') + N')) AS proc_or_function_name,
+       QUOTENAME(object_schema_name(qsq.object_id, DB_ID(' + QUOTENAME(@DatabaseName, '''') + N'))) + ''.'' +
+	   QUOTENAME(object_name(qsq.object_id, DB_ID(' + QUOTENAME(@DatabaseName, '''') + N'))) AS proc_or_function_name,
 	   qsq.batch_sql_handle, qsq.query_hash, qsq.query_parameterization_type_desc, qsq.count_compiles, 
 	   (qsq.avg_compile_duration / 1000.), 
 	   (qsq.last_compile_duration / 1000.), 


### PR DESCRIPTION
Also wraps schema and proc names in quotename because i like brackets

Fixes #1210 

Changes proposed in this pull request:
Adds schema prefix to proc name column

How to test this code:
Run BQS where it detects a stored proc and it should also correctly identify the schema.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016

BQS is 2016+ only
