### PR TITLE
Add sp_Blitz's parameter @OutputType to sp_BlitzIndex and sp_BlitzFirst BIS

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -149,7 +149,14 @@ SELECT
     @StartSampleTime = SYSDATETIMEOFFSET(),
     @FinishSampleTime = DATEADD(ss, @Seconds, SYSDATETIMEOFFSET()),
 	@FinishSampleTimeWaitFor = DATEADD(ss, @Seconds, GETDATE()),
-    @OurSessionID = @@SPID;
+    @OurSessionID = @@SPID,
+    @OutputType                     = UPPER(@OutputType);
+
+IF(@OutputType = 'NONE' AND @ExpertMode = 0 AND (@OutputTableName IS NULL OR @OutputSchemaName IS NULL OR @OutputDatabaseName IS NULL))
+BEGIN
+    RAISERROR('This procedure should be called with a value for all @Output* parameters, as @OutputType is set to NONE',12,1);
+    RETURN;
+END;
 
 IF @LogMessage IS NOT NULL
     BEGIN
@@ -3504,7 +3511,7 @@ BEGIN
                     Finding,
                     Details;
         END;
-        ELSE IF @ExpertMode = 0 AND @OutputXMLasNVARCHAR = 0 AND @SinceStartup = 0
+        ELSE IF @ExpertMode = 0 AND @OutputType <> 'NONE' AND @OutputXMLasNVARCHAR = 0 AND @SinceStartup = 0
         BEGIN
             SELECT  [Priority] ,
                     [FindingsGroup] ,
@@ -3525,7 +3532,7 @@ BEGIN
                     Finding,
                     ID;
         END;
-        ELSE IF @ExpertMode = 0 AND @OutputXMLasNVARCHAR = 1 AND @SinceStartup = 0
+        ELSE IF @ExpertMode = 0 AND @OutputType <> 'NONE' AND @OutputXMLasNVARCHAR = 1 AND @SinceStartup = 0
         BEGIN
             SELECT  [Priority] ,
                     [FindingsGroup] ,

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -4408,7 +4408,7 @@ BEGIN;
 			END; /* @ValidOutputLocation = 1 */
 		ELSE
 	
-		if(@OutputType <> 'NONE')
+		IF(@OutputType <> 'NONE')
 		BEGIN
 			SELECT  i.[database_name] AS [Database Name], 
 					i.[schema_name] AS [Schema Name], 

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -4116,7 +4116,7 @@ BEGIN;
 					END;
 			END;
 																										
-        IF (@ValidOutputLocation = 0 @OutputType = 'NONE')
+        IF (@ValidOutputLocation = 0 AND @OutputType = 'NONE')
         BEGIN
             RAISERROR('Invalid output location and no output asked',12,1);
             RETURN;


### PR DESCRIPTION
Fixes # #1679

Changes proposed in this pull request:

    some tab to space adjustments
    some reformatting
    add a parameter @output parameter or the handling of a "NONE" value for this parameter

How to test this code:

    same as usual should give the same result as usual
    set @OutputType to NONE alone will make it fail
    set @OutputType to NONE with @OutputTableName to something will store the results to the output table

Has been tested on (remove any that don't apply):

    Case-sensitive SQL Server instance
    SQL Server 2014
