### PR TITLE
Fix typo in sp_ineachdb.sql

### DIFF
--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -1,7 +1,7 @@
 USE [master];
 GO
 
-IF OBJECT_ID('dbo.sp_foreachdb') IS NULL
+IF OBJECT_ID('dbo.sp_ineachdb') IS NULL
     EXEC ('CREATE PROCEDURE dbo.sp_ineachdb AS RETURN 0');
 GO
 


### PR DESCRIPTION
Fixes #1824.

Changes proposed in this pull request:
 - Fix typo in sp_ineachdb.sql where sp_foreachdb was being referenced.

How to test this code:
 - Run `sp_ineachdb.sql` on a server twice that does not contain `sp_foreachdb` - it will now run without error.

Has been tested on (remove any that don't apply):
 - SQL Server 2016