### PR TITLE
Add Version Checking  for all SP

### DIFF
--- a/sp_AllNightLog.sql
+++ b/sp_AllNightLog.sql
@@ -20,16 +20,23 @@ ALTER PROCEDURE dbo.sp_AllNightLog
 								@Restore BIT = 0,
 								@Debug BIT = 0,
 								@Help BIT = 0,
-								@VersionDate DATETIME = NULL OUTPUT
+								@Version                 VARCHAR(30) = NULL OUTPUT,
+								@VersionDate             DATETIME = NULL OUTPUT,
+								@VersionCheckMode        BIT = 0
 WITH RECOMPILE
 AS
 SET NOCOUNT ON;
 
 BEGIN;
 
-DECLARE @Version VARCHAR(30);
+
 SET @Version = '3.2';
 SET @VersionDate = '20190128';
+
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
 
 IF @Help = 1
 

--- a/sp_AllNightLog_Setup.sql
+++ b/sp_AllNightLog_Setup.sql
@@ -27,17 +27,23 @@ ALTER PROCEDURE dbo.sp_AllNightLog_Setup
 				@FirstFullBackup BIT = 0,
 				@FirstDiffBackup BIT = 0,
 				@Help BIT = 0,
-				@VersionDate DATETIME = NULL OUTPUT
+				@Version     VARCHAR(30) = NULL OUTPUT,
+				@VersionDate DATETIME = NULL OUTPUT,
+				@VersionCheckMode BIT = 0
 WITH RECOMPILE
 AS
 SET NOCOUNT ON;
 
 BEGIN;
 
-DECLARE @Version VARCHAR(30);
+
 SET @Version = '3.2';
 SET @VersionDate = '20190128';;
 
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
 
 IF @Help = 1
 

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -27,15 +27,22 @@ ALTER PROCEDURE [dbo].[sp_Blitz]
     @BringThePain TINYINT = 0 ,
     @UsualDBOwner sysname = NULL ,
     @Debug TINYINT = 0 ,
-    @VersionDate DATETIME = NULL OUTPUT
+    @Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 WITH RECOMPILE
 AS
     SET NOCOUNT ON;
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-	DECLARE @Version VARCHAR(30);
+	
 	SET @Version = '7.2';
 	SET @VersionDate = '20190128';
 	SET @OutputType = UPPER(@OutputType);
+
+    IF(@VersionCheckMode = 1)
+	BEGIN
+		RETURN;
+	END;
 
 	IF @Help = 1 PRINT '
 	/*

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -14,15 +14,22 @@ ALTER PROCEDURE [dbo].[sp_BlitzBackups]
 	@WriteBackupsToListenerName NVARCHAR(256) = NULL,
     @WriteBackupsToDatabaseName NVARCHAR(256) = NULL,
     @WriteBackupsLastHours INT = 168,
-    @VersionDate DATE = NULL OUTPUT
+    @Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 WITH RECOMPILE
 AS
 	BEGIN
     SET NOCOUNT ON;
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-	DECLARE @Version VARCHAR(30);
+	
 	SET @Version = '3.2';
 	SET @VersionDate = '20190128';
+	
+	IF(@VersionCheckMode = 1)
+	BEGIN
+		RETURN;
+	END;
 
 	IF @Help = 1 PRINT '
 	/*

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -261,17 +261,24 @@ ALTER PROCEDURE dbo.sp_BlitzCache
 	@Debug BIT = 0,
 	@CheckDateOverride DATETIMEOFFSET = NULL,
 	@MinutesBack INT = NULL,
-	@VersionDate DATETIME = NULL OUTPUT
+	@Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+	@VersionCheckMode BIT = 0
 WITH RECOMPILE
 AS
 BEGIN
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-DECLARE @Version VARCHAR(30);
 SET @Version = '7.2';
 SET @VersionDate = '20190128';
 
+
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
+	
 IF @Help = 1 PRINT '
 sp_BlitzCache from http://FirstResponderKit.org
 	
@@ -323,7 +330,7 @@ SOFTWARE.
 ';
 
 DECLARE @nl NVARCHAR(2) = NCHAR(13) + NCHAR(10) ;
-
+	
 IF @Help = 1
 BEGIN
     SELECT N'@Help' AS [Parameter Name] ,

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -33,16 +33,22 @@ ALTER PROCEDURE [dbo].[sp_BlitzFirst]
     @LogMessageURL VARCHAR(200) = '',
     @LogMessageCheckDate DATETIMEOFFSET = NULL,
     @Debug BIT = 0,
-    @VersionDate DATETIME = NULL OUTPUT
+	@Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
     WITH EXECUTE AS CALLER, RECOMPILE
 AS
 BEGIN
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-DECLARE @Version VARCHAR(30);
+
 SET @Version = '7.2';
 SET @VersionDate = '20190128';
 
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
 
 IF @Help = 1 PRINT '
 sp_BlitzFirst from http://FirstResponderKit.org

--- a/sp_BlitzInMemoryOLTP.sql
+++ b/sp_BlitzInMemoryOLTP.sql
@@ -25,7 +25,9 @@ ALTER PROCEDURE dbo.sp_BlitzInMemoryOLTP(
       , @dbName            NVARCHAR(4000) = N'ALL'
       , @tableName         NVARCHAR(4000) = NULL
       , @debug             BIT            = 0
-	  , @VersionDate DATETIME = NULL OUTPUT
+	  , @Version           VARCHAR(30)    = NULL OUTPUT
+	  , @VersionDate       DATETIME       = NULL OUTPUT
+      , @VersionCheckMode  BIT            = 0
 )
 /*
 .SYNOPSIS
@@ -79,10 +81,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 */
 AS 
