### PR TITLE
Update Help Code Branching

### DIFF
--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -85,6 +85,13 @@ IF @Help = 1
 			LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 			OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 			SOFTWARE.
+			
+			Example for basic execution of the stored procedure:
+			
+			exec dbo.sp_foreachdb
+				@command = ''select [name] sys.tables''
+				,@database_list = ''Database1,Database2''
+				,@exclude_list = ''Database5,OldDatabase'';
 		
 		*/
 		';

--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -87,6 +87,7 @@ IF @Help = 1
 		
 		*/
 		';
+	END
 
         IF ( (@command1 IS NOT NULL AND @command IS NOT NULL)
             OR (@command1 IS NULL AND @command IS NULL) )
@@ -270,5 +271,4 @@ IF @Help = 1
         CLOSE c;
         DEALLOCATE c;
     END
-END
 GO

--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -87,6 +87,7 @@ IF @Help = 1
 		
 		*/
 		';
+		RETURN -1;
 	END
 
         IF ( (@command1 IS NOT NULL AND @command IS NOT NULL)

--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -47,7 +47,7 @@ IF @Help = 1
 		/*
 			sp_foreachdb from http://FirstResponderKit.org
 			
-			This script will restore a database from a given file path.
+			This script will execute a given command against all, or user-specified, available databases on an instance.
 		
 			To learn more, visit http://FirstResponderKit.org where you can download new
 			versions for free, watch training videos on how it works, get more info on

--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -270,4 +270,5 @@ IF @Help = 1
         CLOSE c;
         DEALLOCATE c;
     END
+END
 GO

--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -47,7 +47,8 @@ IF @Help = 1
 		/*
 			sp_foreachdb from http://FirstResponderKit.org
 			
-			This script will execute a given command against all, or user-specified, available databases on an instance.
+			This script will execute a given command against all, or user-specified,
+			online, readable databases on an instance.
 		
 			To learn more, visit http://FirstResponderKit.org where you can download new
 			versions for free, watch training videos on how it works, get more info on


### PR DESCRIPTION
Fixes #1893 

Changes proposed in this pull request:
 - Properly close branch for @Help = 1
 - Update help text to display correct description of the intended functionality of the stored procedure.

How to test this code:
 - exec sp_foreachdb @Help = 1; -- Should only show corrected Help info
 - exec sp_foreachdb @command = 'select top 100 [name] from sys.tables;' -- Should only execute command

Has been tested on (remove any that don't apply):
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016