### PR TITLE
Add Joe's nonsense

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4559,6 +4559,14 @@ IF @ProductVersionMajor >= 10
 		         WHERE  is_online = 1
 		                AND scheduler_id < 255
 		                AND parent_node_id < 64
+						AND EXISTS (
+									SELECT 1
+									FROM ( SELECT    memory_node_id, SUM(online_scheduler_count) AS schedulers
+									       FROM      sys.dm_os_nodes
+									       WHERE     memory_node_id < 64
+									       GROUP  BY memory_node_id ) AS nodes
+										   HAVING MIN(nodes.schedulers) <> MAX(nodes.schedulers)
+									)
 		         GROUP BY parent_node_id,
 		                is_online
 		         HAVING ( COUNT(cpu_id) + 2 ) % 2 = 1;


### PR DESCRIPTION
Fixes #1474

Changes proposed in this pull request:
 - Adds code to make sure memory nodes are unbalanced. By itself, auto soft numa might split things into odd numbers of cores.

How to test this code:
 - Have a really weird server.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017

