### PR TITLE
sp_BlitzWho now returns memory grant info for SQL 2017

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -322,6 +322,7 @@ SELECT @EnhanceFlag =
 	    CASE WHEN @ProductVersionMajor = 11 AND @ProductVersionMinor >= 6020 THEN 1
 		     WHEN @ProductVersionMajor = 12 AND @ProductVersionMinor >= 5000 THEN 1
 		     WHEN @ProductVersionMajor = 13 AND	@ProductVersionMinor >= 1601 THEN 1
+			 WHEN @ProductVersionMajor > 13 THEN 1
 		     ELSE 0 
 	    END
 


### PR DESCRIPTION
Fixes #1721 .

Changes proposed in this pull request:
 - Added SQL Server 2017 (and future SQL Server versions) to the list of versions that return memory grant info.  No SP or CU level required.

How to test this code:
 - Run this on SQL Server 2017 and make sure memory grant information is properly returned

Has been tested on:
 - SQL Server 2016
 - SQL Server 2017
