### PR TITLE
Fix hard coded value #1571

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -3218,7 +3218,7 @@ BEGIN
                 + '        SELECT ' + @LineFeed
                 + '                ROW_NUMBER() OVER (ORDER BY [CheckDate]) ID,' + @LineFeed
                 + '                [CheckDate]' + @LineFeed
-                + '        FROM [dbo].[BlitzFirst_WaitStats]' + @LineFeed
+                + '        FROM ' + @OutputSchemaName + '.' + @OutputTableNameWaitStats + @LineFeed
                 + '        GROUP BY [CheckDate]' + @LineFeed
                 + '),' + @LineFeed
                 + 'CheckDates as' + @LineFeed


### PR DESCRIPTION
Fixes #1571 

How to test this code:
A non-default-parameter call like this should not fail:

EXEC sp_BlitzFirst
 @OutputDatabaseName = 'DBAtools'
, @OutputSchemaName = 'testschema'
, @OutputTableName = 'Blist'
, @OutputTableNameFileStats = 'BlitzFirileStats'
, @OutputTableNamePerfmonStats = 'Blist_PerfmonStats'
, @OutputTableNameWaitStats = 'Blirst_WaitStats'
, @OutputTableNameBlitzCache = 'Blithe'



Has been tested on (remove any that don't apply):
 - SQL Server 2016
  - SQL Server 2017
