### PR TITLE
Fixes #1329

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3199,7 +3199,6 @@ WHERE NOT EXISTS
 	FROM   #stored_proc_info AS sp
 	WHERE (sp.proc_name = 'adhoc' AND sp.QueryHash = vi.QueryHash)
 	OR 	(sp.proc_name <> 'adhoc' AND sp.SqlHandle = vi.SqlHandle)
-	AND sp.variable_name = vi.variable_name 
 )
 OPTION ( RECOMPILE );
 
@@ -3221,7 +3220,9 @@ SET    s.variable_datatype = CASE WHEN s.variable_datatype LIKE '%(%)%' THEN
 													- CHARINDEX('(', s.compile_time_value)
 													)
 									WHEN variable_datatype NOT IN ('bit', 'tinyint', 'smallint', 'int', 'bigint') 
-										AND s.variable_datatype NOT LIKE '%binary%' THEN
+										AND s.variable_datatype NOT LIKE '%binary%' 
+										AND s.compile_time_value NOT LIKE 'N''%'''
+										AND s.compile_time_value NOT LIKE '''%''' THEN
 										QUOTENAME(compile_time_value, '''')
 									ELSE s.compile_time_value 
 							  END

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -3057,7 +3057,6 @@ IF EXISTS (   SELECT 1
 			FROM   #stored_proc_info AS sp
 			WHERE (sp.proc_name = 'adhoc' AND sp.query_hash = vi.query_hash)
 			OR 	(sp.proc_name <> 'adhoc' AND sp.sql_handle = vi.sql_handle)
-			AND sp.variable_name = vi.variable_name 
 		)
 		OPTION ( RECOMPILE );
 		
@@ -3078,9 +3077,11 @@ IF EXISTS (   SELECT 1
 															- CHARINDEX('(', s.compile_time_value)
 															)
 											WHEN variable_datatype NOT IN ('bit', 'tinyint', 'smallint', 'int', 'bigint') 
-											AND s.variable_datatype NOT LIKE '%binary%' THEN
-											QUOTENAME(compile_time_value, '''')
-									  ELSE s.compile_time_value 
+												AND s.variable_datatype NOT LIKE '%binary%' 
+												AND s.compile_time_value NOT LIKE 'N''%'''
+												AND s.compile_time_value NOT LIKE '''%''' THEN
+												QUOTENAME(compile_time_value, '''')
+									ELSE s.compile_time_value 
 									  END
 		FROM   #stored_proc_info AS s
 		OPTION(RECOMPILE);


### PR DESCRIPTION
Removes variable name predicates from NOT EXISTS clause.

Fixes #1329

Changes proposed in this pull request:
 - Stop matching on variable name, insert everything.

How to test this code:
 - Requires running in Debug mode to validate correct inserts.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
B
