### PR TITLE
Remove Square Braces

### DIFF
--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -37045,7 +37045,7 @@ GO
 IF OBJECT_ID('dbo.sp_DatabaseRestore') IS NULL
 	EXEC ('CREATE PROCEDURE dbo.sp_DatabaseRestore AS RETURN 0;');
 GO
-ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
+ALTER PROCEDURE dbo.sp_DatabaseRestore
     @Database NVARCHAR(128) = NULL, 
     @RestoreDatabaseName NVARCHAR(128) = NULL, 
     @BackupPathFull NVARCHAR(260) = NULL, 
@@ -38276,7 +38276,7 @@ IF OBJECT_ID('dbo.sp_ineachdb') IS NULL
     EXEC ('CREATE PROCEDURE dbo.sp_ineachdb AS RETURN 0')
 GO
 
-ALTER PROCEDURE [dbo].[sp_ineachdb]
+ALTER PROCEDURE dbo.sp_ineachdb
   -- mssqltips.com/sqlservertip/5694/execute-a-command-in-the-context-of-each-database-in-sql-server--part-2/
   @command             nvarchar(max) = NULL,
   @replace_character   nchar(1) = N'?',

--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -2811,7 +2811,7 @@ IF OBJECT_ID('dbo.sp_Blitz') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_Blitz AS RETURN 0;');
 GO
 
-ALTER PROCEDURE [dbo].[sp_Blitz]
+ALTER PROCEDURE dbo.sp_Blitz
     @Help TINYINT = 0 ,
     @CheckUserDatabaseObjects TINYINT = 1 ,
     @CheckProcedureCache TINYINT = 0 ,
