### PR TITLE
Fixes #1943 - sp_Blitz check if SSIS/SSRS/SSAS are running

### DIFF
--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -239,8 +239,8 @@ If you want to add a new one, start at 225.
 | 200 | Performance | Old Compatibility Level | https://www.BrentOzar.com/go/compatlevel | 62 |
 | 200 | Performance | Query Store Disabled | https://www.BrentOzar.com/go/querystore | 163 |
 | 200 | Performance | Snapshot Backups Occurring | https://www.BrentOzar.com/go/snaps | 178 |
-| 200 | Performance | User-Created Statistics In Place | https://www.BrentOzar.com/go/userstats | 224 |
-| 200 | Performance | SSRS/SSAS/SSIS Installed | https://www.BrentOzar.com/ | 122 |
+| 200 | Performance | User-Created Statistics In Place | https://www.BrentOzar.com/go/userstats | 122 |
+| 200 | Performance | SSRS/SSAS/SSIS Installed | https://www.BrentOzar.com/ | 224 |
 | 200 | Reliability | Extended Stored Procedures in Master | https://www.BrentOzar.com/go/clr | 105 |
 | 200 | Surface Area | Endpoints Configured | https://www.BrentOzar.com/go/endpoints/ | 9 |
 | 210 | Non-Default Database Config | ANSI NULL Default Enabled | https://www.BrentOzar.com/go/dbdefaults | 135 |

--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -6,7 +6,7 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 223.  
+CURRENT HIGH CHECKID: 224.  
 If you want to add a new one, start at 225.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |

--- a/Documentation/sp_Blitz Checks by Priority.md
+++ b/Documentation/sp_Blitz Checks by Priority.md
@@ -7,7 +7,7 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
 CURRENT HIGH CHECKID: 223.  
-If you want to add a new one, start at 224.
+If you want to add a new one, start at 225.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -239,7 +239,8 @@ If you want to add a new one, start at 224.
 | 200 | Performance | Old Compatibility Level | https://www.BrentOzar.com/go/compatlevel | 62 |
 | 200 | Performance | Query Store Disabled | https://www.BrentOzar.com/go/querystore | 163 |
 | 200 | Performance | Snapshot Backups Occurring | https://www.BrentOzar.com/go/snaps | 178 |
-| 200 | Performance | User-Created Statistics In Place | https://www.BrentOzar.com/go/userstats | 122 |
+| 200 | Performance | User-Created Statistics In Place | https://www.BrentOzar.com/go/userstats | 224 |
+| 200 | Performance | SSRS/SSAS/SSIS Installed | https://www.BrentOzar.com/ | 122 |
 | 200 | Reliability | Extended Stored Procedures in Master | https://www.BrentOzar.com/go/clr | 105 |
 | 200 | Surface Area | Endpoints Configured | https://www.BrentOzar.com/go/endpoints/ | 9 |
 | 210 | Non-Default Database Config | ANSI NULL Default Enabled | https://www.BrentOzar.com/go/dbdefaults | 135 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7828,9 +7828,9 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
                                     
                                     IF EXISTS (SELECT 1 
                                                 FROM #services 
-                                                WHERE cmdshell_output LIKE 'SQL Server Reporting Services%'
-                                                    OR cmdshell_output LIKE 'SQL Server Integration Services%'
-                                                    OR cmdshell_output LIKE 'SQL Server Analysis Services%')
+                                                WHERE cmdshell_output LIKE '%SQL Server Reporting Services%'
+                                                    OR cmdshell_output LIKE '%SQL Server Integration Services%'
+                                                    OR cmdshell_output LIKE '%SQL Server Analysis Services%')
                                     BEGIN
 								    INSERT  INTO #BlitzResults
 								    		( CheckID ,

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7816,6 +7816,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 							BEGIN
 								
 								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 224) WITH NOWAIT;
+                                
 								IF (SELECT value_in_use FROM  sys.configurations WHERE [name] = 'xp_cmdshell') = 1
                                 BEGIN
                                     
@@ -7844,7 +7845,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								    				,200 AS Priority
 								    				,'Performance' AS FindingsGroup
 								    				,'SSRS/SSIS/SSAS Installed' AS Finding
-								    				,'https://BrentOzar.com/go/trace' AS URL
+								    				,'https://BrentOzar.com/' AS URL
 								    				,'Did you know you have other SQL Server services installed on this box other than the engine? It can be a real performance pain' as Details
 								    									    		
 								    END;


### PR DESCRIPTION
Fixes #1943 

Changes proposed in this pull request:
 - Updates to sp_Blitz to include check 224 - Check for SSIS/SSRS/SSAS on box
 - Updated documentation
 - 

How to test this code:

 - find a box with either SSIS/SSRS/SSAS running (also needs xp_cmdshell enabled) and run sp_Blitz with @CheckServerInfo = 1. You should see a priority 200 - Performance message about this.

I didn't have a relevant link to supply on this so i've just left it as brentozar.com

Has been tested on (remove any that don't apply):
- SQL Server 2014
