### PR TITLE
Widen table definition

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -177,7 +177,7 @@ IF OBJECT_ID('tempdb..#TemporalTables') IS NOT NULL
               finding VARCHAR(200) NOT NULL,
               [database_name] VARCHAR(200) NULL,
               URL VARCHAR(200) NOT NULL,
-              details NVARCHAR(4000) NOT NULL,
+              details NVARCHAR(MAX) NOT NULL,
               index_definition NVARCHAR(MAX) NOT NULL,
               secret_columns NVARCHAR(MAX) NULL,
               index_usage_summary NVARCHAR(MAX) NULL,


### PR DESCRIPTION
Makes the `details` column a MAX.

Fixes #1449

Changes proposed in this pull request:
 - Changes the details column to nvarchar(max) to get around longer computed column definitions. 


How to test this code:
 - write some absurdly long computed column definitions  

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017
