### PR TITLE
Actually use the ignore_database field.

### DIFF
--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -1173,7 +1173,7 @@ IF @Restore = 1
 											  	AND rw.last_log_restore_finish_time = '9999-12-31 00:00:00.000'
                                                 AND (rw.error_number IS NULL OR rw.error_number > 0) /* negative numbers indicate human attention required */
 											  )
-											  AND rw.ignore_database = 0
+										AND rw.ignore_database = 0
 										ORDER BY rw.last_log_restore_start_time ASC, rw.last_log_restore_finish_time ASC, rw.database_name ASC;
 	
 								

--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -1173,7 +1173,7 @@ IF @Restore = 1
 											  	AND rw.last_log_restore_finish_time = '9999-12-31 00:00:00.000'
                                                 AND (rw.error_number IS NULL OR rw.error_number > 0) /* negative numbers indicate human attention required */
 											  )
-											  AND rw.ignore_database = 1
+											  AND rw.ignore_database = 0
 										ORDER BY rw.last_log_restore_start_time ASC, rw.last_log_restore_finish_time ASC, rw.database_name ASC;
 	
 								

--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -1173,6 +1173,7 @@ IF @Restore = 1
 											  	AND rw.last_log_restore_finish_time = '9999-12-31 00:00:00.000'
                                                 AND (rw.error_number IS NULL OR rw.error_number > 0) /* negative numbers indicate human attention required */
 											  )
+											  AND rw.ignore_database = 1
 										ORDER BY rw.last_log_restore_start_time ASC, rw.last_log_restore_finish_time ASC, rw.database_name ASC;
 	
 								

--- a/sp_AllNightLog.sql
+++ b/sp_AllNightLog.sql
@@ -1173,6 +1173,7 @@ IF @Restore = 1
 											  	AND rw.last_log_restore_finish_time = '9999-12-31 00:00:00.000'
                                                 AND (rw.error_number IS NULL OR rw.error_number > 0) /* negative numbers indicate human attention required */
 											  )
+										AND rw.ignore_database = 1
 										ORDER BY rw.last_log_restore_start_time ASC, rw.last_log_restore_finish_time ASC, rw.database_name ASC;
 	
 								

--- a/sp_AllNightLog.sql
+++ b/sp_AllNightLog.sql
@@ -1173,7 +1173,7 @@ IF @Restore = 1
 											  	AND rw.last_log_restore_finish_time = '9999-12-31 00:00:00.000'
                                                 AND (rw.error_number IS NULL OR rw.error_number > 0) /* negative numbers indicate human attention required */
 											  )
-										AND rw.ignore_database = 1
+										AND rw.ignore_database = 0
 										ORDER BY rw.last_log_restore_start_time ASC, rw.last_log_restore_finish_time ASC, rw.database_name ASC;
 	
 								


### PR DESCRIPTION
Fixes #1727 .

Changes proposed in this pull request:
 - uses ignore_database column in restore_worker table to filter out databases.

How to test this code:
 - Set ignore_database to 1 and verify that it does not get selected for restore.

Has been tested on (remove any that don't apply):
  - SQL Server 2017
