### PR TITLE
#1927 sp_BlitzIndex skip rdsadmin db

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -697,6 +697,7 @@ IF @GetAllDatabases = 1
         AND state_desc = 'ONLINE'
         AND database_id > 4
         AND DB_NAME(database_id) NOT LIKE 'ReportServer%'
+        AND DB_NAME(database_id) NOT LIKE 'rdsadmin%'
         AND is_distributor = 0
 		OPTION    ( RECOMPILE );
 


### PR DESCRIPTION
GetAllDatabases = 1 fails when it hits rdsadmin because they're referring to the resource db. Closes #1927.
