### PR TITLE
Fixing version number on sp_Blitz

### DIFF
--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -2830,8 +2830,8 @@ AS
     SET NOCOUNT ON;
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 	DECLARE @Version VARCHAR(30);
-	SET @Version = '6.8';
-	SET @VersionDate = '20180801';
+	SET @Version = '6.9';
+	SET @VersionDate = '20180901';
 	SET @OutputType = UPPER(@OutputType);
 
 	IF @Help = 1 PRINT '
@@ -10849,6 +10849,8 @@ EXEC [dbo].[sp_Blitz]
     @CheckProcedureCacheFilter = NULL,
     @CheckServerInfo = 1
 */
+
+
 IF OBJECT_ID('dbo.sp_BlitzBackups') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_BlitzBackups AS RETURN 0;');
 GO

--- a/Install-Core-Blitz-No-Query-Store.sql
+++ b/Install-Core-Blitz-No-Query-Store.sql
@@ -32,8 +32,8 @@ AS
     SET NOCOUNT ON;
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 	DECLARE @Version VARCHAR(30);
-	SET @Version = '6.8';
-	SET @VersionDate = '20180801';
+	SET @Version = '6.9';
+	SET @VersionDate = '20180901';
 	SET @OutputType = UPPER(@OutputType);
 
 	IF @Help = 1 PRINT '

--- a/Install-Core-Blitz-With-Query-Store.sql
+++ b/Install-Core-Blitz-With-Query-Store.sql
@@ -32,8 +32,8 @@ AS
     SET NOCOUNT ON;
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 	DECLARE @Version VARCHAR(30);
-	SET @Version = '6.8';
-	SET @VersionDate = '20180801';
+	SET @Version = '6.9';
+	SET @VersionDate = '20180901';
 	SET @OutputType = UPPER(@OutputType);
 
 	IF @Help = 1 PRINT '


### PR DESCRIPTION
Install scripts had the right sp_Blitz contents, but just didn't include the new version number.