### PR TITLE
#1466 sp_Blitz skip checkdb

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6202,7 +6202,9 @@ IF @ProductVersionMajor >= 10
 												Value ,
 												DbName
 									   FROM     #DBCCs
+                                       INNER JOIN sys.databases d ON #DBCCs.DbName = d.name
 									   WHERE    Field = 'dbi_dbccLastKnownGood'
+                                         AND d.create_date < DATEADD(dd, -14, GETDATE())
 									 )
 							INSERT  INTO #BlitzResults
 									( CheckID ,


### PR DESCRIPTION
For databases created in the last 2 weeks. Closes #1466.

Fixes # 1466.

Changes proposed in this pull request:
 - Check 68 (Last good DBCC CHECKDB over 2 weeks old) skips databases created in the last 2 weeks. This also includes newly restored databases.

How to test this code:
 - Create a database, and then run sp_Blitz. It should skip the priority 1 warning for "Last good DBCC CHECKDB over 2 weeks old" for that newly created db.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2017
