### PR TITLE
sp_Blitz: 3 tiny changes to make sp_Blitz run OK in SQL 2005

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3272,14 +3272,15 @@ AS
 							
 							IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 125) WITH NOWAIT;
 							
-								DECLARE @user_perm_sql NVARCHAR(MAX) = N'';
+								DECLARE @user_perm_sql NVARCHAR(MAX);
+								SET @user_perm_sql = N'';
 								DECLARE @user_perm_gb_out DECIMAL(38,2);
 								
 								IF @ProductVersionMajor >= 11
 								
 								BEGIN
 								
-								SET @user_perm_sql += N'
+								SET @user_perm_sql = @user_perm_sql + N'
 									SELECT @user_perm_gb = CASE WHEN (pages_kb / 128.0 / 1024.) >= 2.
 											THEN CONVERT(DECIMAL(38, 2), (pages_kb / 128.0 / 1024.))
 											ELSE NULL 
@@ -3294,7 +3295,7 @@ AS
 								IF @ProductVersionMajor < 11
 								
 								BEGIN
-								SET @user_perm_sql += N'
+								SET @user_perm_sql = @user_perm_sql + N'
 									SELECT @user_perm_gb = CASE WHEN ((single_pages_kb + multi_pages_kb) / 1024.0 / 1024.) >= 2.
 											THEN CONVERT(DECIMAL(38, 2), ((single_pages_kb + multi_pages_kb)  / 1024.0 / 1024.))
 											ELSE NULL 


### PR DESCRIPTION
Fixes #1737, the fact that sp_Blitz doesn't create itself OK when ran out of the box on SQL 2005 servers.

I appreciate SQL 2005 is not supported by MS or the First Responder Kit, but this seemed like such an easy and clean edit to help the poor folks still juggling SQL 2005 boxes...

Changes proposed in this pull request:
 - DECLARE and then SET variable, not both at once
 - stop using magical  += operator, instead use @var = @var + ...

How to test this code:
 - create sp_Blitz on SQL 2005 box
 - run sp_Blitz with common parameters, but also @CheckProcedureCache = 1

Has been tested on (remove any that don't apply):
 - SQL Server 2005
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
