### PR TITLE
spBlitzCache Error Updating Procs

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3206,7 +3206,7 @@ OPTION ( RECOMPILE );
 RAISERROR(N'Updating procs', 0, 1) WITH NOWAIT;
 UPDATE s
 SET    s.variable_datatype = CASE WHEN s.variable_datatype LIKE '%(%)%' THEN
-                                      LEFT(s.variable_datatype, CHARINDEX('(', s.variable_datatype) - 1)
+                                      LEFT(s.variable_datatype, CHARINDEX(N'(', s.variable_datatype) - 1)
 								  ELSE s.variable_datatype
                              END,
        s.converted_to = CASE WHEN s.converted_to LIKE '%(%)%' THEN


### PR DESCRIPTION
8152: String or binary data would be truncated.

Appears to be issue with CharIndex called with varchar and nvarchar columns.
https://connect.microsoft.com/SQLServer/feedback/details/537610/charindex-patindex-does-not-handle-nvarchar-max-or-varchar-max-correctly-generates-error-msg-8152-when-used-on-expression-1

If I re-load the dev branch of sp_BlitzCache the error comes back w/ my current cache.  It appears there is no data in #stored_proc_info when the procedure fails.


Changes proposed in this pull request:
 - Use same data type for finding CharIndex of s.variable_datatype


How to test this code:
 - I don't know exactly how to reproduce, just that it is happening in my environment at times, probably based on the stored procedures in cache.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2014
