### PR TITLE
#1952 sp_BlitzIndex Fix INSERT query column order

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -4569,8 +4569,6 @@ BEGIN;
 											[schema_name], 
 											[table_name], 
 											[index_name],
-                                            [Drop_Tsql],
-                                            [Create_Tsql], 
 											[index_id], 
 											[db_schema_object_indexid], 
 											[object_type], 
@@ -4631,6 +4629,8 @@ BEGIN;
 											[create_date], 
 											[modify_date], 
 											[more_info],
+                                            [Drop_Tsql],
+                                            [Create_Tsql], 
 											[display_order]
 										)
 									SELECT ''@@@RunID@@@'',


### PR DESCRIPTION
Fixes #1952 

Changes proposed in this pull request:
 - Move two columns in the INSERT query to the correct location based on the SELECT query

How to test this code:
 - Run sp_BlitzIndex with 
```SQL
exec master.dbo.sp_BlitzIndex @GetAllDatabases = 0, 
                              @Mode=2,
                              @DatabaseName = 'dba',
                              @OutputDatabaseName = 'dba', 
                              @OutputSchemaName = 'dbo',
                              @OutputTableName = 'T_BlitzIndex_Results',
                              @BringThePain = 1
```

Has been tested on (remove any that don't apply):
 - SQL Server 2014
 - SQL Server 2008 R2
