### PR TITLE
#1664 sp_Blitz ignore AllNightLog recompiles

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -5657,7 +5657,7 @@ IF @ProductVersionMajor >= 10
                                     URL = 'https://BrentOzar.com/go/recompile',
                                     Details = '[' + DBName + '].[' + SPSchema + '].[' + ProcName + '] has WITH RECOMPILE in the stored procedure code, which may cause increased CPU usage due to constant recompiles of the code.',
                                     CheckID = '78'
-                                FROM #Recompile AS TR WHERE ProcName NOT LIKE 'sp_AskBrent%' AND ProcName NOT LIKE 'sp_Blitz%';
+                                FROM #Recompile AS TR WHERE ProcName NOT LIKE 'sp_AllNightLog%' AND ProcName NOT LIKE 'sp_AskBrent%' AND ProcName NOT LIKE 'sp_Blitz%';
                                 DROP TABLE #Recompile;
                             END;
 


### PR DESCRIPTION
Being stealthy. Closes #1664.

Changes proposed in this pull request:
 - in check 78 (alerting on procs with recompile), ignore procs that start with sp_AllNightLog.

How to test this code:
 - Have sp_AllNightLog installed on a server, run the old sp_Blitz. It'll complain about the recompile. Then run it with this new code, and those warnings will be gone.