### PR TITLE
sp_Blitz - new check for alerts that NEVER send out their event details via email/pager

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -147,7 +147,7 @@ If you want to add a new one, start at 220.
 | 200 | Monitoring | Agent Jobs Without Failure Emails | https://www.BrentOzar.com/go/alerts | 94 |
 | 200 | Monitoring | Alerts Configured without Follow Up | https://www.BrentOzar.com/go/alert | 59 |
 | 200 | Monitoring | Alerts Disabled | https://www.BrentOzar.com/go/alerts/ | 98 |
-| 200 | Monitoring | Alerts Without Event Descriptions | https://www.BrentOzar.com/go/alerts/ | 219 |
+| 200 | Monitoring | Alerts Without Event Descriptions | https://BrentOzar.com/go/alert | 219 |
 | 200 | Monitoring | Extended Events Hyperextension | https://www.BrentOzar.com/go/xe | 176 |
 | 200 | Monitoring | No Alerts for Corruption | https://www.BrentOzar.com/go/alert | 96 |
 | 200 | Monitoring | No Alerts for Sev 19-25 | https://www.BrentOzar.com/go/alert | 61 |

--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 218.  
-If you want to add a new one, start at 219.
+CURRENT HIGH CHECKID: 219.  
+If you want to add a new one, start at 220.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -147,6 +147,7 @@ If you want to add a new one, start at 219.
 | 200 | Monitoring | Agent Jobs Without Failure Emails | https://www.BrentOzar.com/go/alerts | 94 |
 | 200 | Monitoring | Alerts Configured without Follow Up | https://www.BrentOzar.com/go/alert | 59 |
 | 200 | Monitoring | Alerts Disabled | https://www.BrentOzar.com/go/alerts/ | 98 |
+| 200 | Monitoring | Alerts Without Event Descriptions | https://www.BrentOzar.com/go/alerts/ | 219 |
 | 200 | Monitoring | Extended Events Hyperextension | https://www.BrentOzar.com/go/xe | 176 |
 | 200 | Monitoring | No Alerts for Corruption | https://www.BrentOzar.com/go/alert | 96 |
 | 200 | Monitoring | No Alerts for Sev 19-25 | https://www.BrentOzar.com/go/alert | 61 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2206,7 +2206,7 @@ AS
 											200 AS Priority ,
 											'Monitoring' AS FindingsGroup ,
 											'Alerts Disabled' AS Finding ,
-											'https://BrentOzar.com/go/alert' AS URL ,
+											'https://www.BrentOzar.com/go/alerts/' AS URL ,
 											( 'The following Alert is disabled, please review and enable if desired: '
 											  + name ) AS Details
 									FROM    msdb.dbo.sysalerts

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2206,7 +2206,7 @@ AS
 											200 AS Priority ,
 											'Monitoring' AS FindingsGroup ,
 											'Alerts Disabled' AS Finding ,
-											'https://www.BrentOzar.com/go/alerts/' AS URL ,
+											'https://BrentOzar.com/go/alert' AS URL ,
 											( 'The following Alert is disabled, please review and enable if desired: '
 											  + name ) AS Details
 									FROM    msdb.dbo.sysalerts
@@ -2229,22 +2229,22 @@ AS
 
 			INSERT INTO #BlitzResults (
 				CheckID
-				,Priority
+				,[Priority]
 				,FindingsGroup
 				,Finding
-				,URL
+				,[URL]
 				,Details
 				)
 			SELECT 219 AS CheckID
-				,200 AS Priority
+				,200 AS [Priority]
 				,'Monitoring' AS FindingsGroup
 				,'Alerts Without Event Descriptions' AS Finding
-				,'https://www.BrentOzar.com/go/alerts/' AS URL
-				,('The following Alert is not including detailed event descriptions in its output messages: ' + name
-				+ '. You can fix this by checking the relevant boxes in its Properties -> Options page.') AS Details
+				,'https://BrentOzar.com/go/alert' AS [URL]
+				,('The following Alert is not including detailed event descriptions in its output messages: ' + QUOTENAME([name])
+				+ '. You can fix it by ticking the relevant boxes in its Properties --> Options page.') AS Details
 			FROM msdb.dbo.sysalerts
-			WHERE enabled = 1
-			  AND include_event_description_in = 0 --bitmask: 1 = email, 2 = pager, 4 = net send
+			WHERE [enabled] = 1
+			  AND include_event_description = 0 --bitmask: 1 = email, 2 = pager, 4 = net send
 			;
 		END;
 

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2211,15 +2211,48 @@ AS
 											  + name ) AS Details
 									FROM    msdb.dbo.sysalerts
 									WHERE   enabled = 0;
-					
-							END;
-					
-					END;
+			END;
+		END;
 
-				IF NOT EXISTS ( SELECT  1
-								FROM    #SkipChecks
-								WHERE   DatabaseName IS NULL AND CheckID = 31 )
-					BEGIN
+		--check for alerts that do NOT include event descriptions in their outputs via email/pager/net-send
+		IF NOT EXISTS (
+				SELECT 1
+				FROM #SkipChecks
+				WHERE DatabaseName IS NULL
+					AND CheckID = 219
+				)
+		BEGIN;
+			IF @Debug IN (1, 2)
+			BEGIN;
+				RAISERROR ('Running CheckId [%d].', 0, 1, 219) WITH NOWAIT;
+			END;
+
+			INSERT INTO #BlitzResults (
+				CheckID
+				,Priority
+				,FindingsGroup
+				,Finding
+				,URL
+				,Details
+				)
+			SELECT 219 AS CheckID
+				,200 AS Priority
+				,'Monitoring' AS FindingsGroup
+				,'Alerts Without Event Descriptions' AS Finding
+				,'https://www.BrentOzar.com/go/alerts/' AS URL
+				,('The following Alert is not including detailed event descriptions in its output messages: ' + name
+				+ '. You can fix this by checking the relevant boxes in its Properties -> Options page.') AS Details
+			FROM msdb.dbo.sysalerts
+			WHERE enabled = 1
+			  AND include_event_description_in = 0 --bitmask: 1 = email, 2 = pager, 4 = net send
+			;
+		END;
+
+		--check whether we have NO ENABLED operators!
+		IF NOT EXISTS ( SELECT  1
+						FROM    #SkipChecks
+						WHERE   DatabaseName IS NULL AND CheckID = 31 )
+		BEGIN;
 						IF NOT EXISTS ( SELECT  *
 										FROM    msdb.dbo.sysoperators
 										WHERE   enabled = 1 )


### PR DESCRIPTION
Fixes #1753 .

Changes proposed in this pull request:
 - add a check for alerts that NEVER send out their event details via email/pager

How to test this code:

EXEC msdb.dbo.sp_add_alert @name = N'DEBUG - No Event Details included :-('
	,@message_id = 0
	,@severity = 10 --harmless?
	,@enabled = 1
	,@delay_between_responses = 600 --seconds
	,@include_event_description_in = 0 -- 0 = I do NOT want free Event Details in my error messages...
	,@job_id = N'00000000-0000-0000-0000-000000000000';

--do we get a "Monitoring - Alerts Without Event Descriptions" line for the alert?
EXEC [dbo].[sp_Blitz] @IgnorePrioritiesBelow = 200, @IgnorePrioritiesAbove = 200

--remove your alert when done testing:
--EXEC msdb.dbo.sp_delete_alert @name=N'DEBUG - No Event Details included :-('

Has been tested on (remove any that don't apply):
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
