### PR TITLE
Filter out heaps from index deadlock results

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -444,7 +444,7 @@ SET @VersionDate = '20180501';
 		INSERT #deadlock_findings ( check_id, database_name, object_name, finding_group, finding ) 	
 		SELECT 2 AS check_id, 
 			   ISNULL(DB_NAME(dow.database_id), 'UNKNOWN') AS database_name, 
-			   ISNULL(dow.index_name, 'UNKNOWN') AS index_name,
+			   dow.index_name AS index_name,
 			   'Total index deadlocks' AS finding_group,
 			   'This index was involved in ' 
 				+ CONVERT(NVARCHAR(20), COUNT_BIG(DISTINCT dow.event_date))
@@ -455,6 +455,7 @@ SET @VersionDate = '20180501';
 		AND (dow.event_date >= @StartDate OR @StartDate IS NULL)
 		AND (dow.event_date < @EndDate OR @EndDate IS NULL)
 		AND (dow.object_name = @ObjectName OR @ObjectName IS NULL)
+		AND dow.index_name IS NOT NULL
 		GROUP BY DB_NAME(dow.database_id), dow.index_name
 		OPTION ( RECOMPILE );
 


### PR DESCRIPTION
Since they are already reported in the object deadlock results

Fixes #1569.

Changes proposed in this pull request:
 - As the issue mentioned, this filters out index deadlocks on heaps from the final results (check id 2)

How to test this code:
 - Run `sp_BlitzLock` on a system with object deadlocks on a heap
 - Observe that they are now filtered excluded from the final "index deadlock" results

Has been tested on (remove any that don't apply):
 - ~~Case-sensitive SQL Server instance~~
 - SQL Server 2012
 - ~~SQL Server 2014~~
 - SQL Server 2016
 - ~~SQL Server 2017~~
 - ~~Amazon RDS~~
 - ~~Azure SQL DB~~

Same deal here in terms of testing as on #1572 (since I was just updating a WHERE clause).  Here's a before and after from my system:

**Before:**  
![before](https://user-images.githubusercontent.com/13036637/39943162-df62532e-552f-11e8-9fe6-d429d8f8af7e.PNG)

**After:**  
![after](https://user-images.githubusercontent.com/13036637/39943167-e5d730b2-552f-11e8-9206-c4164747ef96.PNG)