### PR TITLE
Issue 1706

### DIFF
--- a/Documentation/sp_BlitzCache Checks by Priority.md
+++ b/Documentation/sp_BlitzCache Checks by Priority.md
@@ -63,8 +63,8 @@ If you want to add a new check, start at 62
 | 150 | Low Cost Query With High CPU | You have a low cost query that uses a lot of CPU | https://www.brentozar.com/blitzcache/low-cost-high-cpu/ | 51 | No |
 | 150 | Biblical Statistics | Statistics used in queries are >7 days old with >100k modifications | https://www.brentozar.com/blitzcache/stale-statistics/ | 52 | No |
 | 200 | Adaptive joins | Living in the future | https://www.brentozar.com/blitzcache/adaptive-joins/ | 53 | No |
-| 150 | Expensive Index Spool | You have an index spool, this is usually a sign that there's an index missing somewhere. | https://www.brentozar.com/blitzcache/eager-index-spools/ | 54 | Yes |
-| 150 | Index Spools Many Rows | You have an index spool that spools more rows than the query returns | https://www.brentozar.com/blitzcache/eager-index-spools/ | 55 | Yes |
+| 150 | Expensive Index Spool | You have an index spool, this is usually a sign that there's an index missing somewhere. | https://www.brentozar.com/blitzcache/eager-index-spools/ | 54 | No |
+| 150 | Index Spools Many Rows | You have an index spool that spools more rows than the query returns | https://www.brentozar.com/blitzcache/eager-index-spools/ | 55 | No |
 | 100 | Potentially bad cardinality estimates | Estimated rows are different from average rows by a factor of 10000 | https://www.brentozar.com/blitzcache/bad-estimates/ | 56 | Yes |
 | 200 | Is Paul White Electric? | This query has a Switch operator in it! | http://sqlblog.com/blogs/paul_white/archive/2013/06/11/hello-operator-my-switch-is-bored.aspx | 998 | Yes |
 | 200 | Database Level Statistics | Database has stats updated 7 days ago with more than 100k modifications | https://www.brentozar.com/blitzcache/stale-statistics/ | 999 | No |

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5758,7 +5758,7 @@ BEGIN
                      100,
                      'High Compile Time',
                      'Queries taking >5 seconds to compile',
-                     'No URL yet.',
+                     'https://www.brentozar.com/blitzcache/high-compilers/',
 					 'This can be normal for large plans, but be careful if they compile frequently');	
 
         IF EXISTS (SELECT 1/0
@@ -5771,7 +5771,7 @@ BEGIN
                      50,
                      'High Compile CPU',
                      'Queries taking >5 seconds of CPU to compile',
-                     'No URL yet.',
+                     'https://www.brentozar.com/blitzcache/high-compilers/',
 					 'If CPU is high and plans like this compile frequently, they may be related');
 
         IF EXISTS (SELECT 1/0
@@ -5785,7 +5785,7 @@ BEGIN
                      50,
                      'High Compile Memory',
                      'Queries taking 10% of Max Compile Memory',
-                     'No URL yet.',
+                     'https://www.brentozar.com/blitzcache/high-compilers/',
 					 'If you see high RESOURCE_SEMAPHORE_QUERY_COMPILE waits, these may be related');
 
         IF EXISTS (SELECT 1/0


### PR DESCRIPTION
Fixes #1706 

Changes proposed in this pull request:
 - Move high level plan checks up in the code
 - Warn for resource intensive plan compilation (> 5s compile time or CPU, 10% or more of max compile memory)
 - Adds a site URL: https://www.brentozar.com/blitzcache/high-compilers/
 - This also takes index spools out of ExpertMode, since we're breaking them apart to give missing index requests
 - Adds back a check for missing indexes or spools before entering that section of code to prevent unnecessary roughness
 - Update docs

How to test this code:
 - I'm using some first round guess numbers here, which I'll likely tweak after I see it out in the wild a bit.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017

