### PR TITLE
#2062 sp_BlitzFirst false alarm on index reorgs

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -1369,6 +1369,7 @@ BEGIN
     CROSS APPLY sys.dm_exec_sql_text(r.sql_handle) AS t
     WHERE r.command LIKE 'DBCC%'
 	AND CAST(t.text AS NVARCHAR(4000)) NOT LIKE '%dm_db_index_physical_stats%'
+	AND CAST(t.text AS NVARCHAR(4000)) NOT LIKE '%ALTER INDEX%'
 	AND r.database_id NOT IN (SELECT database_id FROM #ReadableDBs);
 
 


### PR DESCRIPTION
Filtering for sql_text not like %alter index%'. Closes #2062 with duct tape.