### PR TITLE
Get Power Plan value from proper location in registry

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7324,12 +7324,19 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								
 								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 211) WITH NOWAIT;
 
-								DECLARE @outval VARCHAR(36);							
+								DECLARE @outval VARCHAR(36);
+								/* Get power plan if set by group policy [Git Hub Issue #1620] */						
+								EXEC master.sys.xp_regread @rootkey = 'HKEY_LOCAL_MACHINE',
+														   @key = 'SOFTWARE\Policies\Microsoft\Power\PowerSettings',
+														   @value_name = 'ActivePowerScheme',
+														   @value = @outval OUTPUT;
+
+								IF @outval IS NULL /* If power plan was not set by group policy, get local value [Git Hub Issue #1620]*/
 								EXEC master.sys.xp_regread @rootkey = 'HKEY_LOCAL_MACHINE',
 								                           @key = 'SYSTEM\CurrentControlSet\Control\Power\User\PowerSchemes',
 								                           @value_name = 'ActivePowerScheme',
 								                           @value = @outval OUTPUT;
-
+														   
 								DECLARE @cpu_speed_mhz int,
 								        @cpu_speed_ghz decimal(18,2);
 								


### PR DESCRIPTION
If Power Plan was set by group policy, the value is in a different registry key. Look for this one first.

Fixes #1620 .

Changes proposed in this pull request:
 - Grabs value from group policy registry location if it exists. Otherwise, grabs local.

GROUP POLICY LOCATION:
HKLM\SOFTWARE\Policies\Microsoft\Power\PowerSettings\ActivePowerScheme

LOCAL LOCATION:
HKLM\SYSTEM\CurrentControlSet\Control\Power\User\PowerSchemes\ActivePowerScheme

How to test this code:
 - Run against an instance that has a power plan of "high performance" set by GPO (Windows Group Policy), but "balanced" or "power saver" set locally. The fixed version will not tell you that you have a 'power saver' or 'balanced' plan when you have "high performance" set by GPO. 


Has been tested on (remove any that don't apply):
SQL 2008 - SQL 2017
