### PR TITLE
Fix Cannot resolve collation conflict between "Language_A" and "Language_B" in add operator occurring in ORDER BY statement column 3.

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2500,9 +2500,9 @@ BEGIN;
                         N'Total lock wait time > 5 minutes (row + page) with long average waits' AS finding, 
                         [database_name] AS [Database Name],
                         N'http://BrentOzar.com/go/AggressiveIndexes' AS URL,
-                        i.db_schema_object_indexid + N': ' +
-                            sz.index_lock_wait_summary + N' NC indexes on table: ' +
-							 COALESCE((SELECT SUM(1) 
+                        (i.db_schema_object_indexid + N': ' +
+                            sz.index_lock_wait_summary + N' NC indexes on table: ') COLLATE DATABASE_DEFAULT +
+							 CAST(COALESCE((SELECT SUM(1) 
 							                FROM #IndexSanity iMe 
 											INNER JOIN #IndexSanity iOthers 
 												ON iMe.database_id = iOthers.database_id 
@@ -2511,7 +2511,8 @@ BEGIN;
 											WHERE i.index_sanity_id = iMe.index_sanity_id
 											AND iOthers.is_hypothetical = 0
 											AND iOthers.is_disabled = 0
-										   ), 0) AS details, 
+										   ), 0)
+                                         AS NVARCHAR(30))	 AS details, 
                         i.index_definition,
                         i.secret_columns,
                         i.index_usage_summary,
@@ -2556,9 +2557,9 @@ BEGIN;
                         N'Total lock wait time > 5 minutes (row + page) with short average waits' AS finding, 
                         [database_name] AS [Database Name],
                         N'http://BrentOzar.com/go/AggressiveIndexes' AS URL,
-                        i.db_schema_object_indexid + N': ' +
-                            sz.index_lock_wait_summary + N' NC indexes on table: ' +
-							 COALESCE((SELECT SUM(1) 
+                        (i.db_schema_object_indexid + N': ' +
+                            sz.index_lock_wait_summary + N' NC indexes on table: ') COLLATE DATABASE_DEFAULT +
+							 CAST(COALESCE((SELECT SUM(1) 
 							                FROM #IndexSanity iMe 
 											INNER JOIN #IndexSanity iOthers 
 												ON iMe.database_id = iOthers.database_id 
@@ -2567,7 +2568,8 @@ BEGIN;
 											WHERE i.index_sanity_id = iMe.index_sanity_id
 											AND iOthers.is_hypothetical = 0
 											AND iOthers.is_disabled = 0
-										   ),0) AS details, 
+										   ),0)
+                                         AS NVARCHAR(30))	 AS details, 
                         i.index_definition,
                         i.secret_columns,
                         i.index_usage_summary,

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2502,7 +2502,7 @@ BEGIN;
                         N'http://BrentOzar.com/go/AggressiveIndexes' AS URL,
                         i.db_schema_object_indexid + N': ' +
                             sz.index_lock_wait_summary + N' NC indexes on table: ' +
-							 CAST(COALESCE((SELECT SUM(1) 
+							 COALESCE((SELECT SUM(1) 
 							                FROM #IndexSanity iMe 
 											INNER JOIN #IndexSanity iOthers 
 												ON iMe.database_id = iOthers.database_id 
@@ -2511,8 +2511,7 @@ BEGIN;
 											WHERE i.index_sanity_id = iMe.index_sanity_id
 											AND iOthers.is_hypothetical = 0
 											AND iOthers.is_disabled = 0
-										   ), 0)
-                                         AS NVARCHAR(30))	 AS details, 
+										   ), 0) AS details, 
                         i.index_definition,
                         i.secret_columns,
                         i.index_usage_summary,
@@ -2559,7 +2558,7 @@ BEGIN;
                         N'http://BrentOzar.com/go/AggressiveIndexes' AS URL,
                         i.db_schema_object_indexid + N': ' +
                             sz.index_lock_wait_summary + N' NC indexes on table: ' +
-							 CAST(COALESCE((SELECT SUM(1) 
+							 COALESCE((SELECT SUM(1) 
 							                FROM #IndexSanity iMe 
 											INNER JOIN #IndexSanity iOthers 
 												ON iMe.database_id = iOthers.database_id 
@@ -2568,8 +2567,7 @@ BEGIN;
 											WHERE i.index_sanity_id = iMe.index_sanity_id
 											AND iOthers.is_hypothetical = 0
 											AND iOthers.is_disabled = 0
-										   ),0)
-                                         AS NVARCHAR(30))	 AS details, 
+										   ),0) AS details, 
                         i.index_definition,
                         i.secret_columns,
                         i.index_usage_summary,


### PR DESCRIPTION
This is to fix collation problem when running sp_BlitzIndex. Solution in #2126 will produce exception when rows exists.