### PR TITLE
TraceFileIssue check on 106

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -238,6 +238,7 @@ AS
 							FROM    #SkipChecks
 							WHERE   DatabaseName IS NULL AND CheckID = 106 )
 							AND (select convert(int,value_in_use) from sys.configurations where name = 'default trace enabled' ) = 1
+                            AND @TraceFileIssue = 0
 			BEGIN
 				-- Flag for Windows OS to help with Linux support
 				IF EXISTS ( SELECT  1


### PR DESCRIPTION
Added @TraceFileIssue = 0 check to number 106.

Fixes #1761  .

Changes proposed in this pull request:
 - Added check for trace file issue to number 106 

How to test this code:
 - Mess about and delete your log files, it'll set @TraceFileIssue to 1. This new check should stop it throwing an error at check 106.

Has been tested on (remove any that don't apply):
 - SQL Server 2016
