### PR TITLE
Issue 1445

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -219,6 +219,7 @@ CREATE TABLE ##bou_BlitzCacheProcs (
 		is_big_spills BIT,
 		is_mstvf BIT,
 		is_mm_join BIT,
+        is_nonsargable BIT,
 		implicit_conversion_info XML,
 		cached_execution_parameters XML,
 		missing_indexes XML,
@@ -961,6 +962,7 @@ BEGIN
 		is_big_spills BIT,
 		is_mstvf BIT,
 		is_mm_join BIT,
+        is_nonsargable BIT,
 		implicit_conversion_info XML,
 		cached_execution_parameters XML,
 		missing_indexes XML,
@@ -3271,6 +3273,43 @@ ON ipwe.SqlHandle = b.SqlHandle
 WHERE b.SPID = @@SPID
 OPTION (RECOMPILE);
 
+RAISERROR(N'Checking for non-sargable predicates', 0, 1) WITH NOWAIT;
+WITH XMLNAMESPACES ( 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' AS p )
+, nsarg
+    AS (   SELECT       r.QueryHash, 1 AS fn, 0 AS jo, 0 AS lk
+           FROM         #relop AS r
+           CROSS APPLY  r.relop.nodes('/p:RelOp/p:IndexScan/p:Predicate/p:ScalarOperator/p:Compare/p:ScalarOperator') AS ca(x)
+           WHERE        (   ca.x.exist('//p:ScalarOperator/p:Intrinsic/@FunctionName') = 1
+                            OR     ca.x.exist('//p:ScalarOperator/p:IF') = 1 )
+           UNION ALL
+           SELECT       r.QueryHash, 0 AS fn, 1 AS jo, 0 AS lk
+           FROM         #relop AS r
+           CROSS APPLY  r.relop.nodes('/p:RelOp//p:ScalarOperator') AS ca(x)
+           WHERE        r.relop.exist('/p:RelOp[contains(@LogicalOp, "Join")]') = 1
+                        AND ca.x.exist('//p:ScalarOperator[contains(@ScalarString, "Expr")]') = 1
+           UNION ALL
+           SELECT       r.QueryHash, 0 AS fn, 0 AS jo, 1 AS lk
+           FROM         #relop AS r
+           CROSS APPLY  r.relop.nodes('/p:RelOp/p:IndexScan/p:Predicate/p:ScalarOperator') AS ca(x)
+           CROSS APPLY  ca.x.nodes('//p:Const') AS co(x)
+           WHERE        ca.x.exist('//p:ScalarOperator/p:Intrinsic/@FunctionName[.="like"]') = 1
+                        AND (   co.x.value('substring(@ConstValue, 2, 1)', 'VARCHAR(100)') = '%'
+                                OR co.x.value('substring(@ConstValue, 3, 1)', 'VARCHAR(100)') = '%' )),
+  d_nsarg
+    AS (   SELECT   DISTINCT
+                    nsarg.QueryHash
+           FROM     nsarg
+           WHERE    nsarg.fn = 1
+                    OR nsarg.jo = 1
+                    OR nsarg.lk = 1 )
+UPDATE  b
+SET     b.is_nonsargable = 1
+FROM    d_nsarg AS d
+JOIN    ##bou_BlitzCacheProcs AS b
+    ON b.QueryHash = d.QueryHash
+WHERE   b.SPID = @@SPID
+OPTION ( RECOMPILE );
+
 IF EXISTS ( SELECT 1 
 			FROM ##bou_BlitzCacheProcs AS bbcp 
 			WHERE bbcp.implicit_conversions = 1 
@@ -3904,7 +3943,8 @@ SET    Warnings = SUBSTRING(
 				  CASE WHEN is_row_goal = 1 THEN ', Row Goals' ELSE '' END + 
                   CASE WHEN is_big_spills = 1 THEN ', >500mb spills' ELSE '' END + 
 				  CASE WHEN is_mstvf = 1 THEN ', MSTVFs' ELSE '' END + 
-				  CASE WHEN is_mm_join = 1 THEN ', Many to Many Merge' ELSE '' END
+				  CASE WHEN is_mm_join = 1 THEN ', Many to Many Merge' ELSE '' END + 
+                  CASE WHEN is_nonsargable = 1 THEN ', non-SARGables' ELSE '' END
 				  , 2, 200000) 
 WHERE SPID = @@SPID
 OPTION (RECOMPILE);
@@ -3977,7 +4017,8 @@ SELECT  DISTINCT
 				  CASE WHEN is_row_goal = 1 THEN ', Row Goals' ELSE '' END + 
                   CASE WHEN is_big_spills = 1 THEN ', >500mb spills' ELSE '' END + 
 				  CASE WHEN is_mstvf = 1 THEN ', MSTVFs' ELSE '' END + 
-				  CASE WHEN is_mm_join = 1 THEN ', Many to Many Merge' ELSE '' END
+				  CASE WHEN is_mm_join = 1 THEN ', Many to Many Merge' ELSE '' END + 
+                  CASE WHEN is_nonsargable = 1 THEN ', non-SARGables' ELSE '' END
                   , 2, 200000) 
 FROM ##bou_BlitzCacheProcs b
 WHERE SPID = @@SPID
@@ -4447,7 +4488,8 @@ BEGIN
 				  CASE WHEN is_row_goal = 1 THEN '', 58'' ELSE '''' END + 
                   CASE WHEN is_big_spills = 1 THEN '', 59'' ELSE '''' END +
 				  CASE WHEN is_mstvf = 1 THEN '', 60'' ELSE '''' END + 
-				  CASE WHEN is_mm_join = 1 THEN '', 61'' ELSE '''' END
+				  CASE WHEN is_mm_join = 1 THEN '', 61'' ELSE '''' END  + 
+                  CASE WHEN is_nonsargable = 1 THEN '', 62'' ELSE '''' END
 				  , 2, 200000) AS opserver_warning , ' + @nl ;
     END;
     
