### PR TITLE
Update sp_BlitzCache.sql

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3982,6 +3982,7 @@ IF EXISTS ( SELECT 1/0
 		FROM #missing_index_detail AS m
 		JOIN ##bou_BlitzCacheProcs AS bbcp
 		ON m.SqlHandle = bbcp.SqlHandle
+		AND m.QueryHash = bbcp.QueryHash
 		OPTION (RECOMPILE);
 		
 		RAISERROR(N'Inserting to #index_spool_ugly', 0, 1) WITH NOWAIT;


### PR DESCRIPTION
Complete the join between #missing_index_detail and ##bou_BlitzCacheProcs as otherwise on servers running jobs with many steps, each with missing indices, will cause #missing_index_pretty to grow exponentially, causing sp_BlitzCache to run for hours.

Fixes # .


Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - SQL Server 2017
