### PR TITLE
#1785 sp_Blitz duplicate checkid

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 220.  
-If you want to add a new one, start at 221.
+CURRENT HIGH CHECKID: 221.  
+If you want to add a new one, start at 222.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -39,6 +39,7 @@ If you want to add a new one, start at 221.
 | 10 | Performance | High Memory Use for In-Memory OLTP (Hekaton) | https://www.BrentOzar.com/go/hekaton | 145 |
 | 10 | Performance | Memory Nodes Offline | https://www.BrentOzar.com/go/schedulers | 110 |
 | 10 | Performance | Plan Cache Erased Recently | https://www.BrentOzar.com/askbrent/plan-cache-erased-recently/ | 125 |
+| 10 | Reliability | Server restarted in last 24 hours | | 221 |
 | 20 | Reliability | Dangerous Build of SQL Server (Corruption) | http://sqlperformance.com/2014/06/sql-indexes/hotfix-sql-2012-rebuilds | 129 |
 | 20 | Reliability | Dangerous Build of SQL Server (Security) | https://technet.microsoft.com/en-us/library/security/MS14-044 | 157 |
 | 20 | Reliability | Databases in Unusual States | https://www.BrentOzar.com/go/repair | 102 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -5018,7 +5018,7 @@ IF @ProductVersionMajor >= 10
 						
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
-								WHERE   DatabaseName IS NULL AND CheckID = 216 )
+								WHERE   DatabaseName IS NULL AND CheckID = 221 )
 					BEGIN
 						
 						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 216) WITH NOWAIT;
@@ -5041,9 +5041,9 @@ IF @ProductVersionMajor >= 10
 									  URL ,
 									  Details
 									)														
-							SELECT 216 AS CheckID,
+							SELECT 221 AS CheckID,
 							       10 AS Priority,
-							       'Recent Restart' AS FindingsGroup,
+							       'Reliability' AS FindingsGroup,
 							       'Server restarted in last 24 hours' AS Finding,
 							       '' AS URL,
 							       'Surprise! Your server was last restarted on: ' + CONVERT(VARCHAR(30), MAX(reboot_airhorn.create_date)) AS details


### PR DESCRIPTION
Changing recent-restart to checkid 221. Fixes #1785.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
  - SQL Server 2017