### PR TITLE
sp_Blitz - minor typo

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -7796,7 +7796,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
                                 	 		AND c.name IN ('cpu_rate', 'memory_limit_mb', 'process_memory_limit_mb', 'workingset_limit_mb' ))
 							BEGIN
 								
-								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 114) WITH NOWAIT;
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 222) WITH NOWAIT;
 								
 								SET @StringToExecute = 'INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
 										SELECT  222 AS CheckID ,


### PR DESCRIPTION
Fixes #1964  .

Changes proposed in this pull request:
 - fixed typo on RAISERROR to report correct check

How to test this code:
 - run sp_Blitz @CheckServerInfo = 1, look for check 153, the next one should be 222 rather than 114

Has been tested on (remove any that don't apply):
 - SQL Server 2014