### PR TITLE
Fixes checks for active and inactive heaps

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -5204,7 +5204,7 @@ IF @ProductVersionMajor >= 10
 		  INNER JOIN [?].sys.partitions p ON i.object_id = p.object_id AND i.index_id = p.index_id
 		  INNER JOIN sys.databases sd ON sd.name = ''?''
 		  LEFT OUTER JOIN [?].sys.dm_db_index_usage_stats ius ON i.object_id = ius.object_id AND i.index_id = ius.index_id AND ius.database_id = sd.database_id
-		  WHERE i.type_desc = ''HEAP'' AND COALESCE(ius.user_seeks, ius.user_scans, ius.user_lookups, ius.user_updates) IS NOT NULL
+		  WHERE i.type_desc = ''HEAP'' AND (ius.user_seeks > 0 OR ius.user_scans > 0 OR ius.user_lookups > 0 OR ius.user_updates > 0) 
 		  AND sd.name <> ''tempdb'' AND sd.name <> ''DWDiagnostics'' AND o.is_ms_shipped = 0 AND o.type <> ''S'' OPTION (RECOMPILE)';
 							END;
 
@@ -5262,7 +5262,7 @@ IF @ProductVersionMajor >= 10
 		  INNER JOIN [?].sys.partitions p ON i.object_id = p.object_id AND i.index_id = p.index_id
 		  INNER JOIN sys.databases sd ON sd.name = ''?''
 		  LEFT OUTER JOIN [?].sys.dm_db_index_usage_stats ius ON i.object_id = ius.object_id AND i.index_id = ius.index_id AND ius.database_id = sd.database_id
-		  WHERE i.type_desc = ''HEAP'' AND COALESCE(ius.user_seeks, ius.user_scans, ius.user_lookups, ius.user_updates) IS NULL
+		  WHERE i.type_desc = ''HEAP'' AND AND COALESCE(ius.user_seeks,0) = 0 AND COALESCE(ius.user_scans,0) = 0 AND COALESCE(ius.user_lookups,0) = 0 AND COALESCE(ius.user_updates,0) = 0 
 		  AND sd.name <> ''tempdb'' AND sd.name <> ''DWDiagnostics'' AND o.is_ms_shipped = 0 AND o.type <> ''S'' OPTION (RECOMPILE)';
 							END;
 

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -5262,7 +5262,7 @@ IF @ProductVersionMajor >= 10
 		  INNER JOIN [?].sys.partitions p ON i.object_id = p.object_id AND i.index_id = p.index_id
 		  INNER JOIN sys.databases sd ON sd.name = ''?''
 		  LEFT OUTER JOIN [?].sys.dm_db_index_usage_stats ius ON i.object_id = ius.object_id AND i.index_id = ius.index_id AND ius.database_id = sd.database_id
-		  WHERE i.type_desc = ''HEAP'' AND AND COALESCE(ius.user_seeks,0) = 0 AND COALESCE(ius.user_scans,0) = 0 AND COALESCE(ius.user_lookups,0) = 0 AND COALESCE(ius.user_updates,0) = 0 
+		  WHERE i.type_desc = ''HEAP'' AND COALESCE(ius.user_seeks,0) = 0 AND COALESCE(ius.user_scans,0) = 0 AND COALESCE(ius.user_lookups,0) = 0 AND COALESCE(ius.user_updates,0) = 0 
 		  AND sd.name <> ''tempdb'' AND sd.name <> ''DWDiagnostics'' AND o.is_ms_shipped = 0 AND o.type <> ''S'' OPTION (RECOMPILE)';
 							END;
 


### PR DESCRIPTION
Fixes checks for active and inactive heaps, checks 38, 39.

Changes proposed in this pull request:
The checks on the user columns of sys.dm_db_index_usage_stats checks for nulls however a row can exist due to a system scan. In this case the user columns are defaulted to zeros. This change correctly handles zeros. 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2016
