### PR TITLE
Issue 1393 corrected name of default XE session

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4251,7 +4251,7 @@ IF @ProductVersionMajor >= 10
 													'Hey big spender, you have ' + CAST(COUNT_BIG(*) AS VARCHAR(30)) + ' Extended Events sessions running. You sure you meant to do that?' AS Details
 											    FROM sys.dm_xe_sessions
 												WHERE [name] NOT IN
-												( 'AlwaysOn_health', 'system_health', 'telemetry_xevents', 'sp_server_diagnostics', 'hkenginexesession' )
+												( 'AlwaysOn_health', 'system_health', 'telemetry_xevents', 'sp_server_diagnostics sessions', 'hkenginexesession' )
 												AND name NOT LIKE '%$A%'
 											  HAVING COUNT_BIG(*) >= 2; 
 								END;	


### PR DESCRIPTION
Fixes #1393  .

Changes proposed in this pull request:
 - correct name of default XE session

How to test this code:
 - start one XE session
 - verify single non-default XE session is running by executing` SELECT name FROM sys.dm_xe_sessions`
 - run sp_Blitz
 - look for CheckID 176 (it should not be there)
 - start one additional XE session
 - verify there are two XE sessions running
 - run sp_Blitz
 - verify that CheckId 176 is present with Priority 200

Has been tested on (remove any that don't apply):
 - SQL Server 2008 R2
 - SQL Server 2016
