### PR TITLE
Add Repl-LogReader applicaiton_name

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4667,6 +4667,7 @@ IF @ProductVersionMajor >= 10
 			AND d.application_name NOT LIKE '%Spotlight Diagnostic Server%'
 			AND d.application_name NOT LIKE '%SQL Diagnostic Manager%'
 			AND d.application_name NOT LIKE '%Sentry%'
+			AND d.application_name NOT LIKE '%Repl-LogReader%'
 			
 
 			HAVING COUNT(*) > 0;


### PR DESCRIPTION
add %repl-logreader% applicaiton name to good dbcc checks for the replication setinstance, addinstance and incrementinstance dbcc commands. This removed oodles from the dbcc events count for one of our servers.

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
  - SQL Server 2017
 - Amazon RDS
 - Azure SQL DB
