### PR TITLE
Added graceful exit for unsupported SQL versions.

### DIFF
--- a/sp_BlitzInMemoryOLTP.sql
+++ b/sp_BlitzInMemoryOLTP.sql
@@ -1,4 +1,21 @@
-﻿
+﻿DECLARE @msg NVARCHAR(MAX) = N'';
+
+	-- Must be a compatible, on-prem version of SQL (2014+)
+IF  (	(SELECT SERVERPROPERTY ('EDITION')) <> 'SQL Azure' 
+	AND (SELECT PARSENAME(CONVERT(NVARCHAR(128), SERVERPROPERTY ('PRODUCTVERSION')), 4)) < 12
+	)
+	-- or Azure Database (not Azure Data Warehouse), running at database compat level 120+
+OR	(	(SELECT SERVERPROPERTY ('EDITION')) = 'SQL Azure'
+	AND (SELECT SERVERPROPERTY ('ENGINEEDITION')) = 5
+	AND (SELECT [compatibility_level] FROM sys.databases WHERE [name] = DB_NAME()) < 120
+	)
+BEGIN
+	SELECT @msg = N'Sorry, sp_BlitzInMemoryOLTP doesn''t work on versions of SQL prior to 2014.' + REPLICATE(CHAR(13), 7933);
+	PRINT @msg;
+	RETURN;
+END;
+
+
 IF OBJECT_ID('dbo.sp_BlitzInMemoryOLTP', 'P') IS NULL
 EXECUTE ('CREATE PROCEDURE dbo.sp_BlitzInMemoryOLTP AS SELECT 1;');
 GO
@@ -75,12 +92,6 @@ BEGIN TRY
     DECLARE @Version INT = CONVERT(INT, SERVERPROPERTY('ProductMajorVersion'));
 
     IF @debug = 1 PRINT('--@Version = ' + CAST(@Version AS VARCHAR(30)));
-
-    IF @Version < 12
-    BEGIN
-        SET @errorMessage = CONCAT('In-Memory OLTP is not supported if SQL Server version is less than 2014. You are running SQL Server version: ', @Version);
-        THROW 55000, @errorMessage, 1;
-    END;
 
     /*
     ###################################################
@@ -291,7 +302,7 @@ BEGIN TRY
        ,end_time DATETIME
        ,xtp_storage_percent DECIMAL(5, 2)
 
-    )
+    );
     
     CREATE TABLE #resultsContainerDetails 
     (
@@ -301,7 +312,7 @@ BEGIN TRY
         ,container_id BIGINT
         ,sizeMB NVARCHAR(256)
         ,fileCount INT 
-    )
+    );
 
     CREATE TABLE #resultsContainerFileDetails 
     (
@@ -315,7 +326,7 @@ BEGIN TRY
         ,sizeGB NVARCHAR(256) 
         ,fileCount INT 
         ,fileGroupState NVARCHAR(256)
-    )
+    );
 
     CREATE TABLE #resultsContainerFileSummary 
     (
@@ -327,7 +338,8 @@ BEGIN TRY
         ,sizeMB NVARCHAR(256)
         ,fileCount INT 
         ,fileGroupState NVARCHAR(256)
-    )
+    );
+
     IF OBJECT_ID('tempdb..#inmemDatabases') IS NOT NULL DROP TABLE #inmemDatabases;
     
     /*
@@ -1600,7 +1612,8 @@ BEGIN TRY
             IF @RunningOnAzureSQLDB = 1
             BEGIN 
 
-                DELETE @resultsxtp_storage_percent
+                DELETE @resultsxtp_storage_percent;
+
                 INSERT @resultsxtp_storage_percent
                 (
                     databaseName
@@ -1611,7 +1624,7 @@ BEGIN TRY
                       ,end_time
                       ,xtp_storage_percent
                 FROM sys.dm_db_resource_stats
-                WHERE xtp_storage_percent > 0
+                WHERE xtp_storage_percent > 0;
 
                 IF EXISTS(SELECT 1 FROM @resultsxtp_storage_percent)
                 BEGIN 
@@ -1621,7 +1634,7 @@ BEGIN TRY
                           ,xtp_storage_percent
                     FROM @resultsxtp_storage_percent
                     ORDER BY end_time DESC;
-                END
+                END;
 
                 SELECT DB_NAME() AS databaseName
                       ,DBScopedConfig = 'XTP_PROCEDURE_EXECUTION_STATISTICS enabled:'
@@ -1801,12 +1814,12 @@ BEGIN TRY
                     WHEN @InstancecollectionStatus = 1 THEN 'YES' 
                     ELSE 'NO'
                 END AS [instance-level collection of execution statistics for Native Modules enabled];
-        END
+        END;
         ELSE
         BEGIN 
             -- repeating this from the database section if we are running @instanceLevelOnly = 1
 
-                DELETE @resultsxtp_storage_percent
+                DELETE @resultsxtp_storage_percent;
 
                 INSERT @resultsxtp_storage_percent
                 (
@@ -1818,7 +1831,7 @@ BEGIN TRY
                       ,end_time
                       ,xtp_storage_percent
                 FROM sys.dm_db_resource_stats
-                WHERE xtp_storage_percent > 0
+                WHERE xtp_storage_percent > 0;
 
                 IF EXISTS(SELECT 1 FROM @resultsxtp_storage_percent)
                 BEGIN 
@@ -1828,7 +1841,7 @@ BEGIN TRY
                           ,xtp_storage_percent
                     FROM @resultsxtp_storage_percent
                     ORDER BY end_time DESC;
-                END
+                END;
 
             SELECT DB_NAME() AS databaseName
                   ,DBScopedConfig = 'XTP_PROCEDURE_EXECUTION_STATISTICS enabled:'


### PR DESCRIPTION
Fixes #1608 . 
Graceful exit for unsupported SQL versions.

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - EXEC sp_BlitzInMemoryOLTP
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
  - SQL Server 2017
 - Azure SQL DB
