### PR TITLE
Enhancement #1497

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4667,6 +4667,7 @@ IF @ProductVersionMajor >= 10
 			AND d.application_name NOT LIKE '%Spotlight Diagnostic Server%'
 			AND d.application_name NOT LIKE '%SQL Diagnostic Manager%'
 			AND d.application_name NOT LIKE '%Sentry%'
+			AND d.application_name NOT LIKE '%LiteSpeed%'
 			
 
 			HAVING COUNT(*) > 0;


### PR DESCRIPTION


Fixes # 1497 .

Changes proposed in this pull request:
 - Add the line to filter LiteSpeed DBCC PAGE commands from being returned in the DBCC Events findings group.

How to test this code:
 - Execute a Litespeed backup and execute sp_Blitz, Litespeed events should disappear.

Has been tested on (remove any that don't apply):

