### PR TITLE
1808 sp_BlitzFirst Azure SQL DB compatibility

### DIFF
--- a/Documentation/sp_BlitzFirst Checks by Priority.md
+++ b/Documentation/sp_BlitzFirst Checks by Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 40
-If you want to add a new check, start at 41
+CURRENT HIGH CHECKID: 41
+If you want to add a new check, start at 42
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|---------------------------------|---------------------------------------|-------------------------------------------------|----------|
@@ -23,6 +23,7 @@ If you want to add a new check, start at 41
 | 1 | SQL Server Internal Maintenance | Data File Growing | https://BrentOzar.com/go/instant | 4 |
 | 1 | SQL Server Internal Maintenance | Log File Growing | https://BrentOzar.com/go/logsize | 13 |
 | 1 | SQL Server Internal Maintenance | Log File Shrinking | https://BrentOzar.com/go/logsize | 14 |
+| 10 | Azure Performance | Database is Maxed Out | https://BrentOzar.com/go/maxedout | 41 |
 | 10 | Server Performance | Poison Wait Detected | https://BrentOzar.com/go/poison | 30 |
 | 10 | Server Performance | Target Memory Lower Than Max | https://BrentOzar.com/go/target | 35 |
 | 40 | Table Problems | Forwarded Fetches/Sec High | https://BrentOzar.com/go/fetch | 29 |

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2285,26 +2285,27 @@ BEGIN
         AND ps.value_delta > (10 * @Seconds); /* Ignore servers sitting idle */
 
     /* Azure Performance - Database is Maxed Out - CheckID 41 */
-    INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, URL, Details, HowToStopIt)
-    SELECT 41 AS CheckID,
-        10 AS Priority,
-        'Azure Performance' AS FindingGroup,
-        'Database is Maxed Out' AS Finding,
-        'https://BrentOzar.com/go/maxedout' AS URL,
-        N'At ' + CONVERT(NVARCHAR(100), s.end_time ,121) + N', your database approached (or hit) your DTU limits:' + @LineFeed
-            + N'Average CPU percent: ' + CAST(avg_cpu_percent AS NVARCHAR(50)) + @LineFeed
-            + N'Average data IO percent: ' + CAST(avg_data_io_percent AS NVARCHAR(50)) + @LineFeed
-            + N'Average log write percent: ' + CAST(avg_log_write_percent AS NVARCHAR(50)) + @LineFeed
-            + N'Max worker percent: ' + CAST(max_worker_percent AS NVARCHAR(50)) + @LineFeed
-            + N'Max session percent: ' + CAST(max_session_percent AS NVARCHAR(50)) AS Details,
-        'Tune your queries or indexes with sp_BlitzCache or sp_BlitzIndex, or consider upgrading to a higher DTU level.' AS HowToStopIt
-    FROM sys.dm_db_resource_stats s
-    WHERE s.end_time >= DATEADD(MI, -5, GETDATE())
-      AND (avg_cpu_percent > 90
-           OR avg_data_io_percent >= 90
-           OR avg_log_write_percent >=90
-           OR max_worker_percent >= 90
-           OR max_session_percent >= 90);
+    IF SERVERPROPERTY('Edition') = 'SQL Azure'
+        INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, URL, Details, HowToStopIt)
+        SELECT 41 AS CheckID,
+            10 AS Priority,
+            'Azure Performance' AS FindingGroup,
+            'Database is Maxed Out' AS Finding,
+            'https://BrentOzar.com/go/maxedout' AS URL,
+            N'At ' + CONVERT(NVARCHAR(100), s.end_time ,121) + N', your database approached (or hit) your DTU limits:' + @LineFeed
+                + N'Average CPU percent: ' + CAST(avg_cpu_percent AS NVARCHAR(50)) + @LineFeed
+                + N'Average data IO percent: ' + CAST(avg_data_io_percent AS NVARCHAR(50)) + @LineFeed
+                + N'Average log write percent: ' + CAST(avg_log_write_percent AS NVARCHAR(50)) + @LineFeed
+                + N'Max worker percent: ' + CAST(max_worker_percent AS NVARCHAR(50)) + @LineFeed
+                + N'Max session percent: ' + CAST(max_session_percent AS NVARCHAR(50)) AS Details,
+            'Tune your queries or indexes with sp_BlitzCache or sp_BlitzIndex, or consider upgrading to a higher DTU level.' AS HowToStopIt
+        FROM sys.dm_db_resource_stats s
+        WHERE s.end_time >= DATEADD(MI, -5, GETDATE())
+          AND (avg_cpu_percent > 90
+               OR avg_data_io_percent >= 90
+               OR avg_log_write_percent >=90
+               OR max_worker_percent >= 90
+               OR max_session_percent >= 90);
 
     /* Server Info - Batch Requests per Sec - CheckID 19 */
     INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, URL, Details, DetailsInt)


### PR DESCRIPTION
Improves compatibility with Azure SQL DB, plus adds new check 41 looking at sys.dm_db_resource_stats to tell you if you're being throttled due to your DTU level. Closes #1808.

Has been tested on (remove any that don't apply):
  - SQL Server 2017
 - Azure SQL DB
