### PR TITLE
Fix spill math

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1730,7 +1730,7 @@ SELECT @body += N'        ORDER BY ' +
                                  WHEN N'avg writes' THEN N'total_logical_writes / execution_count'
                                  WHEN N'avg duration' THEN N'total_elapsed_time / execution_count'
 								 WHEN N'avg memory grant' THEN N'CASE WHEN max_grant_kb = 0 THEN 0 ELSE max_grant_kb / execution_count END'
-                                 WHEN N'avg spills' THEN N'CASE WHEN max_spills = 0 THEN 0 ELSE max_spills / total_spills END'
+                                 WHEN N'avg spills' THEN N'CASE WHEN total_spills = 0 THEN 0 ELSE total_spills / execution_count END'
 								 WHEN N'avg executions' THEN 'CASE WHEN execution_count = 0 THEN 0
             WHEN COALESCE(CAST((CASE WHEN DATEDIFF(mi, cached_time, GETDATE()) > 0 AND execution_count > 1
                           THEN DATEDIFF(mi, cached_time, GETDATE())
@@ -1829,7 +1829,7 @@ SELECT TOP (@Top)
            min_spills AS MinSpills,
            max_spills AS MaxSpills,
            total_spills AS TotalSpills,
-		   CAST(ISNULL(NULLIF(( max_spills * 1. ), 0) / NULLIF(total_spills, 0), 0) AS MONEY) AS AvgSpills, ';
+		   CAST(ISNULL(NULLIF(( total_spills * 1. ), 0) / NULLIF(execution_count, 0), 0) AS MONEY) AS AvgSpills, ';
     END;
     ELSE
     BEGIN
@@ -1962,7 +1962,7 @@ BEGIN
            min_spills AS MinSpills,
            max_spills AS MaxSpills,
            total_spills AS TotalSpills,
-		   CAST(ISNULL(NULLIF(( max_spills * 1. ), 0) / NULLIF(total_spills, 0), 0) AS MONEY) AS AvgSpills, ';
+		   CAST(ISNULL(NULLIF(( total_spills * 1. ), 0) / NULLIF(execution_count, 0), 0) AS MONEY) AS AvgSpills,';
     END;
     ELSE
     BEGIN
@@ -2043,7 +2043,7 @@ BEGIN
            min_spills AS MinSpills,
            max_spills AS MaxSpills,
            total_spills AS TotalSpills,
-		   CAST(ISNULL(NULLIF(( max_spills * 1. ), 0) / NULLIF(total_spills, 0), 0) AS MONEY) AS AvgSpills, ', 
+		   CAST(ISNULL(NULLIF(( total_spills * 1. ), 0) / NULLIF(execution_count, 0), 0) AS MONEY) AS AvgSpills, ', 
 		   N'
            NULL AS MinSpills,
            NULL AS MaxSpills,
@@ -2110,7 +2110,7 @@ SELECT @sort = CASE @SortOrder  WHEN N'cpu' THEN N'total_worker_time'
                                 WHEN N'avg writes' THEN N'total_logical_writes / execution_count'
                                 WHEN N'avg duration' THEN N'total_elapsed_time / execution_count'
 								WHEN N'avg memory grant' THEN N'CASE WHEN max_grant_kb = 0 THEN 0 ELSE max_grant_kb / execution_count END'
-                                WHEN N'avg spills' THEN N'CASE WHEN max_spills = 0 THEN 0 ELSE max_spills / total_spills END'
+                                WHEN N'avg spills' THEN N'CASE WHEN total_spills = 0 THEN 0 ELSE total_spills / execution_count END'
                                 WHEN N'avg executions' THEN N'CASE WHEN execution_count = 0 THEN 0
             WHEN COALESCE(age_minutes, age_minutes_lifetime, 0) = 0 THEN 0
             ELSE CAST((1.00 * execution_count / COALESCE(age_minutes, age_minutes_lifetime)) AS money)


### PR DESCRIPTION
Closes #1380

Removes crack pipe.


Changes proposed in this pull request:
 - Fix spill math to divide total spills by executions
 - 
 - 

How to test this code:
 - Run on some spilly queries

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017

