### PR TITLE
Fix @StandbyMode=1 (#1673)

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -908,7 +908,9 @@ IF (@StopAt IS NOT NULL AND @OnlyLogsAfter IS NULL)
 IF (@StandbyMode = 1)
 	BEGIN
 		IF (@StandbyUndoPath IS NULL)
-			IF @Execute = 'Y' OR @Debug = 1 RAISERROR('The file path of the undo file for standby mode was not specified. Logs will not be restored in standby mode.', 0, 1) WITH NOWAIT;
+			BEGIN
+				IF @Execute = 'Y' OR @Debug = 1 RAISERROR('The file path of the undo file for standby mode was not specified. Logs will not be restored in standby mode.', 0, 1) WITH NOWAIT;
+			END;
 		ELSE
 			SET @LogRecoveryOption = N'STANDBY = ''' + @StandbyUndoPath + @Database + 'Undo.ldf''';
 	END;


### PR DESCRIPTION
Fixes # 1673.

Changes proposed in this pull request:
 - Fix for @StandbyMode=1

How to test this code:
EXECUTE [DBADB].[dbo].[sp_DatabaseRestore]
@database = 'SOURCE',
@RestoreDatabaseName = 'DEST',
@BackupPathFull = '\BACKUP\SQL\BLA\FULL',
@BackupPathLog = '\BACKUP\SQL\BLA\LOG',
@MoveFiles = 1,
@MoveDataDrive = 'F:\SQLData',
@MoveLogDrive = 'G:\SQLLog',
@ContinueLogs = 1,
@RunRecovery = 0,
@StandbyMode = 1,
@StandbyUndoPath = 'G:\SQLLogship',
@ExistingDBAction = 2,
@debug = 1;

Has been tested on (remove any that don't apply):
  - SQL Server 2016

