### PR TITLE
dbo.SqlServerVersions - little change in object existence check + allow script execution

### DIFF
--- a/SqlServerVersions.sql
+++ b/SqlServerVersions.sql
@@ -1,5 +1,5 @@
 
-IF NOT EXISTS (SELECT NULL FROM sys.tables WHERE [name] = 'SqlServerVersions')
+IF (OBJECT_ID('dbo.SqlServerVersions') IS NULL)
 BEGIN
 
     CREATE TABLE dbo.SqlServerVersions
@@ -23,6 +23,8 @@ BEGIN
     );
 
 END;
+
+GO
 
 DELETE dbo.SqlServerVersions;
 

--- a/SqlServerVersions.sql
+++ b/SqlServerVersions.sql
@@ -313,4 +313,7 @@ VALUES
     (10, 1787, 'RTM CU3', 'https://support.microsoft.com/en-us/help/960484', '2009-01-19', '2014-07-08', '2019-07-09', 'SQL Server 2008', 'RTM Cumulative Update 3'),
     (10, 1779, 'RTM CU2', 'https://support.microsoft.com/en-us/help/958186', '2008-11-19', '2014-07-08', '2019-07-09', 'SQL Server 2008', 'RTM Cumulative Update 2'),
     (10, 1763, 'RTM CU1', 'https://support.microsoft.com/en-us/help/956717', '2008-09-22', '2014-07-08', '2019-07-09', 'SQL Server 2008', 'RTM Cumulative Update 1'),
-    (10, 1600, 'RTM ', '', '2008-08-06', '2014-07-08', '2019-07-09', 'SQL Server 2008', 'RTM ');
+    (10, 1600, 'RTM ', '', '2008-08-06', '2014-07-08', '2019-07-09', 'SQL Server 2008', 'RTM ')
+;
+GO
+


### PR DESCRIPTION
Changes proposed in this pull request:
 - object existence includes schema name (with OBJECT_ID built-in function)
 - a "GO" between object creation and DELETE statement
- a "GO" at the end of the script

How to test this code:
- run it as you are used to

Has been tested on (remove any that don't apply):
 - SQL Server 2014
