### PR TITLE
sp_Blitz Arithmetic overflow line 59

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -617,7 +617,9 @@ AS
 								'Wait Stats',
 								'Wait Stats Have Been Cleared',
 								'https://BrentOzar.com/go/waits',
-								'Someone ran DBCC SQLPERF to clear sys.dm_os_wait_stats at approximately: ' + CONVERT(NVARCHAR(100), DATEADD(ms, (-1 * @MsSinceWaitsCleared), GETDATE()), 120));
+								'Someone ran DBCC SQLPERF to clear sys.dm_os_wait_stats at approximately: ' 
+									+ CONVERT(NVARCHAR(100), 
+										DATEADD(MINUTE, (-1. * (@MsSinceWaitsCleared) / 1000. / 60.), GETDATE()), 120));
 			END;
 
 		/* @CpuMsSinceWaitsCleared is used for waits stats calculations */


### PR DESCRIPTION
Changes the time comparison to minutes to avoid arithmetic overflow in `DATEADD`

Fixes #1600

Changes proposed in this pull request:
 - Change `DATEADD` to:

`DATEADD(MINUTE, (-1. * (@MsSinceWaitsCleared) / 1000. / 60.), GETDATE())`


How to test this code:
 - Run this on a machine with a lot of uptime where stats were cleared a long time ago, or something?

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017

