### PR TITLE
Increase column length

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1238,7 +1238,7 @@ CREATE TABLE #stored_proc_info
 	converted_column_name NVARCHAR(258),
     compile_time_value NVARCHAR(258),
     proc_name NVARCHAR(1000),
-    column_name NVARCHAR(258),
+    column_name NVARCHAR(4000),
     converted_to NVARCHAR(258)
 );
 

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -787,7 +787,7 @@ CREATE TABLE #stored_proc_info
 	converted_column_name NVARCHAR(258),
     compile_time_value NVARCHAR(258),
     proc_name NVARCHAR(1000),
-    column_name NVARCHAR(258),
+    column_name NVARCHAR(4000),
     converted_to NVARCHAR(258)
 	INDEX tf_ix_ids CLUSTERED (sql_handle, query_hash)
 );


### PR DESCRIPTION
Fixes #1523

Changes proposed in this pull request:
 - Increase `column_name` length to 4000 to accommodate expressions.

How to test this code:
 - Have a WHERE clause with a CASE expression that causes implicit conversion.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017

