### PR TITLE
Fixes #1945 - sp_BlitzCache - Plural checks for @SortOrder

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1027,17 +1027,30 @@ SELECT @MinMemoryPerQuery = CONVERT(INT, c.value) FROM sys.configurations AS c W
 SET @SortOrder = LOWER(@SortOrder);
 SET @SortOrder = REPLACE(REPLACE(@SortOrder, 'average', 'avg'), '.', '');
 SET @SortOrder = REPLACE(@SortOrder, 'executions per minute', 'avg executions');
+SET @SortOrder = REPLACE(@SortOrder, 'execution per minute', 'avg executions');
 SET @SortOrder = REPLACE(@SortOrder, 'executions / minute', 'avg executions');
+SET @SortOrder = REPLACE(@SortOrder, 'execution / minute', 'avg executions');							  
 SET @SortOrder = REPLACE(@SortOrder, 'xpm', 'avg executions');
 SET @SortOrder = REPLACE(@SortOrder, 'recent compilations', 'compiles');
-
+SET @SortOrder = REPLACE(@SortOrder, 'recent compilation', 'compiles');
+SET @SortOrder = REPLACE(@SortOrder, 'compile', 'compiles');
+SET @SortOrder = REPLACE(@SortOrder, 'read', 'reads');
+SET @SortOrder = REPLACE(@SortOrder, 'avg read', 'avg reads');
+SET @SortOrder = REPLACE(@SortOrder, 'write', 'writes');
+SET @SortOrder = REPLACE(@SortOrder, 'avg write', 'avg writes');
+SET @SortOrder = REPLACE(@SortOrder, 'memory grants', 'memory grant');
+SET @SortOrder = REPLACE(@SortOrder, 'avg memory grants', 'avg memory grant');
+SET @SortOrder = REPLACE(@SortOrder, 'spill', 'spills');
+SET @SortOrder = REPLACE(@SortOrder, 'avg spill', 'avg spills');							  
+IF @SortOrder = 'execution' SET @SortOrder = 'executions';
+							  
 RAISERROR(N'Checking sort order', 0, 1) WITH NOWAIT;
 IF @SortOrder NOT IN ('cpu', 'avg cpu', 'reads', 'avg reads', 'writes', 'avg writes',
                        'duration', 'avg duration', 'executions', 'avg executions',
                        'compiles', 'memory grant', 'avg memory grant',
 					   'spills', 'avg spills', 'all', 'all avg', 'sp_BlitzIndex')
   BEGIN
-  RAISERROR(N'Invalid sort order chosen, reverting to cpu', 0, 1) WITH NOWAIT;
+  RAISERROR(N'Invalid sort order chosen, reverting to cpu', 16, 1) WITH NOWAIT;
   SET @SortOrder = 'cpu';
   END; 
 


### PR DESCRIPTION
Fixes #1945 

Changes proposed in this pull request:
 - additional plural checks
 - raise error to sev 16 if invalid sort order passed through

How to test this code:
 - It's easy enough to test with the block below. Otherwise call sp_BlitzCache @SortOrder = 'your string' and check the output is as expected

```
DECLARE @SortOrder varchar(20) = 'execution'

SET @SortOrder = LOWER(@SortOrder);
SET @SortOrder = REPLACE(REPLACE(@SortOrder, 'average', 'avg'), '.', '');
SET @SortOrder = REPLACE(@SortOrder, 'executions per minute', 'avg executions');
SET @SortOrder = REPLACE(@SortOrder, 'execution per minute', 'avg executions');
SET @SortOrder = REPLACE(@SortOrder, 'executions / minute', 'avg executions');
SET @SortOrder = REPLACE(@SortOrder, 'execution / minute', 'avg executions');							  
SET @SortOrder = REPLACE(@SortOrder, 'xpm', 'avg executions');
SET @SortOrder = REPLACE(@SortOrder, 'recent compilations', 'compiles');
SET @SortOrder = REPLACE(@SortOrder, 'recent compilation', 'compiles');
SET @SortOrder = REPLACE(@SortOrder, 'compile', 'compiles');
SET @SortOrder = REPLACE(@SortOrder, 'read', 'reads');
SET @SortOrder = REPLACE(@SortOrder, 'avg read', 'avg reads');
SET @SortOrder = REPLACE(@SortOrder, 'write', 'writes');
SET @SortOrder = REPLACE(@SortOrder, 'avg write', 'avg writes');
SET @SortOrder = REPLACE(@SortOrder, 'memory grants', 'memory grant');
SET @SortOrder = REPLACE(@SortOrder, 'avg memory grants', 'avg memory grant');
SET @SortOrder = REPLACE(@SortOrder, 'spill', 'spills');
SET @SortOrder = REPLACE(@SortOrder, 'avg spill', 'avg spills');							  
IF @SortOrder = 'execution' SET @SortOrder = 'executions';

SELECT @SortOrder

RAISERROR(N'Checking sort order', 0, 1) WITH NOWAIT;
IF @SortOrder NOT IN ('cpu', 'avg cpu', 'reads', 'avg reads', 'writes', 'avg writes',
                       'duration', 'avg duration', 'executions', 'avg executions',
                       'compiles', 'memory grant', 'avg memory grant',
					   'spills', 'avg spills', 'all', 'all avg', 'sp_BlitzIndex')
  BEGIN
  RAISERROR(N'Invalid sort order chosen, reverting to cpu', 0, 1) WITH NOWAIT;
  RAISERROR(N'Invalid sort order chosen, reverting to cpu', 16, 1) WITH NOWAIT;
  SET @SortOrder = 'cpu';
  END;
```

Has been tested on (remove any that don't apply):
 - SQL Server 2012
 - SQL Server 2014