@@ -11786,7 +11786,7 @@ GO
 
 /*
 --Sample execution call with the most common parameters:
-EXEC [dbo].[sp_Blitz] 
+EXEC dbo.sp_Blitz
     @CheckUserDatabaseObjects = 1 ,
     @CheckProcedureCache = 0 ,
     @OutputType = 'TABLE' ,
@@ -11797,7 +11797,7 @@ EXEC [dbo].[sp_Blitz]
 IF OBJECT_ID('dbo.sp_BlitzBackups') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_BlitzBackups AS RETURN 0;');
 GO
-ALTER PROCEDURE [dbo].[sp_BlitzBackups]
+ALTER PROCEDURE dbo.sp_BlitzBackups
     @Help TINYINT = 0 ,
 	@HoursBack INT = 168,
 	@MSDBName NVARCHAR(256) = 'msdb',
@@ -20054,7 +20054,7 @@ IF OBJECT_ID('dbo.sp_BlitzFirst') IS NULL
 GO
 
 
-ALTER PROCEDURE [dbo].[sp_BlitzFirst]
+ALTER PROCEDURE dbo.sp_BlitzFirst
     @LogMessage NVARCHAR(4000) = NULL ,
     @Help TINYINT = 0 ,
     @AsOf DATETIMEOFFSET = NULL ,

--- a/Install-Core-Blitz-No-Query-Store.sql
+++ b/Install-Core-Blitz-No-Query-Store.sql
@@ -2,7 +2,7 @@ IF OBJECT_ID('dbo.sp_Blitz') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_Blitz AS RETURN 0;');
 GO
 
-ALTER PROCEDURE [dbo].[sp_Blitz]
+ALTER PROCEDURE dbo.sp_Blitz
     @Help TINYINT = 0 ,
     @CheckUserDatabaseObjects TINYINT = 1 ,
     @CheckProcedureCache TINYINT = 0 ,
@@ -8977,7 +8977,7 @@ GO
 
 /*
 --Sample execution call with the most common parameters:
-EXEC [dbo].[sp_Blitz] 
+EXEC dbo.sp_Blitz
     @CheckUserDatabaseObjects = 1 ,
     @CheckProcedureCache = 0 ,
     @OutputType = 'TABLE' ,
@@ -8988,7 +8988,7 @@ EXEC [dbo].[sp_Blitz]
 IF OBJECT_ID('dbo.sp_BlitzBackups') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_BlitzBackups AS RETURN 0;');
 GO
-ALTER PROCEDURE [dbo].[sp_BlitzBackups]
+ALTER PROCEDURE dbo.sp_BlitzBackups
     @Help TINYINT = 0 ,
 	@HoursBack INT = 168,
 	@MSDBName NVARCHAR(256) = 'msdb',
@@ -17245,7 +17245,7 @@ IF OBJECT_ID('dbo.sp_BlitzFirst') IS NULL
 GO
 
 
-ALTER PROCEDURE [dbo].[sp_BlitzFirst]
+ALTER PROCEDURE dbo.sp_BlitzFirst
     @LogMessage NVARCHAR(4000) = NULL ,
     @Help TINYINT = 0 ,
     @AsOf DATETIMEOFFSET = NULL ,

--- a/Install-Core-Blitz-With-Query-Store.sql
+++ b/Install-Core-Blitz-With-Query-Store.sql
@@ -2,7 +2,7 @@ IF OBJECT_ID('dbo.sp_Blitz') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_Blitz AS RETURN 0;');
 GO
 
-ALTER PROCEDURE [dbo].[sp_Blitz]
+ALTER PROCEDURE dbo.sp_Blitz
     @Help TINYINT = 0 ,
     @CheckUserDatabaseObjects TINYINT = 1 ,
     @CheckProcedureCache TINYINT = 0 ,
@@ -8977,7 +8977,7 @@ GO
 
 /*
 --Sample execution call with the most common parameters:
-EXEC [dbo].[sp_Blitz] 
+EXEC dbo.sp_Blitz
     @CheckUserDatabaseObjects = 1 ,
     @CheckProcedureCache = 0 ,
     @OutputType = 'TABLE' ,
@@ -8988,7 +8988,7 @@ EXEC [dbo].[sp_Blitz]
 IF OBJECT_ID('dbo.sp_BlitzBackups') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_BlitzBackups AS RETURN 0;');
 GO
-ALTER PROCEDURE [dbo].[sp_BlitzBackups]
+ALTER PROCEDURE dbo.sp_BlitzBackups
     @Help TINYINT = 0 ,
 	@HoursBack INT = 168,
 	@MSDBName NVARCHAR(256) = 'msdb',
@@ -17245,7 +17245,7 @@ IF OBJECT_ID('dbo.sp_BlitzFirst') IS NULL
 GO
 
 
-ALTER PROCEDURE [dbo].[sp_BlitzFirst]
+ALTER PROCEDURE dbo.sp_BlitzFirst
     @LogMessage NVARCHAR(4000) = NULL ,
     @Help TINYINT = 0 ,
     @AsOf DATETIMEOFFSET = NULL ,

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2,7 +2,7 @@ IF OBJECT_ID('dbo.sp_Blitz') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_Blitz AS RETURN 0;');
 GO
 
-ALTER PROCEDURE [dbo].[sp_Blitz]
+ALTER PROCEDURE dbo.sp_Blitz
     @Help TINYINT = 0 ,
     @CheckUserDatabaseObjects TINYINT = 1 ,
     @CheckProcedureCache TINYINT = 0 ,
@@ -8977,7 +8977,7 @@ GO
 
 /*
 --Sample execution call with the most common parameters:
-EXEC [dbo].[sp_Blitz] 
+EXEC dbo.sp_Blitz
     @CheckUserDatabaseObjects = 1 ,
     @CheckProcedureCache = 0 ,
     @OutputType = 'TABLE' ,

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -1,7 +1,7 @@
 IF OBJECT_ID('dbo.sp_BlitzBackups') IS NULL
   EXEC ('CREATE PROCEDURE dbo.sp_BlitzBackups AS RETURN 0;');
 GO
-ALTER PROCEDURE [dbo].[sp_BlitzBackups]
+ALTER PROCEDURE dbo.sp_BlitzBackups
     @Help TINYINT = 0 ,
 	@HoursBack INT = 168,
 	@MSDBName NVARCHAR(256) = 'msdb',

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -3,7 +3,7 @@ IF OBJECT_ID('dbo.sp_BlitzFirst') IS NULL
 GO
 
 
-ALTER PROCEDURE [dbo].[sp_BlitzFirst]
+ALTER PROCEDURE dbo.sp_BlitzFirst
     @LogMessage NVARCHAR(4000) = NULL ,
     @Help TINYINT = 0 ,
     @AsOf DATETIMEOFFSET = NULL ,

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -1,7 +1,7 @@
 IF OBJECT_ID('dbo.sp_DatabaseRestore') IS NULL
 	EXEC ('CREATE PROCEDURE dbo.sp_DatabaseRestore AS RETURN 0;');
 GO
-ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
+ALTER PROCEDURE dbo.sp_DatabaseRestore
     @Database NVARCHAR(128) = NULL, 
     @RestoreDatabaseName NVARCHAR(128) = NULL, 
     @BackupPathFull NVARCHAR(260) = NULL, 
@@ -682,7 +682,7 @@ BEGIN
 			        PRINT @sql;
 		        END;
 		        IF @Debug IN (0, 1) AND @Execute = 'Y'
-			        EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'ALTER DATABASE SINGLE_USER', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			        EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'ALTER DATABASE SINGLE_USER', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
             END
             IF @ExistingDBAction IN (2, 3)
             BEGIN
@@ -701,7 +701,7 @@ BEGIN
 			        PRINT @sql;
 		        END;
                 IF @Debug IN (0, 1) AND @Execute = 'Y'
-			        EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'KILL', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			        EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'KILL', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
             END
             IF @ExistingDBAction = 3
             BEGIN
@@ -714,7 +714,7 @@ BEGIN
 			        PRINT @sql;
 		        END;
 		        IF @Debug IN (0, 1) AND @Execute = 'Y'
-			        EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'DROP DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			        EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'DROP DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
             END
         END
         ELSE
@@ -768,7 +768,7 @@ BEGIN
 		END;
 			
 		IF @Debug IN (0, 1) AND @Execute = 'Y'
-			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 
     -- We already loaded #Headers above
 
@@ -888,7 +888,7 @@ BEGIN
 			PRINT @sql;
 		END;  
 		IF @Debug IN (0, 1) AND @Execute = 'Y'
-			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 		
 		--get the backup completed data so we can apply tlogs from that point forwards                                                   
 		SET @sql = REPLACE(@HeadersSQL, N'{Path}', @BackupPathDiff + @LastDiffBackup);
@@ -1129,7 +1129,7 @@ FETCH NEXT FROM BackupFiles INTO @BackupFile;
 					END; 
 				
 					IF @Debug IN (0, 1) AND @Execute = 'Y'
-						EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE LOG', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+						EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'RESTORE LOG', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 			END;
 			
 			FETCH NEXT FROM BackupFiles INTO @BackupFile;
@@ -1157,7 +1157,7 @@ IF @RunRecovery = 1
 			END; 
 
 		IF @Debug IN (0, 1) AND @Execute = 'Y'
-			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;
 
 -- Ensure simple recovery model
@@ -1172,13 +1172,13 @@ IF @ForceSimpleRecovery = 1
 			END; 
 
 		IF @Debug IN (0, 1) AND @Execute = 'Y'
-			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'ALTER DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'ALTER DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;	    
 
  -- Run checkdb against this database
 IF @RunCheckDB = 1
 	BEGIN
-		SET @sql = N'EXECUTE [dbo].[DatabaseIntegrityCheck] @Databases = ' + @RestoreDatabaseName + N', @LogToTable = ''Y''' + NCHAR(13);
+		SET @sql = N'EXECUTE dbo.DatabaseIntegrityCheck @Databases = ' + @RestoreDatabaseName + N', @LogToTable = ''Y''' + NCHAR(13);
 			
 			IF @Debug = 1 OR @Execute = 'N'
 			BEGIN
@@ -1187,7 +1187,7 @@ IF @RunCheckDB = 1
 			END; 
 		
 		IF @Debug IN (0, 1) AND @Execute = 'Y'
-			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'INTEGRITY CHECK', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'INTEGRITY CHECK', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 	END;
 
 
@@ -1224,7 +1224,7 @@ IF @TestRestore = 1
 			END; 
 		
 		IF @Debug IN (0, 1) AND @Execute = 'Y'
-			EXECUTE @sql = [dbo].[CommandExecute] @Command = @sql, @CommandType = 'DROP DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
+			EXECUTE @sql = dbo.CommandExecute @Command = @sql, @CommandType = 'DROP DATABASE', @Mode = 1, @DatabaseName = @Database, @LogToTable = 'Y', @Execute = 'Y';
 
 	END;
 GO

--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -2,7 +2,7 @@ IF OBJECT_ID('dbo.sp_ineachdb') IS NULL
     EXEC ('CREATE PROCEDURE dbo.sp_ineachdb AS RETURN 0')
 GO
 
-ALTER PROCEDURE [dbo].[sp_ineachdb]
+ALTER PROCEDURE dbo.sp_ineachdb
   -- mssqltips.com/sqlservertip/5694/execute-a-command-in-the-context-of-each-database-in-sql-server--part-2/
   @command             nvarchar(max) = NULL,
   @replace_character   nchar(1) = N'?',


### PR DESCRIPTION
Removed square braces from FRK-specific objects to make it easier to convert this into a series of temporary procs if we can't create them on a target server.  Can now replace "dbo.sp_Blitz" with "##sp_Blitz" and run.