@@ -5359,6 +5401,19 @@ BEGIN
                      100,
                      'Many to Many Merge',
                      'These use secret worktables that could be doing lots of reads',
+                     'link to blog post when published',
+					 'Occurs when join inputs aren''t known to be unique. Can be really bad when parallel.');	
+
+        IF EXISTS (SELECT 1/0
+                    FROM   ##bou_BlitzCacheProcs p
+                    WHERE  p.is_nonsargable = 1
+  					)
+             INSERT INTO ##bou_BlitzCacheResults (SPID, CheckID, Priority, FindingsGroup, Finding, URL, Details)
+             VALUES (@@SPID,
+                     62,
+                     50,
+                     'Non-SARGable queries',
+                     'Queries may be using',
                      'link to blog post when published',
 					 'Occurs when join inputs aren''t known to be unique. Can be really bad when parallel.');	
 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3293,8 +3293,10 @@ WITH XMLNAMESPACES ( 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' A
            CROSS APPLY  r.relop.nodes('/p:RelOp/p:IndexScan/p:Predicate/p:ScalarOperator') AS ca(x)
            CROSS APPLY  ca.x.nodes('//p:Const') AS co(x)
            WHERE        ca.x.exist('//p:ScalarOperator/p:Intrinsic/@FunctionName[.="like"]') = 1
-                        AND (   co.x.value('substring(@ConstValue, 2, 1)', 'VARCHAR(100)') = '%'
-                                OR co.x.value('substring(@ConstValue, 3, 1)', 'VARCHAR(100)') = '%' )),
+                        AND (   (   co.x.value('substring(@ConstValue, 1, 1)', 'VARCHAR(100)') <> 'N'
+                                    AND co.x.value('substring(@ConstValue, 2, 1)', 'VARCHAR(100)') = '%' )
+                                OR (   co.x.value('substring(@ConstValue, 1, 1)', 'VARCHAR(100)') = 'N'
+                                       AND co.x.value('substring(@ConstValue, 3, 1)', 'VARCHAR(100)') = '%' ))),
   d_nsarg
     AS (   SELECT   DISTINCT
                     nsarg.QueryHash

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -3053,8 +3053,10 @@ WITH XMLNAMESPACES ( 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' A
            CROSS APPLY  r.relop.nodes('/p:RelOp/p:IndexScan/p:Predicate/p:ScalarOperator') AS ca(x)
            CROSS APPLY  ca.x.nodes('//p:Const') AS co(x)
            WHERE        ca.x.exist('//p:ScalarOperator/p:Intrinsic/@FunctionName[.="like"]') = 1
-                        AND (   co.x.value('substring(@ConstValue, 2, 1)', 'VARCHAR(100)') = '%'
-                                OR co.x.value('substring(@ConstValue, 3, 1)', 'VARCHAR(100)') = '%' )),
+                        AND (   (   co.x.value('substring(@ConstValue, 1, 1)', 'VARCHAR(100)') <> 'N'
+                                    AND co.x.value('substring(@ConstValue, 2, 1)', 'VARCHAR(100)') = '%' )
+                                OR (   co.x.value('substring(@ConstValue, 1, 1)', 'VARCHAR(100)') = 'N'
+                                       AND co.x.value('substring(@ConstValue, 3, 1)', 'VARCHAR(100)') = '%' ))),
   d_nsarg
     AS (   SELECT   DISTINCT
                     nsarg.query_hash

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -616,6 +616,7 @@ CREATE TABLE #working_warnings
 	is_row_goal BIT,
 	is_mstvf BIT,
 	is_mm_join BIT,
+    is_nonsargable BIT,
 	implicit_conversion_info XML,
 	cached_execution_parameters XML,
 	missing_indexes XML,
@@ -3032,6 +3033,42 @@ JOIN is_paul_white_electric ipwe
 ON ipwe.sql_handle = b.sql_handle 
 OPTION (RECOMPILE);
 
+RAISERROR(N'Checking for non-sargable predicates', 0, 1) WITH NOWAIT;
+WITH XMLNAMESPACES ( 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' AS p )
+, nsarg
+    AS (   SELECT       r.query_hash, 1 AS fn, 0 AS jo, 0 AS lk
+           FROM         #relop AS r
+           CROSS APPLY  r.relop.nodes('/p:RelOp/p:IndexScan/p:Predicate/p:ScalarOperator/p:Compare/p:ScalarOperator') AS ca(x)
+           WHERE        (   ca.x.exist('//p:ScalarOperator/p:Intrinsic/@FunctionName') = 1
+                            OR     ca.x.exist('//p:ScalarOperator/p:IF') = 1 )
+           UNION ALL
+           SELECT       r.query_hash, 0 AS fn, 1 AS jo, 0 AS lk
+           FROM         #relop AS r
+           CROSS APPLY  r.relop.nodes('/p:RelOp//p:ScalarOperator') AS ca(x)
+           WHERE        r.relop.exist('/p:RelOp[contains(@LogicalOp, "Join")]') = 1
+                        AND ca.x.exist('//p:ScalarOperator[contains(@ScalarString, "Expr")]') = 1
+           UNION ALL
+           SELECT       r.query_hash, 0 AS fn, 0 AS jo, 1 AS lk
+           FROM         #relop AS r
+           CROSS APPLY  r.relop.nodes('/p:RelOp/p:IndexScan/p:Predicate/p:ScalarOperator') AS ca(x)
+           CROSS APPLY  ca.x.nodes('//p:Const') AS co(x)
+           WHERE        ca.x.exist('//p:ScalarOperator/p:Intrinsic/@FunctionName[.="like"]') = 1
+                        AND (   co.x.value('substring(@ConstValue, 2, 1)', 'VARCHAR(100)') = '%'
+                                OR co.x.value('substring(@ConstValue, 3, 1)', 'VARCHAR(100)') = '%' )),
+  d_nsarg
+    AS (   SELECT   DISTINCT
+                    nsarg.query_hash
+           FROM     nsarg
+           WHERE    nsarg.fn = 1
+                    OR nsarg.jo = 1
+                    OR nsarg.lk = 1 )
+UPDATE  b
+SET     b.is_nonsargable = 1
+FROM    d_nsarg AS d
+JOIN    #working_warnings AS b
+    ON b.query_hash = d.query_hash
+OPTION ( RECOMPILE );
+
 IF EXISTS (   SELECT 1
               FROM   #working_warnings AS ww
               WHERE  ww.implicit_conversions = 1
@@ -3527,7 +3564,8 @@ SET    b.warnings = SUBSTRING(
 				  CASE WHEN b.is_paul_white_electric = 1 THEN ', SWITCH!' ELSE '' END + 
 				  CASE WHEN b.is_row_goal = 1 THEN ', Row Goals' ELSE '' END + 
 				  CASE WHEN b.is_mstvf = 1 THEN ', MSTVFs' ELSE '' END + 
-				  CASE WHEN b.is_mm_join = 1 THEN ', Many to Many Merge' ELSE '' END
+				  CASE WHEN b.is_mm_join = 1 THEN ', Many to Many Merge' ELSE '' END + 
+                  CASE WHEN b.is_nonsargable = 1 THEN ', non-SARGables' ELSE '' END
                   , 2, 200000) 
 FROM #working_warnings b
 OPTION (RECOMPILE);
@@ -4535,6 +4573,18 @@ BEGIN
                      100,
                      'Many to Many Merge',
                      'These use secret worktables that could be doing lots of reads',
+                     'link to blog post when published',
+					 'Occurs when join inputs aren''t known to be unique. Can be really bad when parallel.');
+
+        IF EXISTS (SELECT 1/0
+                    FROM   #working_warnings p
+                    WHERE  p.is_nonsargable = 1
+  					)
+             INSERT INTO #warning_results (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+             VALUES (62,
+                     50,
+                     'Non-SARGable queries',
+                     'Queries may be using',
                      'link to blog post when published',
 					 'Occurs when join inputs aren''t known to be unique. Can be really bad when parallel.');
 					


### PR DESCRIPTION
Your mom

Fixes #1445

Changes proposed in this pull request:
 
New code will check plans for the following ickies:
- Where clauses that call an intrinsic (system) function, or contain an IF branch
- Joins that contain an expression [Expr____]
- LIKE operators that lead with a wildcard

How to test this code:
```
USE StackOverflow

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE LEN(u.DisplayName) > 30;
GO 

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE DATEDIFF(DAY, u.CreationDate, u.LastAccessDate) > 365;
GO 

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE DATEADD(DAY, 365, u.LastAccessDate) <= GETDATE();
GO 

DECLARE @i INT = 22656

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE u.Id = @i OR  @i IS NULL;

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE u.Id = COALESCE(@i, u.Id);

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE u.Id = ISNULL(@i, u.Id);
GO 

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE u.DisplayName LIKE '%keet%'
GO 

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE ISNUMERIC(u.Age) = 1
GO 

SELECT COUNT(*)
FROM dbo.Users AS u
WHERE ISNUMERIC(u.Age) = 1
GO 

SELECT COUNT_BIG(*)
FROM dbo.Users AS u
JOIN dbo.Users AS u2
ON u.Age = ISNULL(u2.Age, 0);
GO 

SELECT COUNT_BIG(*)
FROM dbo.Users AS u
JOIN dbo.Users AS u2
ON u.Age = ISNULL(u2.Age, 0)
OPTION(LOOP JOIN);
GO 

SELECT COUNT_BIG(*)
FROM dbo.Users AS u
JOIN dbo.Users AS u2
ON u.Age = ISNULL(u2.Age, 0)
OPTION (MERGE JOIN);
GO 
```

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017
