### PR TITLE
#2136 Fix BlitzQS DB Name Comparison for Query Store Check.

### DIFF
--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -200,7 +200,7 @@ IF  (	SELECT COUNT(*)
 		PRINT @msg;
 		RETURN;
 	END;
-
+									
 /*Making sure your databases are using QDS.*/
 RAISERROR('Checking database validity', 0, 1) WITH NOWAIT;
 
@@ -241,14 +241,14 @@ END;
 /*Does it have Query Store enabled?*/
 RAISERROR('Making sure [%s] has Query Store enabled', 0, 1, @DatabaseName) WITH NOWAIT;
 IF 	
-	((DB_ID(@DatabaseName)) IS NOT NULL AND @DatabaseName <> '')
-AND		
-	(   SELECT DB_NAME(d.database_id)
-		FROM sys.databases AS d
-		WHERE d.is_query_store_on = 1
-		AND d.user_access_desc='MULTI_USER'
-		AND d.state_desc = 'ONLINE'
-		AND DB_NAME(d.database_id) = @DatabaseName ) IS NULL
+
+	( SELECT [d].[name]
+		FROM [sys].[databases] AS d
+		WHERE [d].[is_query_store_on] = 1
+		AND [d].[user_access_desc]='MULTI_USER'
+		AND [d].[state_desc] = 'ONLINE'
+		AND [d].[database_id] = (SELECT database_id FROM sys.databases WHERE name = @DatabaseName)
+	) IS NULL
 BEGIN
 	RAISERROR('The @DatabaseName you specified ([%s]) does not have the Query Store enabled. Please check the name or settings, and try again.', 0, 1, @DatabaseName) WITH	NOWAIT;
 	RETURN;


### PR DESCRIPTION
I've added in a new parameter which sets the database ID to what it is in `sys.databases`, rather than using the result from `DB_ID`, as this can differ in Azure SQL DB and the docs advise using `sys.databases` for comparisons. (Documented [here](https://docs.microsoft.com/en-us/sql/t-sql/functions/db-id-transact-sql?view=sql-server-2017))

Comparisons for the check on whether or not query store is enabled are then done just using the DatabaseName and DatabaseID variables and comparing them with the values in `sys.databases`.

There are possibly other places those functions will be causing problems in Azure, but having tested this change I at least managed to get this working correctly and the script will now run on a readable secondary and return the query store results from the primary.

Closes #2136 