### PR TITLE
sp_BlitzFirst - BlitzCache Ouput Table Checks - Fix #1412

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2475,11 +2475,12 @@ BEGIN
                 /* Get the most recent sp_BlitzCache execution before this one - don't use sp_BlitzFirst because user logs are added in there at any time */
                 SET @StringToExecute = N' IF EXISTS(SELECT * FROM '
                     + @OutputDatabaseName
-                    + '.INFORMATION_SCHEMA.SCHEMATA WHERE QUOTENAME(SCHEMA_NAME) = '''
-                    + @OutputSchemaName + ''') SELECT TOP 1 @BlitzCacheMinutesBack = DATEDIFF(MI,CheckDate,SYSDATETIMEOFFSET()) FROM '
+                    + '.INFORMATION_SCHEMA.TABLES WHERE QUOTENAME(TABLE_SCHEMA) = '''
+                    + @OutputSchemaName + ''' AND QUOTENAME(TABLE_NAME) = '''
+                    + QUOTENAME(@OutputTableNameBlitzCache) + ''') SELECT TOP 1 @BlitzCacheMinutesBack = DATEDIFF(MI,CheckDate,SYSDATETIMEOFFSET()) FROM '
                     + @OutputDatabaseName + '.'
                     + @OutputSchemaName + '.'
-                    + @OutputTableNameBlitzCache
+                    + QUOTENAME(@OutputTableNameBlitzCache)
                     + ' WHERE ServerName = ''' + CAST(SERVERPROPERTY('ServerName') AS NVARCHAR(128)) + ''' ORDER BY CheckDate DESC;';
                 EXEC sp_executesql @StringToExecute, N'@BlitzCacheMinutesBack INT OUTPUT', @BlitzCacheMinutesBack OUTPUT;
 
@@ -2512,7 +2513,7 @@ BEGIN
                     + @OutputSchemaName + ''') DELETE '
                     + @OutputDatabaseName + '.'
                     + @OutputSchemaName + '.'
-                    + @OutputTableNameBlitzCache
+                    + QUOTENAME(@OutputTableNameBlitzCache)
                     + ' WHERE ServerName = '''
                     + CAST(SERVERPROPERTY('ServerName') AS NVARCHAR(128))
                     + ''' AND CheckDate < ''' + CAST(CAST( (DATEADD(DAY, -1 * @OutputTableRetentionDays, GETDATE() ) ) AS DATE) AS NVARCHAR(20)) + ''';';


### PR DESCRIPTION
Fixes #1412 

Changes proposed in this pull request:
 - Use INFORMATION_SCHEMA.TABLES instead of INFORMATION_SCHEMA.SCHEMATA to check BlitzCache output table exists before querying it
 - Use QUOTENAME() on the table name when deleting BlitzCache history (this doesn't get applied to the variable as sp_BlitzCache applies it)

How to test this code:
 - In a clean database (or one where the specified BlitzCache table does not exist) run sp_BlitzFirst with output table parameters.
 - Specify a value for @outputtablenameblitzcache with non-standard characters (i.e. spaces - [Blitz Cache]

Has been tested on (remove any that don't apply):
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2016

NB: Second attempt at the pull request, branched from dev & merging to dev so hopefully this one looks ok.