### PR TITLE
#1801 sp_Blitz skip alerts on RDS

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -326,6 +326,7 @@ AS
 						INSERT INTO #SkipChecks (CheckID) VALUES (184); /* xp_readerrorlog checking for IFI */
 						INSERT INTO #SkipChecks (CheckID) VALUES (211); /* xp_regread checking for power saving */
 						INSERT INTO #SkipChecks (CheckID) VALUES (212); /* xp_regread */
+						INSERT INTO #SkipChecks (CheckID) VALUES (219);
 			END; /* Amazon RDS skipped checks */
 
 		/* If the server is ExpressEdition, skip checks that it doesn't allow */


### PR DESCRIPTION
New check 219 wasn't being skipped on RDS. Fixes #1801.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
  - SQL Server 2017
