### PR TITLE
Added Cumulative Update value for CheckID 85

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6949,6 +6949,11 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												+ CAST(SERVERPROPERTY('productversion') AS NVARCHAR(100))
 												+ N'. Patch Level: '
 												+ CAST(SERVERPROPERTY('productlevel') AS NVARCHAR(100))
+								  				+ CASE WHEN SERVERPROPERTY('ProductUpdateLevel') IS NULL
+												       THEN N''
+												       ELSE N'. Cumulative Update: '
+													   + CAST(SERVERPROPERTY('ProductUpdateLevel') AS NVARCHAR(100))
+												END
 												+ N'. Edition: '
 												+ CAST(SERVERPROPERTY('edition') AS VARCHAR(100))
 												+ N'. AlwaysOn Enabled: '


### PR DESCRIPTION
SQL Server 2012 and higher has `SERVERPROPERTY('ProductUpdateLevel')`, and now that SQL Server 2017 doesn't use service packs anymore, it would be useful to know this value.

Changes proposed in this pull request:
 - Added `SERVERPROPERTY('ProductUpdateLevel')` to CheckID 85

Has been tested on (remove any that don't apply):
 - SQL Server 2017
