### PR TITLE
Update sp_DatabaseRestore for issue #1436

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -1014,7 +1014,7 @@ IF @RunRecovery = 1
 			END; 
 
 		IF @Debug IN (0, 1)
-			EXECUTE sp_executesql @sql;
+			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;
 
 -- Ensure simple recovery model
@@ -1029,7 +1029,7 @@ IF @ForceSimpleRecovery = 1
 			END; 
 
 		IF @Debug IN (0, 1)
-			EXECUTE sp_executesql @sql;
+			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'ALTER DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;	    
 
  -- Run checkdb against this database
@@ -1044,7 +1044,7 @@ IF @RunCheckDB = 1
 			END; 
 		
 		IF @Debug IN (0, 1)
-			EXECUTE sys.sp_executesql @sql;
+			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'INTEGRITY CHECK', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;
 
  -- If test restore then blow the database away (be careful)
@@ -1059,7 +1059,7 @@ IF @TestRestore = 1
 			END; 
 		
 		IF @Debug IN (0, 1)
-			EXECUTE sp_executesql @sql;
+			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'DROP DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 
 	END;
 


### PR DESCRIPTION
Changes proposed in this pull request:
Updates to sp_DatabaseRestore to make key statements execute through sp_CommandLog

How to test this code:
call sp_DatabaseRestore
Verify that all key restore statements are logged in the CommandLog table.

Has been tested on (remove any that don't apply):
SQL Server 2017