### PR TITLE
Issue 1522 1525

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5597,7 +5597,7 @@ BEGIN
             URL,
             Details,
             CheckID
-    ORDER BY Priority ASC, CheckID ASC
+    ORDER BY Priority ASC, FindingsGroup, Finding, CheckID ASC
     OPTION (RECOMPILE);
 END;
 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -4917,7 +4917,7 @@ BEGIN
                 16,
                 100,
                 'Performance',
-                'Frequently executed operators',
+                'Busy Loops',
                 'http://brentozar.com/blitzcache/busy-loops/',
                 'Operations have been found that are executed 100 times more often than the number of rows returned by each iteration. This is an indicator that something is off in query execution.');
 


### PR DESCRIPTION
Fixes #1522 
Fixes #1525 

Changes proposed in this pull request:
 - Change warnings table ordering
 - Change wording for Busy Loops to match

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
  - SQL Server 2017
 - Amazon RDS
 - Azure SQL DB
