### PR TITLE
Fix session name list

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4279,7 +4279,12 @@ IF @ProductVersionMajor >= 10
 													'Hey big spender, you have ' + CAST(COUNT_BIG(*) AS VARCHAR(30)) + ' Extended Events sessions running. You sure you meant to do that?' AS Details
 											    FROM sys.dm_xe_sessions
 												WHERE [name] NOT IN
-												( 'AlwaysOn_health', 'system_health', 'telemetry_xevents', 'sp_server_diagnostics', 'hkenginexesession' )
+												( 'AlwaysOn_health', 
+												  'system_health', 
+												  'telemetry_xevents', 
+												  'sp_server_diagnostics', 
+												  'sp_server_diagnostics session', 
+												  'hkenginexesession' )
 												AND name NOT LIKE '%$A%'
 											  HAVING COUNT_BIG(*) >= 2;
 								END;	


### PR DESCRIPTION
Closes #1552

Changes proposed in this pull request:
 - Add `'sp_server_diagnostics session'` to the list of ignored XE sessions. I'm keeping both permutations in there because I have a feeling both exist out in the world. 

How to test this code:
 - Run Blitz, see if it correctly ignores system XE sessions.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017

