### PR TITLE
Update for sp_foreachdb.sql

### DIFF
--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -55,12 +55,24 @@ AS
 
         IF @database_list > N''
             BEGIN
+			CREATE TABLE #Number (N INT CONSTRAINT Number_FO3OPK PRIMARY KEY CLUSTERED(N)
+              ); 
+ 
+      		 WITH
+              L0   AS(SELECT 1 AS C UNION ALL SELECT 1 AS O), -- 2 rows
+              L1   AS(SELECT 1 AS C FROM L0 AS A CROSS JOIN L0 AS B), -- 4 rows
+              L2   AS(SELECT 1 AS C FROM L1 AS A CROSS JOIN L1 AS B), -- 16 rows
+              L3   AS(SELECT 1 AS C FROM L2 AS A CROSS JOIN L2 AS B), -- 256 rows
+              L4   AS(SELECT 1 AS C FROM L3 AS A CROSS JOIN L3 AS B), -- 65,536 rows
+              L5   AS(SELECT 1 AS C FROM L4 AS A CROSS JOIN L4 AS B), -- 4,294,967,296 rows
+              Nums AS(SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) AS N FROM L5)
+ 
+  		INSERT INTO #Number SELECT TOP 500000 N FROM Nums ORDER BY N									   
        ;
                 WITH    n ( n )
-                          AS ( SELECT   ROW_NUMBER() OVER ( ORDER BY s1.name )
-                                        - 1
-                               FROM     sys.objects AS s1
-                                        CROSS JOIN sys.objects AS s2
+                          AS (            SELECT ROW_NUMBER() OVER (ORDER BY N) - 1
+            								FROM  #Number
+
                              )
                     SELECT  @dblist = REPLACE(REPLACE(REPLACE(x, '</x><x>',
                                                               ','), '</x>', ''),


### PR DESCRIPTION
I have run into an issue where if I pass a @database_list longer than 18225 characters my query will not be run against all of the databases in the list even though the variable is an nvarchar(max).  Since SQL Server 2016 allows 32,767 databases I could see where this could happen to others.  I ran into the problem with 800 databases(not that I love having that many on one instance)  
There may be a better cleaner way to write this fix, but for me I ended up using Itzik Ben-Gan's auxillary table of numbers to create a temp table capping at 1/2 a million characters and referencing that table in the CTE versus using sysobjects the way it was before .  Perhaps you might want to increase the characters limit.

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 
--Have a lot of databases 
DECLARE @DBs nvarchar(max)
SELECT @DBs = ''

SELECT @DBs = @DBs +  Name + ',' 
FROM Sysdatabases WHERE name like 'DBPrefix-%'
AND status < 70000  --<--This means online

SELECT LEN(@DBs) --verify longer than say 19000 characters

EXEC dbo.sp_foreachdb 
 @user_only= 1, @database_list = @DBs,
@command =' SELECT GETDATE() AS dtm'

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2012
 - SQL Server 2016

