### PR TITLE
#1255 Add context_info to output of sp_BlitzWho

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -230,7 +230,8 @@ SET @StringToExecute = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 			            r.start_time ,
 						r.percent_complete , 
 						wg.name AS workload_group_name , 
-						rp.name AS resource_pool_name
+						rp.name AS resource_pool_name ,
+						CONVERT(VARCHAR(128), r.context_info)  AS context_info
 			    FROM    sys.dm_exec_sessions AS s
 			    LEFT JOIN    sys.dm_exec_requests AS r
 			    ON      r.session_id = s.session_id
@@ -442,7 +443,8 @@ SELECT @StringToExecute = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 			            r.start_time ,
 						r.percent_complete , 
 						wg.name AS workload_group_name, 
-						rp.name AS resource_pool_name
+						rp.name AS resource_pool_name ,
+						CONVERT(VARCHAR(128), r.context_info)  AS context_info
 						FROM sys.dm_exec_sessions AS s
 						LEFT JOIN    sys.dm_exec_requests AS r
 									    ON      r.session_id = s.session_id


### PR DESCRIPTION
Fixes #1255 

Changes proposed in this pull request:
 - Add the context_info field from
   the sys.dm_exec_requests view.  Field added to the end of
   the SELECT clause to both version blocks.  Converted
   to VARCHAR from VARBINARY for readability.

How to test this code:
 - Run sp_BlitzWho with active processes in the database.
 - To facilitate this, you can run the following code block 
   which will run for 1 minute to allow for time to run
  sp_BlitzWho.  Also populates the CONTEXT_INFO value.
  BEGIN
     DECLARE @Context VARBINARY(128);
     SET @Context = CONVERT(VARBINARY(128), 'Testing changes for 1255');
     SET CONTEXT_INFO @Context;
     -- wait for 1 minute to allow testing sp_BlitzWho
     WAITFOR DELAY '00:01';  
  END
  

Has been tested on (remove any that don't apply):
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS

