### PR TITLE
sp_Blitz AMD processor support

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7322,14 +7322,15 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								                           @value_name = 'ActivePowerScheme',
 								                           @value = @outval OUTPUT;
 
-								DECLARE @cpu_speed VARCHAR(256)
+								DECLARE @cpu_speed_mhz int,
+								        @cpu_speed_ghz decimal(18,2);
 								
 								EXEC master.sys.xp_regread @rootkey = 'HKEY_LOCAL_MACHINE',
 								                           @key = 'HARDWARE\DESCRIPTION\System\CentralProcessor\0',
-								                           @value_name = 'ProcessorNameString',
-								                           @value = @cpu_speed OUTPUT;
+								                           @value_name = '~MHz',
+								                           @value = @cpu_speed_mhz OUTPUT;
 								
-								SELECT @cpu_speed = SUBSTRING(@cpu_speed, CHARINDEX('@ ', @cpu_speed) + 1, LEN(@cpu_speed))
+								SELECT @cpu_speed_ghz = CAST(CAST(@cpu_speed_mhz AS DECIMAL) / 1000 AS DECIMAL(18,2));
 
 									INSERT  INTO #BlitzResults
 										( CheckID ,
@@ -7344,9 +7345,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									'Server Info' AS FindingsGroup,
 									'Power Plan' AS Finding,
 									'https://www.brentozar.com/blitz/power-mode/' AS URL,
-									'Your server has'
-									+ @cpu_speed
-									+ ' CPUs, and is in '
+									'Your server has '
+									+ CAST(@cpu_speed_ghz as VARCHAR(4))
+									+ 'GHz CPUs, and is in '
 									+ CASE @outval
 							             WHEN 'a1841308-3541-4fab-bc81-f71556f20b4a'
 							             THEN 'power saving mode -- are you sure this is a production SQL Server?'

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7355,7 +7355,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 							             THEN 'balanced power mode -- Uh... you want your CPUs to run at full speed, right?'
 							             WHEN '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
 							             THEN 'high performance power mode'
-										 ELSE 'Unknown!'
+										 ELSE 'an unknown power mode.'
 							        END AS Details
 								
 								END;


### PR DESCRIPTION
This ~MHz key seems to be more consistent (between manufacturers) than the ProcessorNameString key

Fixes #1560.

Changes proposed in this pull request:
 - Add a space (for formatting) to the output of the CPU check
 - Change registry key being read for processor speed from "ProcessorNameString" to "~MHz" in order for this check to display the right information for AMD processors as well as Intel
 - Slightly changed the phrasing of what's displayed when you're in an unknown (customized) power mode
    - I changed "...and is in Unknown!" to "...and is in an unknown power mode." just because I thought it read a little better.  I can change it back if needed

How to test this code:
 - run the updated sp_Blitz with the CheckServerInfo setting on PCs with both Intel and AMD processors
 - Verify the Power Plan check (CheckID 211) looks okay

I tested this on two PCs (one Intel and one AMD).  They happened to each be running SQL Server 2016.  I also tested on a SQL Server 2008R2 instance.  Since this isn't using an exotic features of SQL Server, that seems good.  But let me know if I need to do more testing.

**Results**

Intel PC before and after (Intel was being a bit generous in their rounding in the processor name):

    Your server has 3.00GHz CPUs, and is in Unknown!
    Your server has 2.99GHz CPUs, and is in an unknown power mode.

AMD PC before and after:

    Your server hasAMD Opteron(tm) Processor 6376 CPUs, and is in balanced power mode -- Uh... you want your CPUs to run at full speed, right?
    Your server has 2.30GHz CPUs, and is in balanced power mode -- Uh... you want your CPUs to run at full speed, right?