### PR TITLE
Added @TraceFileIssue to check 106

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7559,6 +7559,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 											WHERE   DatabaseName IS NULL AND CheckID = 106 )
 											AND (select convert(int,value_in_use) from sys.configurations where name = 'default trace enabled' ) = 1
                                 AND DATALENGTH( COALESCE( @base_tracefilename, '' ) ) > DATALENGTH('.TRC')
+                                AND @TraceFileIssue = 0
 							BEGIN
 
 								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 106) WITH NOWAIT;


### PR DESCRIPTION
Fixes #1761  .

Changes proposed in this pull request:
 - Added a @TraceFileIssue check to number 106, same as is used elsewhere.

How to test this code:
 - Add a line before the new check to set @base_tracefilename to something that doesn't exist and it'll throw an error.

Has been tested on (remove any that don't apply):
 - SQL Server 2016