### PR TITLE
Make sp_BlitzQueryStore installable on versions lower than 2016 but failing

### DIFF
--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -549,7 +549,7 @@ CREATE TABLE #working_plan_text
 	top_three_waits NVARCHAR(MAX)
 ); 
 
-EXEC sp_executesql N'CREATE CLUSTERED INDEX wpt_ix_ids ON #working_plan_text(plan_id, query_id, query_hash);';
+EXEC sp_executesql N'CREATE CLUSTERED INDEX wpt_ix_ids ON #working_plan_text(plan_id, query_id, query_plan_hash);';
 
 /*
 This is where we store warnings that we generate from the XML and metrics


### PR DESCRIPTION
Fixes #1961 .

Changes proposed in this pull request:
 - Moved SQL Server version checking inside the SP
 - Dynamic Query for `DROP TABLE IF EXISTS`
 - Dynamic Query for index creation on temporary tables
 - Dynamic Query for "database with query store enabled check"

How to test this code:
 - `EXEC dbo.sp_BlitzQueryStore` -- fails before SQL Server 2016
 - `EXEC dbo.sp_BlitzQueryStore @DatabaseName = 'XXX'` works on SQL Server 2016
 - 'EXEC dbo.sp_BlitzQueryStore @VersionCheckMode = 1`  -- works in any case

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008 R2
 - SQL Server 2014
 - SQL Server 2016
