### PR TITLE
Check for database with Unknown owners

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,8 @@ Why not just email your file to the maintainers? Well, lots of folks may be work
 2. If you cloned a while ago, get the latest changes from upstream:
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout dev
+   git pull upstream dev
    ```
 
 3. Create a new topic branch (off the main project development branch) to
@@ -76,23 +76,29 @@ Why not just email your file to the maintainers? Well, lots of folks may be work
    git checkout -b <topic-branch-name>
    ```
 
-4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines]
+4. Make changes.
+
+   Make changes to one or more of the files in the project.
+   If your change requires a new CheckId look here: https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/blob/dev/Documentation/sp_Blitz%20Checks%20by%20Priority.md.
+   You should modify the file `Documentation\sp_Blitz Checks by Priority.md` in the project by yourself.
+
+5. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines]
    or your code is unlikely be merged into the main project. Use Git's [interactive rebase]
    feature to tidy up your commits before making them public.
 
-5. Locally merge (or rebase) the upstream development branch into your topic branch:
+6. Locally merge (or rebase) the upstream development branch into your topic branch:
 
    ```bash
-   git pull [--rebase] upstream master
+   git pull [--rebase] upstream dev
    ```
 
-6. Push your topic branch up to your fork:
+7. Push your topic branch up to your fork:
 
    ```bash
    git push origin <topic-branch-name>
    ```
 
-7. [Open a Pull Request] with a clear title and description.
+8. [Open a Pull Request] with a clear title and description.
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to license your work under the MIT [LICENSE]
 

--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 212
-If you want to add a new one, start at 213
+CURRENT HIGH CHECKID: 213
+If you want to add a new one, start at 214
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -254,6 +254,7 @@ If you want to add a new one, start at 213
 | 210 | Non-Default Database Scoped Config | Query Optimizer Hotfixes | https://www.BrentOzar.com/go/dbscope | 197 |
 | 230 | Security | Control Server Permissions | https://www.BrentOzar.com/go/sa | 104 |
 | 230 | Security | Database Owner <> SA | https://www.BrentOzar.com/go/owndb | 55 |
+| 230 | Security | Database Owner is Unknown |  | 213 |
 | 230 | Security | Elevated Permissions on a Database | https://www.BrentOzar.com/go/elevated | 86 |
 | 230 | Security | Endpoints Owned by Users | https://www.BrentOzar.com/go/owners | 187 |
 | 230 | Security | Jobs Owned By Users | https://www.BrentOzar.com/go/owners | 6 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2682,6 +2682,37 @@ AS
 
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
+								WHERE   DatabaseName IS NULL AND CheckID = 213 )
+					BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 213) WITH NOWAIT;
+
+						INSERT  INTO #BlitzResults
+								( CheckID ,
+								  DatabaseName ,
+								  Priority ,
+								  FindingsGroup ,
+								  Finding ,
+								  URL ,
+								  Details
+								)
+								SELECT  213 AS CheckID ,
+										[name] AS DatabaseName ,
+										230 AS Priority ,
+										'Security' AS FindingsGroup ,
+										'Database Owner is Unknown' AS Finding ,
+										'' AS URL ,
+										( 'Database name: ' + [name] + '   '
+										  + 'Owner name: ' + ISNULL(SUSER_SNAME(owner_sid),'~~ UNKNOWN ~~') ) AS Details
+								FROM    sys.databases
+								WHERE   SUSER_SNAME(owner_sid) is NULL
+										AND name NOT IN ( SELECT DISTINCT DatabaseName
+														  FROM    #SkipChecks 
+														  WHERE CheckID IS NULL OR CheckID = 213);
+					END;
+
+				IF NOT EXISTS ( SELECT  1
+								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 57 )
 					BEGIN
 


### PR DESCRIPTION
Enhancement #1407.

Changes proposed in this pull request:
 - Check if the owner of a database is an existing user
Sometimes if you execute sp_helpdb you see databases which have no current database owner.
Mostly because the owner of the database was an administrator which has left the company, eg:

name | db_size | owner
--------- | --------- | ---------
dbname | 2284.13 MB | \~~ UNKNOWN ~~

This check reports those databases so you can give the database a proper owner like the 'sa' user.

How to test this code:
 - Create a new Windows account. 
 - Create a new SQL account for this Windows account. 
 - Create a test database with this SQL account as owner of the test database.
 - Delete the new SQL account.
 - Delete the new Windows account.
 - Execute sp_helpdb to see that the owner is Unknown.
 - Execute sp_blitz on this sql instance.

Has been tested on (remove any that don't apply):
 - SQL Server 2008 R2
 - SQL Server 2012
