### PR TITLE
Issue 1910

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -409,6 +409,17 @@ BEGIN
 			);
 		END; /* IF OBJECT_ID('tempdb..##WaitCategories') IS NULL */
 
+	IF OBJECT_ID ('tempdb..#checkversion') IS NOT NULL
+		DROP TABLE #checkversion;
+	CREATE TABLE #checkversion (
+		version NVARCHAR(128),
+		common_version AS SUBSTRING(version, 1, CHARINDEX('.', version) + 1 ),
+		major AS PARSENAME(CONVERT(VARCHAR(32), version), 4),
+		minor AS PARSENAME(CONVERT(VARCHAR(32), version), 3),
+		build AS PARSENAME(CONVERT(VARCHAR(32), version), 2),
+		revision AS PARSENAME(CONVERT(VARCHAR(32), version), 1)
+	);
+
 	IF 504 <> (SELECT COALESCE(SUM(1),0) FROM ##WaitCategories)
 		BEGIN
 		    TRUNCATE TABLE ##WaitCategories;


### PR DESCRIPTION
Fixes # 1910.

Changes proposed in this pull request:
 - Add the same SQL Server version check as in sp_BlitzCache for the @BlitzCacheSortOrder parameter.
 - If it fails the check, don't set @BlitzCacheSortOrder to 'memory grant'.

How to test this code:
 - Kinda tricky to test as you'd need an older SQL Server instance that can trigger CheckID 34.

Has been tested on (remove any that don't apply):
 - SQL Server 2008
 - SQL Server 2016
