### PR TITLE
Ignore SQL Monitor

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4780,6 +4780,7 @@ IF @ProductVersionMajor >= 10
 			AND d.application_name NOT LIKE '%SQL Diagnostic Manager%'
 			AND d.application_name NOT LIKE '%Sentry%'
 			AND d.application_name NOT LIKE '%LiteSpeed%'
+            AND d.application_name NOT LIKE '%SQL Monitor - Monitoring%'
 			
 
 			HAVING COUNT(*) > 0;


### PR DESCRIPTION
Closes #1853


Changes proposed in this pull request:
 - Ignore RedGate SQL Monitor

How to test this code:
 - You know...

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
  - SQL Server 2017
 - Amazon RDS
 - Azure SQL DB
