### PR TITLE
Azure helpfulness

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -129,6 +129,19 @@ SET @VersionDate = '20181001';
                     1) WITH NOWAIT;
                 RETURN;
             END;
+        
+        IF ((SELECT SERVERPROPERTY ('EDITION')) = 'SQL Azure'
+             AND 
+             LOWER(@EventSessionPath) NOT LIKE 'http%')
+            BEGIN
+                    RAISERROR(
+                    'The default storage path doesn''t work in Azure SQLDB/Managed instances.
+You need to use an Azure storage account, and the path has to look like this: https://StorageAccount.blob.core.windows.net/Container/FileName.xel',
+                    0,
+                    1) WITH NOWAIT;
+                RETURN;
+            END
+
 
 		IF @Top IS NULL
 			SET @Top = 2147483647;

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -92,18 +92,21 @@ FROM   sys.configurations AS c
 WHERE  c.name = N'min memory per query (KB)'
 OPTION (RECOMPILE);
 
-/*Grabs log size for datbase*/
-SELECT @log_size_mb = AVG(((mf.size * 8) / 1024.))
-FROM sys.master_files AS mf
-WHERE mf.database_id = DB_ID(@DatabaseName)
-AND mf.type_desc = 'LOG';
-
-/*Grab avg tempdb file size*/
-SELECT @avg_tempdb_data_file = AVG(((mf.size * 8) / 1024.))
-FROM sys.master_files AS mf
-WHERE mf.database_id = DB_ID('tempdb')
-AND mf.type_desc = 'ROWS';
-
+/*Check if this is Azure first*/
+IF (SELECT SERVERPROPERTY ('EDITION')) <> 'SQL Azure'
+    BEGIN 
+        /*Grabs log size for datbase*/
+        SELECT @log_size_mb = AVG(((mf.size * 8) / 1024.))
+        FROM sys.master_files AS mf
+        WHERE mf.database_id = DB_ID(@DatabaseName)
+        AND mf.type_desc = 'LOG';
+        
+        /*Grab avg tempdb file size*/
+        SELECT @avg_tempdb_data_file = AVG(((mf.size * 8) / 1024.))
+        FROM sys.master_files AS mf
+        WHERE mf.database_id = DB_ID('tempdb')
+        AND mf.type_desc = 'ROWS';
+    END;
 
 /*Help section*/
 


### PR DESCRIPTION
BQS and BL now work better.

Fixes #1859 

Changes proposed in this pull request:
 - BQS skips sys.master_files queries
 - BL throws a more helpful error.

How to test this code:
 - Use Azure/MI

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
  - SQL Server 2017
 - Amazon RDS
 - Azure SQL DB
