### PR TITLE
Fix false positive on NC PKs

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -3219,7 +3219,15 @@ BEGIN;
                                 sz.index_size_summary
                         FROM    #IndexSanity i
                         JOIN #IndexSanitySize sz ON i.index_sanity_id = sz.index_sanity_id
-                        WHERE    i.index_type = 2 AND i.is_primary_key = 1 AND i.secret_columns LIKE '%RID%'
+                        WHERE    i.index_type = 2 AND i.is_primary_key = 1
+                        AND EXISTS 
+                            (
+                              SELECT 1/0 
+                              FROM #IndexSanity AS isa
+                              WHERE i.database_id = isa.database_id
+                              AND   i.object_id = isa.object_id
+                              AND   isa.index_id = 0
+                            )
 						OPTION    ( RECOMPILE );
 
 				            RAISERROR(N'check_id 48: Nonclustered indexes with a bad read to write ratio', 0,1) WITH NOWAIT;


### PR DESCRIPTION
Closes #1883

Changes proposed in this pull request:
 - Fix false positives on NC/PK

How to test this code:
```
CREATE TABLE dbo.HeapsOfSadness (Id1 INT IDENTITY(1,1), CustomeRID INT, Stuffing CHAR(1000),
CONSTRAINT PK_Id1 PRIMARY KEY NONCLUSTERED ([Id1] ASC));
GO
--CREATE CLUSTERED INDEX [CLIX_CustomeRID] ON [dbo].HeapsOfSadness (CustomeRID);
GO
INSERT INTO dbo.HeapsOfSadness (CustomeRID, Stuffing)
  SELECT 1, 'Stuff' /* Short */
  FROM sys.messages;
GO
```
Toggle creating the CX.

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
  - SQL Server 2017
