### PR TITLE
Issue 1543

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1986,7 +1986,7 @@ BEGIN
 		   NULL AS AvgMaxMemoryGrant, ' ;
     END;
 
-		IF @v >=15 OR (@v = 14 AND @build >= 3015)
+		IF @v >=15 OR (@v = 14 AND @build >= 3015) OR (@v = 13 AND @build >= 5026)
     BEGIN
         RAISERROR(N'Getting spill information for newer versions of SQL', 0, 1) WITH NOWAIT;
 		SET @sql += N'


### PR DESCRIPTION
Fixes #1543 

Changes proposed in this pull request:
 - 2016 SP2 back ported a bunch of query plan stuff, like tempdb spills, stats used, and row goals. BlitzCache will collect those now.

How to test this code:
 - Be on 2016 SP2 and have some query problems, yo.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017

