### PR TITLE
#1295 sp_Blitz tells you to run sp_BlitzLock

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3260,7 +3260,7 @@ AS
 									URL,
 									Details)
 								SELECT 124, 150, 'Performance', 'Deadlocks Happening Daily', 'https://BrentOzar.com/go/deadlocks',
-									CAST(p.cntr_value AS NVARCHAR(100)) + ' deadlocks have been recorded since startup.' AS Details
+									CAST(p.cntr_value AS NVARCHAR(100)) + ' deadlocks recorded since startup. To find them, run sp_BlitzLock.' AS Details
 								FROM sys.dm_os_performance_counters p
 									INNER JOIN sys.databases d ON d.name = 'tempdb'
 								WHERE RTRIM(p.counter_name) = 'Number of Deadlocks/sec'


### PR DESCRIPTION
When deadlocks are recorded since startup. Closes #1295.