### PR TITLE
Fix Cannot resolve collation conflict between "Language_A" and "Language_B" in add operator occurring in ORDER BY statement column 3.

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2502,7 +2502,7 @@ BEGIN;
                         N'http://BrentOzar.com/go/AggressiveIndexes' AS URL,
                         i.db_schema_object_indexid + N': ' +
                             sz.index_lock_wait_summary + N' NC indexes on table: ' +
-							 CAST(COALESCE((SELECT SUM(1) 
+							 COALESCE((SELECT SUM(1) 
 							                FROM #IndexSanity iMe 
 											INNER JOIN #IndexSanity iOthers 
 												ON iMe.database_id = iOthers.database_id 
@@ -2511,8 +2511,7 @@ BEGIN;
 											WHERE i.index_sanity_id = iMe.index_sanity_id
 											AND iOthers.is_hypothetical = 0
 											AND iOthers.is_disabled = 0
-										   ), 0)
-                                         AS NVARCHAR(30))	 AS details, 
+										   ), 0) AS details, 
                         i.index_definition,
                         i.secret_columns,
                         i.index_usage_summary,
@@ -2559,7 +2558,7 @@ BEGIN;
                         N'http://BrentOzar.com/go/AggressiveIndexes' AS URL,
                         i.db_schema_object_indexid + N': ' +
                             sz.index_lock_wait_summary + N' NC indexes on table: ' +
-							 CAST(COALESCE((SELECT SUM(1) 
+							 COALESCE((SELECT SUM(1) 
 							                FROM #IndexSanity iMe 
 											INNER JOIN #IndexSanity iOthers 
 												ON iMe.database_id = iOthers.database_id 
@@ -2568,8 +2567,7 @@ BEGIN;
 											WHERE i.index_sanity_id = iMe.index_sanity_id
 											AND iOthers.is_hypothetical = 0
 											AND iOthers.is_disabled = 0
-										   ),0)
-                                         AS NVARCHAR(30))	 AS details, 
+										   ),0) AS details, 
                         i.index_definition,
                         i.secret_columns,
                         i.index_usage_summary,


### PR DESCRIPTION
I have problem when I run sp_BlitzIndex on database with different collation to tempdb. And found problem on step that script casts int to nvarchar. Casting will create different collation to temp table, and it causes exception when sorting.

I fixed it by remove casting. int can be concatenated to nvarchar without casting.