### PR TITLE
Added use of CommandExecute for @ExistingDBAction actions

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -564,7 +564,7 @@ BEGIN
 			    PRINT @sql;
 		    END;
 		    IF @Debug IN (0, 1)
-			    EXECUTE sp_executesql @sql;
+                EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'ALTER DATABASE SINGLE_USER', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
         END
 
         IF @ExistingDBAction IN (2, 3)
@@ -586,7 +586,7 @@ BEGIN
 			    PRINT @sql;
 		    END;
             IF @Debug IN (0, 1)
-			    EXECUTE sp_executesql @sql;
+                EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'KILL', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
         END
 
         IF @ExistingDBAction = 3
@@ -600,7 +600,7 @@ BEGIN
 			    PRINT @sql;
 		    END;
 		    IF @Debug IN (0, 1)
-			    EXECUTE sp_executesql @sql;
+                EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'DROP DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
         END
 
     END


### PR DESCRIPTION
Fixes #1657

Changes proposed in this pull request:
- Call CommandExecute instead of dynamic SQL

How to test this code:
- Just run normally

Has been tested on (remove any that don't apply):
 - SQL Server 2016
