### PR TITLE
Ignore DBCC AUTOPILOT

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4639,6 +4639,7 @@ IF @ProductVersionMajor >= 10
 			   command they're trying to run. See Github issues 1062, 1074, 1075.
 			*/
 			WHERE d.dbcc_event_full_upper NOT LIKE '%DBCC%ADDINSTANCE%'
+			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%AUTOPILOT%'
 			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%CHECKALLOC%'
 			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%CHECKCATALOG%'
 			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%CHECKCONSTRAINTS%'


### PR DESCRIPTION
Fixes #1494

Changes proposed in this pull request:
 - Add DBCC AUTOPILOT to the list of ignored dbcc types.

How to test this code:
 - Well, you could run some dbcc autopilot commands, or run DTA. Neither one sounds fun.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
  - SQL Server 2017

