### PR TITLE
sp_Blitz typo in MSDB table check

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2076,7 +2076,7 @@ AS
 								  Details
 								)
 								SELECT  29 AS CheckID ,
-								        'msdb' AS DatabaseName ,
+								        'model' AS DatabaseName ,
 										200 AS Priority ,
 										'Informational' AS FindingsGroup ,
 										'Tables in the Model Database' AS Finding ,


### PR DESCRIPTION
Fixing typo in "Tables in MSDB" check, closes #1719.