### PR TITLE
First responder consistency check

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -264,10 +264,10 @@ AS
             SubjectName                 VARCHAR(256),
             SubjectFullPath             VARCHAR(1024),
             StatementText               NVARCHAR(MAX),
-            StatementOutputsCounter     BIT, -- currently not used
+            StatementOutputsCounter     BIT,
             OutputCounterExpectedValue  INT,
-            StatementOutputsExecRet     BIT, -- currently not used
-            StatementOutputsDateTime    BIT  -- currently not used
+            StatementOutputsExecRet     BIT,
+            StatementOutputsDateTime    BIT 
         );
 
         /* End of First Responder Kit consistency (temporary tables) */
@@ -4551,7 +4551,7 @@ BEGIN
 
         IF(@StatementCheckName = 'Mandatory')
         BEGIN
-
+            -- outputs counter
             EXEC @ExecRet = sp_executesql @tsql, N'@cnt INT OUTPUT',@cnt = @TmpCnt OUTPUT;
 
             IF(@ExecRet <> 0)
@@ -4635,6 +4635,7 @@ BEGIN
                 CONTINUE;
             END;
 
+            -- outputs counter
             EXEC @ExecRet = sp_executesql @tsql, N'@cnt INT OUTPUT',@cnt = @TmpCnt OUTPUT;
 
             IF(@ExecRet <> 0)
@@ -4674,12 +4675,13 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2264 AS CheckID ,
+                    2266 AS CheckID ,
                     200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
-                    'Component ' + @CurrentComponentFullName + ' is not at the minimum version required to run this procedure' AS Finding ,
+                    'First Responder kit consistency: outdated component (' + @CurrentComponentFullName + ')' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
-                    'VersionCheckMode has been introduced in component version date "20190219". This means its version is from before that date.' AS Details;
+                    'Component ' + @CurrentComponentFullName + ' is not at the minimum version required to run this procedure' + @crlf +
+                    'VersionCheckMode has been introduced in component version date after "20190320". This means its version is lower than or equal to that date.' AS Details;
                 ;            
                             
                 DELETE FROM #StatementsToRun4FRKVersionCheck WHERE SubjectFullPath = @CurrentComponentFullName ;

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8893,7 +8893,7 @@ GO
 
 /*
 --Sample execution call with the most common parameters:
-EXEC [dbo].[sp_Blitz] @Debug = 1
+EXEC [dbo].[sp_Blitz] 
     @CheckUserDatabaseObjects = 1 ,
     @CheckProcedureCache = 0 ,
     @OutputType = 'TABLE' ,

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4337,7 +4337,7 @@ IF(
     NOT EXISTS ( 
         SELECT  1
         FROM    #SkipChecks
-        WHERE   DatabaseName IS NULL AND CheckID = 2000 
+        WHERE   DatabaseName IS NULL AND CheckID = 226 
     )
 )
 BEGIN
@@ -4535,8 +4535,8 @@ BEGIN
                 Details
             )
             SELECT 
-                2000 AS CheckID ,
-                1 AS Priority ,
+                2260 AS CheckID ,
+                200 AS Priority ,
                 'Reliability' AS FindingsGroup ,
                 'First Responder kit consistency check has been unexpectedly modified (check names)' AS Finding ,
                 'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4566,8 +4566,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2261 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'First Responder kit consistency check has been unexpectedly modified (dynamic query failure)' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4592,8 +4592,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2262 AS CheckID ,
+                    200 AS Priority ,
                     'Features' AS FindingsGroup ,
                     'First Responder kit mandatory component called "' + @CurrentComponentName + '" is missing' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4621,8 +4621,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2263 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'First Responder kit consistency check has been unexpectedly modified (checks ordering)' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4648,8 +4648,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2261 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'First Responder kit consistency check has been unexpectedly modified (dynamic query failure)' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4674,8 +4674,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2264 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'Component ' + @CurrentComponentFullName + ' is not at the minimum version required to run this procedure' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4702,8 +4702,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2263 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'First Responder kit consistency check has been unexpectedly modified (checks ordering)' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4729,8 +4729,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2261 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'First Responder kit consistency check has been unexpectedly modified (dynamic query failure)' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4756,8 +4756,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2265 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'First Responder kit consistency check (Failed dynamic SP call to ' + @CurrentComponentFullName + ')' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4784,8 +4784,8 @@ BEGIN
                     Details
                 )
                 SELECT 
-                    2000 AS CheckID ,
-                    1 AS Priority ,
+                    2266 AS CheckID ,
+                    200 AS Priority ,
                     'Reliability' AS FindingsGroup ,
                     'First Responder kit consistency: outdated component (' + @CurrentComponentFullName + ')' AS Finding ,
                     'https://www.BrentOzar.com/blitz/' AS URL ,
@@ -4807,6 +4807,7 @@ BEGIN
                     SET @MaximumVersionDate = @CurrentComponentVersionDate;
                 END;
             END;
+            /* Kept for debug purpose:
             ELSE 
             BEGIN
                 INSERT  INTO #BlitzResults( 
@@ -4826,6 +4827,7 @@ BEGIN
                     'Version date is: ' + CONVERT(VARCHAR(32),@CurrentComponentVersionDate,121) AS Details
                 ;
             END;
+            */
         END;
 
         -- could be performed differently to minimize computation


### PR DESCRIPTION
Addresses #1994 

Tested on SQL Server 2008 R2 and 2014 with missing components.

I added the schema name in the equation because I'm transferring all the First Responder Kit objects to another schema (FirstResponderKit) with a custom PS script. 

It's possible, for instance for testing purpose, that objects resides in both 'FirstResponderKit' and 'dbo' schemas.

The main idea here was to generate the set of commands to be executed so that the overhead of adding a new object is minimal.

As I'm writing, it would also be easy to add to this check the capability to pinpoint depreciated components (like sp_BlitzTrace), but this would be the subject of another pull request.