### PR TITLE
Fix sp_BlitzLock reports only 1 total deadlock for each object

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -373,7 +373,7 @@ SET @VersionDate = '20180301';
 			   dow.object_name AS object_name,
 			   'Total object deadlocks' AS finding_group,
 			   'This object was involved in ' 
-				+ CONVERT(NVARCHAR(20), COUNT_BIG(DISTINCT dow.object_name))
+				+ CONVERT(NVARCHAR(20), COUNT_BIG(DISTINCT dow.event_date))
 				+ ' deadlock(s).'
         FROM   #deadlock_owner_waiter AS dow
 		WHERE 1 = 1


### PR DESCRIPTION
Fixes #1469.

Changes proposed in this pull request:
 - Count the number of distinct `event_date` values for each object, rather than the name (which will always be 1?).

How to test this code:
 - See this sqlfiddle: http://sqlfiddle.com/#!18/e26d5/1

Has been tested on (remove any that don't apply):
 - SQL Server 2016
