### PR TITLE
#1583 sp_Blitz ignore dbcc useroptions

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4678,6 +4678,7 @@ IF @ProductVersionMajor >= 10
 			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%TRACEON%'
 			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%TRACEOFF%'
 			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%TRACESTATUS%'
+			AND d.dbcc_event_full_upper NOT LIKE '%DBCC%USEROPTIONS%'
 			AND d.application_name NOT LIKE 'Critical Care(R) Collector'
 			AND d.application_name NOT LIKE '%Red Gate Software Ltd SQL Prompt%'
 			AND d.application_name NOT LIKE '%Spotlight Diagnostic Server%'


### PR DESCRIPTION
Closes #1583.

Changes proposed in this pull request:
 - In checkid 203, added '%DBCC%USEROPTIONS%' to the list of ignored events. 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
  - SQL Server 2017