### PR TITLE
Issue 2051 query hash sort

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1136,7 +1136,7 @@ IF @SortOrder IN ('all', 'all avg')
 
 IF @SortOrder = 'query hash'
 	BEGIN
-	RAISERROR(N'Checking longest runing queries with multiple plans', 0, 1) WITH NOWAIT;
+	RAISERROR(N'Checking most CPU-intensive queries with multiple plans', 0, 1) WITH NOWAIT;
     GOTO QueryHash;
 	END;
 
@@ -6466,7 +6466,7 @@ BEGIN
 	         @qhg = STUFF((SELECT DISTINCT N',' + CONVERT(NVARCHAR(MAX), qhg.query_hash, 1) 
     FROM #query_hash_grouped AS qhg 
     WHERE qhg.query_hash <> 0x00
-    FOR XML PATH(N''), TYPE).value(N'.[1]', N'NVARCHAR(MAX)'), 1, 1, N'''')
+    FOR XML PATH(N''), TYPE).value(N'.[1]', N'NVARCHAR(MAX)'), 1, 1, N'')
 	OPTION(RECOMPILE);
     
     EXEC sp_BlitzCache @Top = @Top,

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -6443,7 +6443,7 @@ END;
 
 /*Begin*/
 QueryHash:
-RAISERROR('Beginning query hash ', 0, 1) WITH NOWAIT;
+RAISERROR('Beginning query hash sort', 0, 1) WITH NOWAIT;
 
 BEGIN
 


### PR DESCRIPTION
Grabs top 10 highest cpu consuming plans with highest count of query hashes (multiple plans), and runs BlitsCache to find them.

Some quick notes:
- Doesn't change anything for the collector
- Adds a new sort order! Documentation for `@Help` was updated to reflect
- Adds a GOTO 👎 
- I added a self-imposed query requirement to group by database id, to avoid queries with the same hash that run in multiple databases which may be parameterized, etc.
- The rest is pretty self-explanatory: BlitzCache is re-executed with all passed in parameters, and the list of query hashes gathered
- Sort order is not passed to the calling block to prevent an infinite loop 💯 💯 💯 
- Sort order defaults back to cpu, but I'm fine with that changing (or if you want a `@SecondarySortOrder` parameter)