### PR TITLE
Issue #1904 Change RAISERROR 'severity' to 16 for those that should throw an error…

### DIFF
--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -237,7 +237,7 @@ CREATE TABLE #Warnings
 
 IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = @MSDBName)
 	BEGIN
-	RAISERROR('@MSDBName was specified, but the database does not exist.', 0, 1) WITH NOWAIT;
+	RAISERROR('@MSDBName was specified, but the database does not exist.', 16, 1) WITH NOWAIT;
 	RETURN;
 	END
 
@@ -1149,13 +1149,13 @@ DECLARE @RemoteCheck TABLE (c INT NULL);
 
 IF @WriteBackupsToDatabaseName IS NULL
 	BEGIN
-	RAISERROR('@WriteBackupsToDatabaseName can''t be NULL.', 0, 1) WITH NOWAIT
+	RAISERROR('@WriteBackupsToDatabaseName can''t be NULL.', 16, 1) WITH NOWAIT
 	RETURN;
 	END
 
 IF LOWER(@WriteBackupsToDatabaseName) = N'msdb'
 	BEGIN
-	RAISERROR('We can''t write to the real msdb, we have to write to a fake msdb.', 0, 1) WITH NOWAIT
+	RAISERROR('We can''t write to the real msdb, we have to write to a fake msdb.', 16, 1) WITH NOWAIT
 	RETURN;
 	END
 
@@ -1163,7 +1163,7 @@ IF @WriteBackupsToListenerName IS NULL
 BEGIN
 	IF @AGName IS NULL
 		BEGIN
-			RAISERROR('@WriteBackupsToListenerName and @AGName can''t both be NULL.', 0, 1) WITH NOWAIT;
+			RAISERROR('@WriteBackupsToListenerName and @AGName can''t both be NULL.', 16, 1) WITH NOWAIT;
 			RETURN;
 		END
 	ELSE
@@ -1187,7 +1187,7 @@ BEGIN
 		)
 			BEGIN
 				SET @msg = N'We need a linked server to write data across. Please set one up for ' + @WriteBackupsToListenerName + N'.';
-				RAISERROR(@msg, 0, 1) WITH NOWAIT;
+				RAISERROR(@msg, 16, 1) WITH NOWAIT;
 				RETURN;
 			END
 END
@@ -1206,7 +1206,7 @@ END
 	IF @@ROWCOUNT = 0
 		BEGIN
 		SET @msg = N'The database ' + @WriteBackupsToDatabaseName + N' doesn''t appear to exist on that server.'
-		RAISERROR(@msg, 0, 1) WITH NOWAIT
+		RAISERROR(@msg, 16, 1) WITH NOWAIT
 		RETURN;
 		END
 


### PR DESCRIPTION
… and error.

Fixes # 1904.

Changes proposed in this pull request:
 - Changed the severity value from 0 to 16 for RAISERROR call that should throw an error.

How to test this code:
 - Execute this: ``
EXEC sp_BlitzBackups 
	@PushBackupHistoryToListener = 1, 
	@WriteBackupsToListenerName = 'BIG-AG', 
	@WriteBackupsToDatabaseName = 'Backups-AG', 
	@WriteBackupsLastHours = 3000
``
 - It should terminate with an error that looks like this:
``
Pushing backup history to listener
Msg 50000, Level 16, State 1, Procedure sp_BlitzBackupsR, Line 1187 [Batch Start Line 0]
We need a linked server to write data across. Please set one up for BIG-AG.
``

Has been tested on (remove any that don't apply):
 - SQL Server 2016
