### PR TITLE
Add linguist overrides for correct syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,8 @@ BlitzBuilder/ export-ignore
 sp_AskBrent/ export-ignore
 sp_Blitz/ export-ignore
 sp_BlitzIndex/ export-ignore
+
+# linguist overrides
+*.sql linguist-language=TSQL
+*.R linguist-language=R
+*.ps1 linguist-language=Powershell


### PR DESCRIPTION
TSQL is being misclassified as PLpgSQL for repo:
![image](https://user-images.githubusercontent.com/6460726/63675374-56ded280-c7f1-11e9-96dd-559d5769f499.png)


Adding linguist overrides to `.gitattributes` file solve this issue but after editing one of the affected files to force a refresh.

See more details here https://github.com/github/linguist/issues/4622