### PR TITLE
#1318 - Make sp_foreachdb AG-aware

### DIFF
--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -7,13 +7,14 @@ GO
 
 ALTER PROCEDURE dbo.sp_foreachdb
     -- Original fields from sp_MSforeachdb...
-    @command1 NVARCHAR(MAX) ,
+    @command1 NVARCHAR(MAX) = NULL,
     @replacechar NCHAR(1) = N'?' ,
     @command2 NVARCHAR(MAX) = NULL ,
     @command3 NVARCHAR(MAX) = NULL ,
     @precommand NVARCHAR(MAX) = NULL ,
     @postcommand NVARCHAR(MAX) = NULL ,
     -- Additional fields for our sp_foreachdb!
+    @command NVARCHAR(MAX) = NULL,  --For backwards compatibility
     @print_dbname BIT = 0 ,
     @print_command_only BIT = 0 ,
     @suppress_quotename BIT = 0 ,
@@ -37,6 +38,14 @@ AS
 		SET @Version = '2.0';
 		SET @VersionDate = '20171201';
 
+        IF ( (@command1 IS NOT NULL AND @command IS NOT NULL)
+            OR (@command1 IS NULL AND @command IS NULL) )
+        BEGIN
+            RAISERROR('You must supply either @command1 or @command, but not both.',16,1);
+            RETURN -1;
+        END;
+
+        SET @command1 = COALESCE(@command1,@command);
 
         DECLARE @sql NVARCHAR(MAX) ,
             @dblist NVARCHAR(MAX) ,
@@ -104,55 +113,66 @@ AS
 
         CREATE TABLE #x ( db NVARCHAR(300) );
 
-        SET @sql = N'SELECT name FROM sys.databases WHERE 1=1'
-            + CASE WHEN @system_only = 1 THEN ' AND database_id IN (1,2,3,4)'
+        SET @sql = N'SELECT name FROM sys.databases d WHERE 1=1'
+            + CASE WHEN @system_only = 1 THEN ' AND d.database_id IN (1,2,3,4)'
                    ELSE ''
               END
             + CASE WHEN @user_only = 1
-                   THEN ' AND database_id NOT IN (1,2,3,4)'
+                   THEN ' AND d.database_id NOT IN (1,2,3,4)'
                    ELSE ''
               END
 -- To exclude databases from changes	
             + CASE WHEN @exlist IS NOT NULL
-                   THEN ' AND name NOT IN (' + @exlist + ')'
+                   THEN ' AND d.name NOT IN (' + @exlist + ')'
                    ELSE ''
               END + CASE WHEN @name_pattern <> N'%'
-                         THEN ' AND name LIKE N''' + REPLACE(@name_pattern,
+                         THEN ' AND d.name LIKE N''' + REPLACE(@name_pattern,
                                                               '''', '''''')
                               + ''''
                          ELSE ''
                     END + CASE WHEN @dblist IS NOT NULL
-                               THEN ' AND name IN (' + @dblist + ')'
+                               THEN ' AND d.name IN (' + @dblist + ')'
                                ELSE ''
                           END
             + CASE WHEN @recovery_model_desc IS NOT NULL
-                   THEN ' AND recovery_model_desc = N'''
+                   THEN ' AND d.recovery_model_desc = N'''
                         + @recovery_model_desc + ''''
                    ELSE ''
               END
             + CASE WHEN @compatibility_level IS NOT NULL
-                   THEN ' AND compatibility_level = '
+                   THEN ' AND d.compatibility_level = '
                         + RTRIM(@compatibility_level)
                    ELSE ''
               END
             + CASE WHEN @state_desc IS NOT NULL
-                   THEN ' AND state_desc = N''' + @state_desc + ''''
+                   THEN ' AND d.state_desc = N''' + @state_desc + ''''
                    ELSE ''
               END
+            + CASE WHEN @state_desc = 'ONLINE' AND SERVERPROPERTY('IsHadrEnabled') = 1
+                   THEN ' AND NOT EXISTS (SELECT 1 
+                                          FROM sys.dm_hadr_database_replica_states drs 
+                                          JOIN sys.availability_replicas ar
+                                                ON ar.replica_id = drs.replica_id
+                                          JOIN sys.dm_hadr_availability_group_states ags 
+                                                ON ags.group_id = ar.group_id
+                                          WHERE drs.database_id = d.database_id
+                                          AND ar.secondary_role_allow_connections = 0
+                                          AND ags.primary_replica <> @@SERVERNAME)'
+              END
             + CASE WHEN @is_read_only IS NOT NULL
-                   THEN ' AND is_read_only = ' + RTRIM(@is_read_only)
+                   THEN ' AND d.is_read_only = ' + RTRIM(@is_read_only)
                    ELSE ''
               END
             + CASE WHEN @is_auto_close_on IS NOT NULL
-                   THEN ' AND is_auto_close_on = ' + RTRIM(@is_auto_close_on)
+                   THEN ' AND d.is_auto_close_on = ' + RTRIM(@is_auto_close_on)
                    ELSE ''
               END
             + CASE WHEN @is_auto_shrink_on IS NOT NULL
-                   THEN ' AND is_auto_shrink_on = ' + RTRIM(@is_auto_shrink_on)
+                   THEN ' AND d.is_auto_shrink_on = ' + RTRIM(@is_auto_shrink_on)
                    ELSE ''
               END
             + CASE WHEN @is_broker_enabled IS NOT NULL
-                   THEN ' AND is_broker_enabled = ' + RTRIM(@is_broker_enabled)
+                   THEN ' AND d.is_broker_enabled = ' + RTRIM(@is_broker_enabled)
                    ELSE ''
               END;
 


### PR DESCRIPTION
Also sneak in fix for 1156 to maintain backwards compatibility of command params

Fixes #1318, #1156 

Changes proposed in this pull request:
 - #1318 - When using existing `@state_desc` check for ONLINE database, ignore AG secondaries that are not accessible. (Instances without AGs enabled will no nothing)
 - #1156 - Maintain `@command` in addition to `@command1` for backwards compatibility. Do some checking to make sure exactly 1 value is supplied

How to test this code:
 - On a secondary AG replica that is *not* enabled for data access, run something like:
```
EXEC sp_foreachdb @suppress_quotename = 1, @state_desc = 'ONLINE', @command = 'USE [?]; SELECT db_name();'
EXEC sp_foreachdb @suppress_quotename = 1, @state_desc = 'ONLINE', @command1 = 'USE [?]; SELECT db_name();'
```
- Confirm that both return identical results, and does not error on the non-readable secondary replicas.
- Run something like this, and confirm that errors occur if both or neither `@command` and `@command1` are supplied:
```
EXEC sp_foreachdb @suppress_quotename = 1, @state_desc = 'ONLINE', @command1 = 'USE [?]; SELECT db_name();', @command = 'USE [?]; SELECT db_name();';
EXEC sp_foreachdb @suppress_quotename = 1, @state_desc = 'ONLINE';
```

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - SQL Server 2017
