### PR TITLE
Fixes #1938 - sp_BlitzIndex create table script modification 

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -535,13 +535,13 @@ IF OBJECT_ID('tempdb..#FilteredIndexes') IS NOT NULL
                     END + CASE WHEN included_columns IS NOT NULL THEN N'INCLUDES: ' + included_columns + N' '
                         ELSE N''
                     END,
-                [create_tsql] AS N'CREATE INDEX [ix_' + table_name + N'_' 
+                [create_tsql] AS N'CREATE INDEX [IX_ 
                     + REPLACE(REPLACE(REPLACE(REPLACE(
                         ISNULL(equality_columns,N'')+ 
                         CASE WHEN equality_columns IS NOT NULL AND inequality_columns IS NOT NULL THEN N'_' ELSE N'' END
                         + ISNULL(inequality_columns,''),',','')
                         ,'[',''),']',''),' ','_') 
-                    + CASE WHEN included_columns IS NOT NULL THEN N'_includes' ELSE N'' END + N'] ON ' 
+                    + CASE WHEN included_columns IS NOT NULL THEN N'_Includes' ELSE N'' END + N'] ON ' 
                     + [statement] + N' (' + ISNULL(equality_columns,N'')
                     + CASE WHEN equality_columns IS NOT NULL AND inequality_columns IS NOT NULL THEN N', ' ELSE N'' END
                     + CASE WHEN inequality_columns IS NOT NULL THEN inequality_columns ELSE N'' END + 


### PR DESCRIPTION
Fixes #1938  .

Changes proposed in this pull request:
 - removed table name from create scripts
 - some capitalisation


How to test this code:
 - run blitzindex and check the 'create index' recommendations. shouldn't include tablename and should be nicely capitalized
