### PR TITLE
Issue 1970/henrik staun poulsen

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2763,6 +2763,7 @@ INSERT  INTO #BlitzResults
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 40 )
+                    AND @@VERSION NOT LIKE 'Microsoft SQL Azure (RTM)%'
 					BEGIN
 						IF ( SELECT COUNT(*)
 							 FROM   tempdb.sys.database_files
@@ -3630,6 +3631,7 @@ INSERT  INTO #BlitzResults
 										FROM    #SkipChecks
 										WHERE   DatabaseName IS NULL AND CheckID = 189 )
                             AND SERVERPROPERTY('EngineEdition') <> 8 /* Azure Managed Instances */
+                            AND @@VERSION NOT LIKE 'Microsoft SQL Azure (RTM)%'
 							BEGIN
 							IF (@ProductVersionMajor = 13 AND @ProductVersionMinor < 4001 AND @@VERSION LIKE '%Standard Edition%')
 								BEGIN
@@ -8126,7 +8128,6 @@ GO
 --Sample execution call with the most common parameters:
 EXEC [dbo].[sp_Blitz]
     @CheckUserDatabaseObjects = 1 ,
-
     @CheckProcedureCache = 0 ,
     @OutputType = 'TABLE' ,
     @OutputProcedureCache = 0 ,

--- a/sp_foreachdb.sql
+++ b/sp_foreachdb.sql
@@ -1,3 +1,4 @@
+
 IF OBJECT_ID('dbo.sp_foreachdb') IS NULL
     EXEC ('CREATE PROCEDURE dbo.sp_foreachdb AS RETURN 0');
 GO
@@ -110,6 +111,11 @@ IF @Help = 1
         END;
 
         SET @command1 = COALESCE(@command1,@command);
+
+        IF @@VERSION LIKE 'Microsoft SQL Azure (RTM)%' begin
+            SELECT @command1 = REPLACE(@Command1,'use [?];', '')
+            SELECT @command1 = REPLACE(@Command1,'[?].', '')
+        end
 
         DECLARE @sql NVARCHAR(MAX) ,
             @dblist NVARCHAR(MAX) ,


### PR DESCRIPTION
I think this is ready.

I've found the first problem on Azure SQL DB with sp_blitz.
I had run out of disk space the first time I ran Data Migration Assistant, and that must have left non-clustered indexes disabled, because sp_blitz reported lots of CheckId = 47

So I think my job on SP_Blitz is done, but I cannot find a way to put the label "ReadyToTest" on the stuff.
It contains lots of mundane changes, so that it will run on Azure SQL DB. 
I've also tested the changes on SQL 2017 cu13 and SQL 2008 R2 sp3. Problems found, but I've fixed those.
I do not have any more servers to test on.


