### PR TITLE
issue 1623 #fix

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -1388,7 +1388,8 @@ BEGIN
     AND     request_mode = N'S'
     AND     request_status = N'GRANT') AS db ON s.session_id = db.request_session_id
     CROSS APPLY sys.dm_exec_query_plan(r.plan_handle) pl
-    WHERE r.command LIKE 'RESTORE%';
+    WHERE r.command LIKE 'RESTORE%'
+    AND s.program_name <> 'SQL Server Log Shipping';
 
 
     /* SQL Server Internal Maintenance - Database File Growing - CheckID 4 */


### PR DESCRIPTION
Fixes #1623 

Changes proposed in this pull request:
- Added a WHERE clause to exclude Log Shipping Restore tasks from the procedure.

How to test this code:
 - Just run sp_blitzFirst.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance 
 - SQL Server 2008
 - SQL Server 2008 R2 - YES
 - SQL Server 2012 - YES
 - SQL Server 2014
 - SQL Server 2016
  - SQL Server 2017
 - Amazon RDS
 - Azure SQL DB