-DECLARE @ScriptVersion VARCHAR(30);
 SET @ScriptVersion = '1.8';
 SET @VersionDate = '20180801';
 
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
+								
 BEGIN TRY
 
     SET NOCOUNT ON;

--- a/sp_BlitzInMemoryOLTP.sql
+++ b/sp_BlitzInMemoryOLTP.sql
@@ -1,4 +1,4 @@
-﻿DECLARE @msg NVARCHAR(MAX) = N'';
+DECLARE @msg NVARCHAR(MAX) = N'';
 
 	-- Must be a compatible, on-prem version of SQL (2014+)
 IF  (	(SELECT SERVERPROPERTY ('EDITION')) <> 'SQL Azure' 
@@ -81,11 +81,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 */
 AS 
+DECLARE @ScriptVersion VARCHAR(30);
 SET @ScriptVersion = '1.8';
 SET @VersionDate = '20180801';
 
 IF(@VersionCheckMode = 1)
 BEGIN
+    SET @Version = @ScriptVersion;
 	RETURN;
 END;
 								
@@ -100,9 +102,9 @@ BEGIN TRY
     DECLARE @Edition NVARCHAR(MAX) = CAST(SERVERPROPERTY('Edition') AS NVARCHAR(128))
           , @errorMessage  NVARCHAR(512);
 
-    DECLARE @Version INT = CONVERT(INT, SERVERPROPERTY('ProductMajorVersion'));
+    DECLARE @MSSQLVersion INT = CONVERT(INT, SERVERPROPERTY('ProductMajorVersion'));
 
-    IF @debug = 1 PRINT('--@Version = ' + CAST(@Version AS VARCHAR(30)));
+    IF @debug = 1 PRINT('--@MSSQLVersion = ' + CAST(@MSSQLVersion AS VARCHAR(30)));
 
     /*
     ###################################################
@@ -139,7 +141,7 @@ BEGIN TRY
 
     -- not on Azure, so we need to check versions/Editions
     -- SQL 2014 only supports XTP on Enterprise edition
-    IF (SERVERPROPERTY('EngineEdition') IN (2, 4)) AND @Version = 12 AND (@Edition NOT LIKE 'Enterprise%' AND  @Edition NOT LIKE 'Developer%')
+    IF (SERVERPROPERTY('EngineEdition') IN (2, 4)) AND @MSSQLVersion = 12 AND (@Edition NOT LIKE 'Enterprise%' AND  @Edition NOT LIKE 'Developer%')
     BEGIN
         SET @errorMessage = CONCAT('For SQL 2014, In-Memory OLTP is only suppported on Enterprise Edition. You are running SQL Server edition: ', @Edition);
         THROW 55002, @errorMessage, 1;
@@ -149,7 +151,7 @@ BEGIN TRY
     -- SQL 2016 non-Enterprise only supports XTP after SP1
     DECLARE @BuildString VARCHAR(4) = CONVERT(VARCHAR(4), SERVERPROPERTY('ProductBuild'));
     
-    IF (SERVERPROPERTY('EngineEdition') IN (2, 4)) AND @Version = 13 AND (@BuildString < 4001)
+    IF (SERVERPROPERTY('EngineEdition') IN (2, 4)) AND @MSSQLVersion = 13 AND (@BuildString < 4001)
     -- 13.0.4001.0 is the minimum build for XTP support
     BEGIN
         SET @errorMessage = 'For SQL 2016, In-Memory OLTP is only suppported on non-Enterprise Edition as of SP1';
@@ -674,7 +676,7 @@ BEGIN TRY
                     ,', b.name AS tableName 
                     , p.rows AS [rowCount]
                     ,durability_desc '
-                    ,CASE WHEN @Version >= 13 THEN ', temporal_type_desc ' ELSE ',NULL AS temporal_type_desc' END
+                    ,CASE WHEN @MSSQLVersion >= 13 THEN ', temporal_type_desc ' ELSE ',NULL AS temporal_type_desc' END
                     ,', FORMAT(memory_allocated_for_table_kb, ''###,###,###'') AS memoryAllocatedForTableKB
                     ,FORMAT(memory_used_by_table_kb, ''###,###,###'') AS memoryUsedByTableKB
                     ,FORMAT(memory_allocated_for_indexes_kb, ''###,###,###'') AS memoryAllocatedForIndexesKB
@@ -745,13 +747,13 @@ BEGIN TRY
                     INNER JOIN '
                     ,dbName
                     ,'.sys.tables t ON t.object_id = c.object_id'
-                    ,CASE WHEN @Version > 12 THEN ' INNER JOIN sys.memory_optimized_tables_internal_attributes a ON a.object_id = c.object_id
+                    ,CASE WHEN @MSSQLVersion > 12 THEN ' INNER JOIN sys.memory_optimized_tables_internal_attributes a ON a.object_id = c.object_id
                                                                             AND a.xtp_object_id = c.xtp_object_id' ELSE NULL END
                     ,@crlf + ' LEFT JOIN '
                     ,dbName 
                     ,'.sys.indexes i ON c.object_id = i.object_id
                                                     AND c.index_id = i.index_id '
-                                                    ,CASE WHEN @Version > 12 THEN 'AND a.minor_id = 0' ELSE NULL END
+                                                    ,CASE WHEN @MSSQLVersion > 12 THEN 'AND a.minor_id = 0' ELSE NULL END
                     ,@crlf + ' WHERE t.type = '
                     , '''u'''
                     , '   AND t.is_memory_optimized = 1 '
@@ -825,7 +827,7 @@ BEGIN TRY
                     INNER JOIN '
                     ,dbName
                     ,'.sys.indexes AS i ON h.object_id = i.object_id AND h.index_id = i.index_id'
-                    ,CASE WHEN @Version > 12 THEN
+                    ,CASE WHEN @MSSQLVersion > 12 THEN
                     CONCAT(' INNER JOIN ', dbName ,'.sys.memory_optimized_tables_internal_attributes ia ON h.xtp_object_id = ia.xtp_object_id') ELSE NULL END
                     ,' INNER JOIN '
                     ,dbName
@@ -833,7 +835,7 @@ BEGIN TRY
                     ,' INNER JOIN '
                     ,dbName
                     ,'.sys.schemas sch ON sch.schema_id = t.schema_id '
-                    ,CASE WHEN @Version > 12 THEN 'WHERE ia.type = 1' ELSE NULL END
+                    ,CASE WHEN @MSSQLVersion > 12 THEN 'WHERE ia.type = 1' ELSE NULL END
                 )
             FROM #MemoryOptimizedDatabases
             WHERE rowNumber = @dbCounter;
@@ -885,14 +887,14 @@ BEGIN TRY
                     INNER JOIN '
                     ,dbName
                     ,'.sys.tables t ON t.object_id = c.object_id'
-                    ,CASE WHEN @Version > 12 THEN
+                    ,CASE WHEN @MSSQLVersion > 12 THEN
                     CONCAT(' INNER JOIN ', dbName ,'.sys.memory_optimized_tables_internal_attributes a ON a.object_id = c.object_id
                                                                         AND a.xtp_object_id = c.xtp_object_id') ELSE NULL END 
                     ,' LEFT JOIN '
                     ,dbName 
                     ,'.sys.indexes i ON c.object_id = i.object_id
                                                     AND c.index_id = i.index_id '
-                                                    ,CASE WHEN @Version > 12 THEN ' AND a.minor_id = 0' ELSE NULL END
+                                                    ,CASE WHEN @MSSQLVersion > 12 THEN ' AND a.minor_id = 0' ELSE NULL END
                     ,' WHERE t.type = '
                     , '''u'''
                     , '   AND t.is_memory_optimized = 1 '
@@ -1021,8 +1023,8 @@ BEGIN TRY
                             SELECT DISTINCT REPLACE(value, ''.dll'', '''') AS object_id
                             FROM #moduleSplit
                             WHERE rowNumber % ' 
-                     ,CASE WHEN @Version = 12 THEN ' 4 = 0'
-                           ELSE ' 6 = 4'  -- @Version >= 13 
+                     ,CASE WHEN @MSSQLVersion = 12 THEN ' 4 = 0'
+                           ELSE ' 6 = 4'  -- @MSSQLVersion >= 13 
                       END 
                         ,')'
                     );
@@ -1049,7 +1051,7 @@ BEGIN TRY
                 WHERE rowNumber = @dbCounter;
 
                 IF @debug = 1
-                PRINT('--List loaded natively compiled modules in this database (@Version >= 13)' + @crlf + @sql + @crlf);
+                PRINT('--List loaded natively compiled modules in this database (@MSSQLVersion >= 13)' + @crlf + @sql + @crlf);
                 ELSE 
                 BEGIN
 
@@ -1113,7 +1115,7 @@ BEGIN TRY
             */
 
             -- temporal is supported in SQL 2016+
-            IF @Version >= 13
+            IF @MSSQLVersion >= 13
             BEGIN
 
                 SELECT @sql = 
@@ -1210,7 +1212,7 @@ BEGIN TRY
             #########################################################
             */
 
-            IF @Version >= 13
+            IF @MSSQLVersion >= 13
             BEGIN
     
                 SELECT @sql = 
@@ -1684,7 +1686,7 @@ BEGIN TRY
     ###################################################
     */
 
-    IF @instanceLevelOnly = 1 AND @Version >= 12
+    IF @instanceLevelOnly = 1 AND @MSSQLVersion >= 12
     BEGIN
 
         SELECT @@version AS Version;
@@ -2026,7 +2028,7 @@ BEGIN TRY
             SELECT *
             FROM sys.event_notifications;
         END;
-    END; -- @instanceLevelOnly = 1 AND @Version >= 12
+    END; -- @instanceLevelOnly = 1 AND @MSSQLVersion >= 12
 
 	SELECT
 		'Thanks for using sp_BlitzInMemoryOLTP!' AS [Thanks],

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -31,16 +31,22 @@ ALTER PROCEDURE dbo.sp_BlitzIndex
     @OutputSchemaName NVARCHAR(256) = NULL ,
     @OutputTableName NVARCHAR(256) = NULL ,
     @Help TINYINT = 0,
-    @VersionDate DATETIME = NULL OUTPUT
+    @Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 WITH RECOMPILE
 AS
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-DECLARE @Version VARCHAR(30);
 SET @Version = '7.2';
 SET @VersionDate = '20190128';
 SET @OutputType  = UPPER(@OutputType);
+
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
 
 IF @Help = 1 PRINT '
 /*

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -16,7 +16,7 @@ ALTER PROCEDURE dbo.sp_BlitzLock
 	@EventSessionPath VARCHAR(256) = 'system_health*.xel', 
 	@Debug BIT = 0, 
 	@Help BIT = 0,
-	Version     VARCHAR(30) = NULL OUTPUT,
+	@Version     VARCHAR(30) = NULL OUTPUT,
 	@VersionDate DATETIME = NULL OUTPUT,
     @VersionCheckMode BIT = 0
 )

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -16,7 +16,9 @@ ALTER PROCEDURE dbo.sp_BlitzLock
 	@EventSessionPath VARCHAR(256) = 'system_health*.xel', 
 	@Debug BIT = 0, 
 	@Help BIT = 0,
-	@VersionDate DATETIME = NULL OUTPUT
+	Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 )
 WITH RECOMPILE
 AS
@@ -25,11 +27,13 @@ BEGIN
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-DECLARE @Version VARCHAR(30);
 SET @Version = '2.2';
 SET @VersionDate = '20190128';
 
-
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
 	IF @Help = 1 PRINT '
 	/*
 	sp_BlitzLock from http://FirstResponderKit.org

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -46,7 +46,9 @@ ALTER PROCEDURE dbo.sp_BlitzQueryStore
 	@SkipXML BIT = 0,
 	@Debug BIT = 0,
 	@ExpertMode BIT = 0,
-	@VersionDate DATETIME = NULL OUTPUT
+	@Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 WITH RECOMPILE
 AS
 BEGIN /*First BEGIN*/
@@ -54,10 +56,13 @@ BEGIN /*First BEGIN*/
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-DECLARE @Version NVARCHAR(30);
-	SET @Version = '3.2';
-	SET @VersionDate = '20190128';
-
+SET @Version = '3.2';
+SET @VersionDate = '20190128';
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
+								
 DECLARE /*Variables for the variable Gods*/
 		@msg NVARCHAR(MAX) = N'', --Used to format RAISERROR messages in some places
 		@sql_select NVARCHAR(MAX) = N'', --Used to hold SELECT statements for dynamic SQL

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -19,15 +19,21 @@ ALTER PROCEDURE dbo.sp_BlitzWho
 	@MinTempdbMB INT = 0 ,
 	@MinRequestedMemoryKB INT = 0 ,
 	@MinBlockingSeconds INT = 0 ,
-	@VersionDate DATETIME = NULL OUTPUT
+	@Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 AS
 BEGIN
 	SET NOCOUNT ON;
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-	DECLARE @Version VARCHAR(30);
+	
 	SET @Version = '7.2';
 	SET @VersionDate = '20190128';
-
+    
+	IF(@VersionCheckMode = 1)
+	BEGIN
+		RETURN;
+	END;
 
 	IF @Help = 1
 		PRINT '

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -26,15 +26,21 @@ ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
     @Execute CHAR(1) = Y,
     @Debug INT = 0, 
     @Help BIT = 0,
-    @VersionDate DATETIME = NULL OUTPUT
+    @Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 AS
 SET NOCOUNT ON;
 
 /*Versioning details*/
-DECLARE @Version NVARCHAR(30);
+
 SET @Version = '7.2';
 SET @VersionDate = '20190128';
 
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
  
 IF @Help = 1
 BEGIN

--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -28,13 +28,19 @@ ALTER PROCEDURE dbo.sp_foreachdb
     @is_auto_shrink_on BIT = NULL ,
     @is_broker_enabled BIT = NULL , 
     @Help BIT = 0,
-	@VersionDate DATETIME = NULL OUTPUT
+	@Version     VARCHAR(30) = NULL OUTPUT,
+	@VersionDate DATETIME = NULL OUTPUT,
+    @VersionCheckMode BIT = 0
 AS
     BEGIN
         SET NOCOUNT ON;
-		DECLARE @Version VARCHAR(30);
 		SET @Version = '3.2';
 		SET @VersionDate = '20190128';
+		
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
 
 IF @Help = 1
 

--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -25,15 +25,21 @@ ALTER PROCEDURE dbo.sp_ineachdb
   @is_broker_enabled   bit = NULL,
   @user_access         nvarchar(128)  = NULL, 
   @Help                BIT = 0,
-  @VersionDate DATETIME = NULL OUTPUT
+  @Version             VARCHAR(30)    = NULL OUTPUT,
+  @VersionDate         DATETIME       = NULL OUTPUT,
+  @VersionCheckMode    BIT            = 0
 -- WITH EXECUTE AS OWNER – maybe not a great idea, depending on the security your system
 AS
 BEGIN
   SET NOCOUNT ON;
-  DECLARE @Version VARCHAR(30);
+
   SET @Version = '2.2';
   SET @VersionDate = '20190128';
-
+  
+IF(@VersionCheckMode = 1)
+BEGIN
+	RETURN;
+END;
 IF @Help = 1
 
 	BEGIN


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - In sp_BlitzInMemoryOLTP => changed internal variable name from @Version to @MSSQLVersion
 - In all stored procs, added @Version VARCHAR(30) as OUTPUT parameter
 - In all stored procs, added @VersionCheckMode BIT which when set to 1 ends almost directly the SP

How to test this code:
Call each SP as usual
Call each SP with @VersionCheckMode = 1
For instance:

DECLARE @BlitzCacheVersion     VARCHAR(30);
DECLARE @BlitzCacheVersionDate DATETIME2;
EXEC dbo.sp_BlitzCache @VersionCheckMode = 1, @Version = @BlitzCacheVersion OUTPUT, @VersionDate = @BlitzCacheVersionDate OUTPUT ;
SELECT @BlitzCacheVersion as BlitzCacheVersion , @BlitzCacheVersionDate as BlitzCacheVersionDate


Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2016
