### PR TITLE
sp_Blitz - Check for Instance Stacking - Fixes #1382

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 211
-If you want to add a new one, start at 212
+CURRENT HIGH CHECKID: 212
+If you want to add a new one, start at 213
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -283,5 +283,6 @@ If you want to add a new one, start at 212
 | 250 | Server Info | Virtual Server | https://www.BrentOzar.com/go/virtual | 103 |
 | 250 | Server Info | Windows Version |  | 172 |
 | 250 | Server Info | Power Plan |  | 211 |
+| 250 | Server Info | Stacked Instances | https://www.brentozar.com/go/babygotstacked/ | 212 |
 | 254 | Rundate | (Current Date) |  | 156 |
 | 255 | Thanks! | From Your Community Volunteers |  | -1 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -520,6 +520,16 @@ AS
 			  LoginName NVARCHAR(256) ,
 			  DBUserName NVARCHAR(256)
 			 );
+        
+        
+		IF OBJECT_ID('tempdb..#Instances') IS NOT NULL
+			DROP TABLE #Instances;
+		CREATE TABLE #Instances
+            (
+              Instance_Number NVARCHAR(MAX) ,
+              Instance_Name NVARCHAR(MAX) ,
+              Data_Field NVARCHAR(MAX)
+            );
 
 		IF OBJECT_ID('tempdb..#IgnorableWaits') IS NOT NULL
 			DROP TABLE #IgnorableWaits;
@@ -7186,7 +7196,42 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								
 								END;
 
-							
+						IF NOT EXISTS ( SELECT  1
+										FROM    #SkipChecks
+										WHERE   DatabaseName IS NULL AND CheckID = 212 )
+								BEGIN																		
+								
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 212) WITH NOWAIT;
+
+						        INSERT INTO #Instances (Instance_Number, Instance_Name, Data_Field)
+								EXEC master.sys.xp_regread @rootkey = 'HKEY_LOCAL_MACHINE',
+								                           @key = 'SOFTWARE\Microsoft\Microsoft SQL Server',
+								                           @value_name = 'InstalledInstances'
+								
+                                IF (SELECT COUNT(*) FROM #Instances) > 1
+                                BEGIN
+
+                                    DECLARE @InstanceCount NVARCHAR(MAX)
+                                    SELECT @InstanceCount = COUNT(*) FROM #Instances
+                                                              
+									INSERT INTO #BlitzResults
+										( 
+                                          CheckID ,
+										  Priority ,
+										  FindingsGroup ,
+										  Finding ,
+										  URL ,
+										  Details
+										)							
+							        SELECT  
+                                        212 AS CheckId ,
+									    250 AS Priority ,
+									    'Server Info' AS FindingsGroup ,
+									    'Instance Stacking' AS Finding ,
+									    'https://www.brentozar.com/go/babygotstacked/' AS URL ,
+									    'Your Server has ' + @InstanceCount + ' Instances of SQL Server running. More than one is usually a bad idea. Read the URL for more info'
+							    END;
+	                        END;
 							
 							IF NOT EXISTS ( SELECT  1
 											FROM    #SkipChecks

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7216,7 +7216,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
                                                               
 									INSERT INTO #BlitzResults
 										( 
-                                          CheckID ,
+										  CheckID ,
 										  Priority ,
 										  FindingsGroup ,
 										  Finding ,
@@ -7224,7 +7224,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 										  Details
 										)							
 							        SELECT  
-                                        212 AS CheckId ,
+									    212 AS CheckId ,
 									    250 AS Priority ,
 									    'Server Info' AS FindingsGroup ,
 									    'Instance Stacking' AS Finding ,


### PR DESCRIPTION
Fixes #1382  .

Changes proposed in this pull request:
 - Added check 212 that checks for multiple instances of SQL Server running on one box
 - Updated documentation on sp_Blitz

How to test this code:
 - Install sp_Blitz on a machine with more than one instance of SQL Server running
 - EXEC sp_Blitz @CheckServerInfo = 1
 - You should see a priority 250 check for instance stacking

Has been tested on (remove any that don't apply):
 - SQL Server 2016 SP1 (13.0.4001.0) - it's the only one i could find with multiple instances
