### PR TITLE
#1680 sp_BlitzFirst skip server info

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -22,6 +22,7 @@ ALTER PROCEDURE [dbo].[sp_BlitzFirst]
     @OutputXMLasNVARCHAR TINYINT = 0 ,
     @FilterPlansByDatabase VARCHAR(MAX) = NULL ,
     @CheckProcedureCache TINYINT = 0 ,
+    @CheckServerInfo TINYINT = 1 ,
     @FileLatencyThresholdMS INT = 100 ,
     @SinceStartup TINYINT = 0 ,
     @ShowSleepingSPIDs TINYINT = 0 ,
@@ -2486,6 +2487,12 @@ BEGIN
                                         'http://FirstResponderKit.org/' AS URL ,
                                         'Some things get better with age, like fine wine and your T-SQL. However, sp_BlitzFirst is not one of those things - time to go download the current one.' AS Details;
                     END;
+
+    IF @CheckServerInfo = 0 /* Github #1680 */
+        BEGIN
+        DELETE #BlitzFirstResults
+          WHERE FindingsGroup = 'Server Info';
+        END
 
     RAISERROR('Analysis finished, outputting results',10,1) WITH NOWAIT;
 


### PR DESCRIPTION
If CheckServerInfo = 0. Closes #1680.

Changes proposed in this pull request:
 - Adds new @CheckServerInfo parameter, defaulting to 1 (to mimic existing proc behavior.)
 - Before returning results, if @CheckServerInfo = 0, delete #BlitzFirstResults table where FindingsGroup = 'Server Info'. (So no, it's not technically skipping the checks - but if someone wants to write a more robust way of doing this, they're welcome to.)

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
  - SQL Server 2017
