### PR TITLE
Issue 1294

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -545,10 +545,23 @@ SET @VersionDate = '20171201';
 		
 
 		/*Check 8 gives you stored proc deadlock counts*/
-
-		SELECT ds.id, ds.proc_name, ds.sql_handle
+		INSERT #deadlock_findings ( check_id, database_name, object_name, finding_group, finding )
+		SELECT 8 AS check_id,
+			   DB_NAME(dp.database_id) AS database_name,
+			   ds.proc_name, 
+			   'Stored Procedure Deadlocks',
+			   'The stored procedure ' 
+			   + PARSENAME(ds.proc_name, 2)
+			   + '.'
+			   + PARSENAME(ds.proc_name, 1)
+			   + ' has been involved in '
+			   + CONVERT(NVARCHAR(10), COUNT_BIG(DISTINCT ds.id))
+			   + ' deadlocks.'
 		FROM #deadlock_stack AS ds
+		JOIN #deadlock_process AS dp
+		ON dp.id = ds.id
 		WHERE ds.proc_name <> 'adhoc'
+		GROUP BY DB_NAME(dp.database_id), ds.proc_name
 		OPTION(RECOMPILE);
 
 

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -241,7 +241,7 @@ SET @VersionDate = '20171201';
 
 		/*Parse execution stack XML*/
         SELECT      dp.id,
-                    ca.dp.value('@procname', 'NVARCHAR(256)') AS proc_name,
+                    ca.dp.value('@procname', 'NVARCHAR(1000)') AS proc_name,
                     ca.dp.value('@sqlhandle', 'NVARCHAR(128)') AS sql_handle
         INTO        #deadlock_stack
         FROM        #deadlock_process AS dp


### PR DESCRIPTION
Fixes #1294 

Changes proposed in this pull request:
When we pull then out of XML, the length should be 1000 to be safe (db + schema + proc name)
When we give the more info query for BC, we need to remove db + schema
We should add a line for BQS to be fair
We should report on the number of times each stored proc has been involved in a deadlock

How to test this code:
 - Call proc on a server where stored procs are involved in deadlocks

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016

