### PR TITLE
1950 sp blitz lock azure sql db hyperscale

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -176,7 +176,7 @@ You need to use an Azure storage account, and the path has to look like this: ht
 			finding NVARCHAR(4000)
 		);
 
-        DECLARE @d VARCHAR(40);
+        DECLARE @d VARCHAR(40), @StringToExecute NVARCHAR(4000)
 
         CREATE TABLE #t (id INT NOT NULL);
         UPDATE STATISTICS #t WITH ROWCOUNT = 100000000, PAGECOUNT = 100000000;
@@ -555,17 +555,19 @@ You need to use an Azure storage account, and the path has to look like this: ht
         ALTER TABLE #agent_job ADD job_name NVARCHAR(256),
                                    step_name NVARCHAR(256);
 
-        
-        UPDATE aj
-        SET  aj.job_name = j.name, 
-             aj.step_name = s.step_name
-		FROM msdb.dbo.sysjobs AS j
-		JOIN msdb.dbo.sysjobsteps AS s 
-            ON j.job_id = s.job_id
-        JOIN #agent_job AS aj
-            ON  aj.job_id_guid = j.job_id
-            AND aj.step_id = s.step_id;
-
+        IF SERVERPROPERTY('EngineEdition') NOT IN (5, 6) /* Azure SQL DB doesn't support querying jobs */
+            BEGIN
+            SET @StringToExecute = N'UPDATE aj
+                    SET  aj.job_name = j.name, 
+                         aj.step_name = s.step_name
+		            FROM msdb.dbo.sysjobs AS j
+		            JOIN msdb.dbo.sysjobsteps AS s 
+                        ON j.job_id = s.job_id
+                    JOIN #agent_job AS aj
+                        ON  aj.job_id_guid = j.job_id
+                        AND aj.step_id = s.step_id;';
+            EXEC(@StringToExecute);
+            END
 
         UPDATE dp
            SET dp.client_app = 
@@ -1225,4 +1227,3 @@ You need to use an Azure storage account, and the path has to look like this: ht
     END; --Final End
 
 GO
-

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -176,7 +176,7 @@ You need to use an Azure storage account, and the path has to look like this: ht
 			finding NVARCHAR(4000)
 		);
 
-        DECLARE @d VARCHAR(40), @StringToExecute NVARCHAR(4000)
+        DECLARE @d VARCHAR(40), @StringToExecute NVARCHAR(4000);
 
         CREATE TABLE #t (id INT NOT NULL);
         UPDATE STATISTICS #t WITH ROWCOUNT = 100000000, PAGECOUNT = 100000000;


### PR DESCRIPTION
Fixes #1950.

Changes proposed in this pull request:
 - Skip sysjobs query on Azure SQL DB Hyperscale.

Has been tested on (remove any that don't apply):
 - Azure SQL DB Hyperscale