### PR TITLE
#2212 sp_BlitzCache matching warning names

### DIFF
--- a/Documentation/sp_BlitzCache Checks by Priority.md
+++ b/Documentation/sp_BlitzCache Checks by Priority.md
@@ -11,67 +11,67 @@ If you want to add a new check, start at 63
 
 | Priority | FindingsGroup | Finding | URL | CheckID | Expert Mode |
 |----------|---------------------------------|---------------------------------------|-------------------------------------------------|----------|-------------|
-| 100 | Execution Pattern | Frequently Executed Queries | http://brentozar.com/blitzcache/frequently-executed-queries/ | 1 | No |
+| 100 | Execution Pattern | Frequently Execution | http://brentozar.com/blitzcache/frequently-executed-queries/ | 1 | No |
 | 50 | Parameterization | Parameter Sniffing | http://brentozar.com/blitzcache/parameter-sniffing/ | 2 | No |
-| 50 | Parameterization | Forced Plans | http://brentozar.com/blitzcache/forced-plans/ | 3 | No |
-| 200 | Cursors | Cursors | http://brentozar.com/blitzcache/cursors-found-slow-queries/ | 4 | No |
+| 50 | Parameterization | Forced Plan | http://brentozar.com/blitzcache/forced-plans/ | 3 | No |
+| 200 | Cursors | Cursor | http://brentozar.com/blitzcache/cursors-found-slow-queries/ | 4 | No |
 | 200 | Cursors | Optimistic Cursors | http://brentozar.com/blitzcache/cursors-found-slow-queries/ | 4 | No |
 | 200 | Cursors | Non-forward Only Cursors | http://brentozar.com/blitzcache/cursors-found-slow-queries/ | 4 | No |
 | 200 | Cursors | Dynamic Cursors | http://brentozar.com/blitzcache/cursors-found-slow-queries/ | 4 | No |
 | 200 | Cursors | Fast Forward Cursors | http://brentozar.com/blitzcache/cursors-found-slow-queries/ | 4 | No |
 | 50 | Parameterization | Forced Parameterization | http://brentozar.com/blitzcache/forced-parameterization/ | 5 | No |
-| 200 | Execution Plans | Parallelism | http://brentozar.com/blitzcache/parallel-plans-detected/ | 6 | No |
+| 200 | Execution Plans | Parallel | http://brentozar.com/blitzcache/parallel-plans-detected/ | 6 | No |
 | 200 | Execution Plans | Nearly Parallel | http://brentozar.com/blitzcache/query-cost-near-cost-threshold-parallelism/ | 7 | No |
-| 50 | Execution Plans | Query Plan Warnings | http://brentozar.com/blitzcache/query-plan-warnings/ | 8 | No |
-| 50 | Performance | Long Running Queries | http://brentozar.com/blitzcache/long-running-queries/ | 9 | No |
-| 50 | Performance | Missing Index Request | http://brentozar.com/blitzcache/missing-index-request/ | 10 | No |
-| 200 | Cardinality | Legacy Cardinality Estimator in Use | http://brentozar.com/blitzcache/legacy-cardinality-estimator/ | 13 | No |
+| 50 | Execution Plans | Plan Warnings | http://brentozar.com/blitzcache/query-plan-warnings/ | 8 | No |
+| 50 | Performance | Long Running Query | http://brentozar.com/blitzcache/long-running-queries/ | 9 | No |
+| 50 | Performance | Missing Indexes | http://brentozar.com/blitzcache/missing-index-request/ | 10 | No |
+| 200 | Cardinality | Downlevel CE | http://brentozar.com/blitzcache/legacy-cardinality-estimator/ | 13 | No |
 | 50 | Performance | Implicit Conversions | http://brentozar.com/go/implicit | 14 | No |
 | 100 | Performance | Frequently executed operators | http://brentozar.com/blitzcache/busy-loops/ | 16 | Yes |
-| 50 | Performance | Joining to table valued functions | http://brentozar.com/blitzcache/tvf-join/ | 17 | Yes |
+| 50 | Performance | Function Join | http://brentozar.com/blitzcache/tvf-join/ | 17 | Yes |
 | 50 | Execution Plans | Compilation timeout | http://brentozar.com/blitzcache/compilation-timeout/ | 18 | No |
-| 50 | Execution Plans | Compilation memory limit exceeded | http://brentozar.com/blitzcache/compile-memory-limit-exceeded/ | 19 | No |
+| 50 | Execution Plans | Compile Memory Limit Exceeded | http://brentozar.com/blitzcache/compile-memory-limit-exceeded/ | 19 | No |
 | 50 | Execution Plans | No join predicate | http://brentozar.com/blitzcache/no-join-predicate/ | 20 | No |
-| 200 | Execution Plans | Multiple execution plans | http://brentozar.com/blitzcache/multiple-plans/ | 21 | No |
-| 100 | Performance | Unmatched indexes | http://brentozar.com/blitzcache/unmatched-indexes | 22 | No |
-| 100 | Parameterization | Unparameterized queries | http://brentozar.com/blitzcache/unparameterized-queries | 23 | Yes |
+| 200 | Execution Plans | Multiple Plans | http://brentozar.com/blitzcache/multiple-plans/ | 21 | No |
+| 100 | Performance | Unmatched Indexes | http://brentozar.com/blitzcache/unmatched-indexes | 22 | No |
+| 100 | Parameterization | Unparameterized Query | http://brentozar.com/blitzcache/unparameterized-queries | 23 | Yes |
 | 100 | Execution Plans | Trivial Plans | http://brentozar.com/blitzcache/trivial-plans | 24 | No |
 | 10 | Execution Plans | Forced Serialization | http://www.brentozar.com/blitzcache/forced-serialization/ | 25 | No |
-| 100 | Execution Plans | Expensive Key Lookups | http://www.brentozar.com/blitzcache/expensive-key-lookups/ | 26 | No |
+| 100 | Execution Plans | Expensive Key Lookup | http://www.brentozar.com/blitzcache/expensive-key-lookups/ | 26 | No |
 | 100 | Execution Plans | Expensive Remote Query | http://www.brentozar.com/blitzcache/expensive-remote-query/ | 28 |  |
 | 200 | Trace Flags | Session Level Trace Flags Enabled | https://www.brentozar.com/blitz/trace-flags-enabled-globally/ | 29 | No |
-| 100 | Unused memory grants | Queries are asking for more memory than they're using | https://www.brentozar.com/blitzcache/unused-memory-grants/ | 30 | No |
-| 100 | Compute Scalar That References A Function | This could be trouble if you''re using Scalar Functions or MSTVFs |  https://www.brentozar.com/blitzcache/compute-scalar-functions/| 31 | Yes |
-| 100 | Compute Scalar That References A CLR Function | TThis could be trouble if your CLR functions perform data access |  https://www.brentozar.com/blitzcache/compute-scalar-functions/| 31 | Yes |
+| 100 | Memory Grant | Unused Memory Grant | https://www.brentozar.com/blitzcache/unused-memory-grants/ | 30 | No |
+| 100 | Compute Scalar That References A Function | Calls Functions |  https://www.brentozar.com/blitzcache/compute-scalar-functions/| 31 | Yes |
+| 100 | Compute Scalar That References A CLR Function | Calls CLR Functions |  https://www.brentozar.com/blitzcache/compute-scalar-functions/| 31 | Yes |
 | 100 | Table Variables detected | Beware nasty side effects | https://www.brentozar.com/blitzcache/table-variables/ | 33 | No |
-| 100 | Columns with no statistics | Poor cardinality estimates may ensue | https://www.brentozar.com/blitzcache/columns-no-statistics/ | 35 | No |
-| 100 | Operator Warnings | SQL is throwing operator level plan warnings | http://brentozar.com/blitzcache/query-plan-warnings/ | 36 | Yes |
-| 100 | Table Scans | Your database has HEAPs | https://www.brentozar.com/archive/2012/05/video-heaps/ | 37 | No |
-| 200 | Backwards Scans | Indexes are being read backwards | https://www.brentozar.com/blitzcache/backwards-scans/ | 38 | Yes |
-| 100 | Index forcing | Someone is using hints to force index usage | https://www.brentozar.com/blitzcache/optimizer-forcing/ | 39 | Yes |
-| 100 | Seek/Scan forcing | Someone is using hints to force index seeks/scans | https://www.brentozar.com/blitzcache/optimizer-forcing/ | 40 | Yes |
-| 100 | ColumnStore indexes operating in Row Mode | Batch Mode is optimal for ColumnStore indexes | https://www.brentozar.com/blitzcache/columnstore-indexes-operating-row-mode/ | 41 | Yes |
-| 50 | Computed Columns Referencing Scalar UDFs | This makes a whole lot of stuff run serially | https://www.brentozar.com/blitzcache/computed-columns-referencing-functions/ | 42 | Yes |
+| 100 | Statistics | Columns With No Statistics | https://www.brentozar.com/blitzcache/columns-no-statistics/ | 35 | No |
+| 100 | Warnings | Operator Warnings | http://brentozar.com/blitzcache/query-plan-warnings/ | 36 | Yes |
+| 100 | Indexes | Table Scans (Heaps) | https://www.brentozar.com/archive/2012/05/video-heaps/ | 37 | No |
+| 200 | Indexes | Backwards Scans | https://www.brentozar.com/blitzcache/backwards-scans/ | 38 | Yes |
+| 100 | Indexes | Forced Indexes | https://www.brentozar.com/blitzcache/optimizer-forcing/ | 39 | Yes |
+| 100 | Indexes                                       | Forced Seeks/Scans | https://www.brentozar.com/blitzcache/optimizer-forcing/ | 40 | Yes |
+| 100 | Indexes | ColumnStore Row Mode | https://www.brentozar.com/blitzcache/columnstore-indexes-operating-row-mode/ | 41 | Yes |
+| 50 | Functions | Computed Column UDF | https://www.brentozar.com/blitzcache/computed-columns-referencing-functions/ | 42 | Yes |
 | 100 | Execution Plan | Expensive Sort | http://www.brentozar.com/blitzcache/expensive-sorts/ | 43 | No |
-| 50 | Filters Referencing Scalar UDFs | This forces serialization | https://www.brentozar.com/blitzcache/compute-scalar-functions/ | 44 | Yes |
-| 100 | Many Indexes Modified | Write Queries Are Hitting >= 5 Indexes | https://www.brentozar.com/blitzcache/many-indexes-modified/ | 45 | Yes |
-| 200 | Plan Confusion | Row Level Security is in use | https://www.brentozar.com/blitzcache/row-level-security/ | 46 | Yes |
-| 200 | Spatial Abuse | You hit a Spatial Index | https://www.brentozar.com/blitzcache/spatial-indexes/ | 47 | Yes |
-| 150 | Index DML | Indexes were created or dropped | https://www.brentozar.com/blitzcache/index-dml/ | 48 | Yes |
-| 150 | Table DML | Tables were created or dropped | https://www.brentozar.com/blitzcache/table-dml/ | 49 | Yes |
-| 150 | Long Running Low CPU | You have a query that runs for much longer than it uses CPU | https://www.brentozar.com/blitzcache/long-running-low-cpu/ | 50 | No |
-| 150 | Low Cost Query With High CPU | You have a low cost query that uses a lot of CPU | https://www.brentozar.com/blitzcache/low-cost-high-cpu/ | 51 | No |
-| 150 | Biblical Statistics | Statistics used in queries are >7 days old with >100k modifications | https://www.brentozar.com/blitzcache/stale-statistics/ | 52 | No |
-| 200 | Adaptive joins | Living in the future | https://www.brentozar.com/blitzcache/adaptive-joins/ | 53 | No |
-| 150 | Expensive Index Spool | You have an index spool, this is usually a sign that there's an index missing somewhere. | https://www.brentozar.com/blitzcache/eager-index-spools/ | 54 | No |
-| 150 | Index Spools Many Rows | You have an index spool that spools more rows than the query returns | https://www.brentozar.com/blitzcache/eager-index-spools/ | 55 | No |
-| 100 | Potentially bad cardinality estimates | Estimated rows are different from average rows by a factor of 10000 | https://www.brentozar.com/blitzcache/bad-estimates/ | 56 | Yes |
+| 50 | Functions | Filter UDF | https://www.brentozar.com/blitzcache/compute-scalar-functions/ | 44 | Yes |
+| 100 | Indexes | \>= 5 Indexes Modified | https://www.brentozar.com/blitzcache/many-indexes-modified/ | 45 | Yes |
+| 200 | Complexity | Row Level Security | https://www.brentozar.com/blitzcache/row-level-security/ | 46 | Yes |
+| 200 | Complexity | Spatial Index | https://www.brentozar.com/blitzcache/spatial-indexes/ | 47 | Yes |
+| 150 | Complexity                                    | Index DML | https://www.brentozar.com/blitzcache/index-dml/ | 48 | Yes |
+| 150 | Complexity | Table DML | https://www.brentozar.com/blitzcache/table-dml/ | 49 | Yes |
+| 150 | Blocking | Long Running Low CPU | https://www.brentozar.com/blitzcache/long-running-low-cpu/ | 50 | No |
+| 150 | Complexity | Low Cost Query With High CPU | https://www.brentozar.com/blitzcache/low-cost-high-cpu/ | 51 | No |
+| 150 | Statistics | Statistics used have > 100k modifications in the last 7 days | https://www.brentozar.com/blitzcache/stale-statistics/ | 52 | No |
+| 200 | Complexity | Adaptive Joins | https://www.brentozar.com/blitzcache/adaptive-joins/ | 53 | No |
+| 150 | Indexes | Expensive Index Spool | https://www.brentozar.com/blitzcache/eager-index-spools/ | 54 | No |
+| 150 | Indexes | Large Index Row Spool | https://www.brentozar.com/blitzcache/eager-index-spools/ | 55 | No |
+| 100 | Complexity | Row Estimate Mismatch | https://www.brentozar.com/blitzcache/bad-estimates/ | 56 | Yes |
 | 200 | Is Paul White Electric? | This query has a Switch operator in it! | https://www.sql.kiwi/2013/06/hello-operator-my-switch-is-bored.html | 998 | Yes |
 | 200 | Database Level Statistics | Database has stats updated 7 days ago with more than 100k modifications | https://www.brentozar.com/blitzcache/stale-statistics/ | 997 | No |
-| 200 | Row Goals | This query had row goals introduced | https://www.brentozar.com/go/rowgoals/ | 58 | Yes |
-| 100 | tempdb Spills | This query spills >500mb to tempdb on average | https://www.brentozar.com/blitzcache/tempdb-spills/ | 59 | No |
-| 100 | MSTVFs | These have many of the same problems scalar UDFs have | http://brentozar.com/blitzcache/tvf-join/ | 60 | No |
-| 100 | Many to Many Merge | These use secret worktables that could be doing lots of reads | Blog not published yet | 61 | Yes |
+| 200 | Complexity | Row Goals | https://www.brentozar.com/go/rowgoals/ | 58 | Yes |
+| 100 | TempDB | >500mb Spills | https://www.brentozar.com/blitzcache/tempdb-spills/ | 59 | No |
+| 100 | Functions | MSTVFs | http://brentozar.com/blitzcache/tvf-join/ | 60 | No |
+| 100 | Complexity | Many to Many Merge | Blog not published yet | 61 | Yes |
 | 50 | Non-SARGable queries | Queries may have non-SARGable predicates |http://brentozar.com/go/sargable| 62 | No |
 | 50 | Selects w/ Writes | Read queries are causing writes | https://dba.stackexchange.com/questions/191825/ | This is thrown when reads cause writes that are not already flagged as big spills (2016+) or index spools | No |
 | 254 | Plan Cache Information | Breaks cache down by creation date (24/4/1 hrs) | None | 999 | No |

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -4453,13 +4453,13 @@ SET    Warnings = SUBSTRING(
 				  CASE WHEN is_remote_query_expensive = 1 THEN ', Expensive Remote Query' ELSE '' END + 
 				  CASE WHEN trace_flags_session IS NOT NULL THEN ', Session Level Trace Flag(s) Enabled: ' + trace_flags_session ELSE '' END +
 				  CASE WHEN is_unused_grant = 1 THEN ', Unused Memory Grant' ELSE '' END +
-				  CASE WHEN function_count > 0 THEN ', Calls ' + CONVERT(VARCHAR(10), function_count) + ' function(s)' ELSE '' END + 
-				  CASE WHEN clr_function_count > 0 THEN ', Calls ' + CONVERT(VARCHAR(10), clr_function_count) + ' CLR function(s)' ELSE '' END + 
+				  CASE WHEN function_count > 0 THEN ', Calls ' + CONVERT(VARCHAR(10), function_count) + ' Function(s)' ELSE '' END + 
+				  CASE WHEN clr_function_count > 0 THEN ', Calls ' + CONVERT(VARCHAR(10), clr_function_count) + ' CLR Function(s)' ELSE '' END + 
 				  CASE WHEN PlanCreationTimeHours <= 4 THEN ', Plan created last 4hrs' ELSE '' END +
 				  CASE WHEN is_table_variable = 1 THEN ', Table Variables' ELSE '' END +
 				  CASE WHEN no_stats_warning = 1 THEN ', Columns With No Statistics' ELSE '' END +
 				  CASE WHEN relop_warnings = 1 THEN ', Operator Warnings' ELSE '' END  + 
-				  CASE WHEN is_table_scan = 1 THEN ', Table Scans' ELSE '' END  + 
+				  CASE WHEN is_table_scan = 1 THEN ', Table Scans (Heaps)' ELSE '' END  + 
 				  CASE WHEN backwards_scan = 1 THEN ', Backwards Scans' ELSE '' END  + 
 				  CASE WHEN forced_index = 1 THEN ', Forced Indexes' ELSE '' END  + 
 				  CASE WHEN forced_seek = 1 THEN ', Forced Seeks' ELSE '' END  + 
@@ -4479,10 +4479,10 @@ SET    Warnings = SUBSTRING(
 				  CASE WHEN is_adaptive = 1 THEN + ', Adaptive Joins' ELSE '' END +
 				  CASE WHEN is_spool_expensive = 1 THEN + ', Expensive Index Spool' ELSE '' END +
 				  CASE WHEN is_spool_more_rows = 1 THEN + ', Large Index Row Spool' ELSE '' END +
-				  CASE WHEN is_bad_estimate = 1 THEN + ', Row estimate mismatch' ELSE '' END  +
+				  CASE WHEN is_bad_estimate = 1 THEN + ', Row Estimate Mismatch' ELSE '' END  +
 				  CASE WHEN is_paul_white_electric = 1 THEN ', SWITCH!' ELSE '' END + 
 				  CASE WHEN is_row_goal = 1 THEN ', Row Goals' ELSE '' END + 
-                  CASE WHEN is_big_spills = 1 THEN ', >500mb spills' ELSE '' END + 
+                  CASE WHEN is_big_spills = 1 THEN ', >500mb Spills' ELSE '' END + 
 				  CASE WHEN is_mstvf = 1 THEN ', MSTVFs' ELSE '' END + 
 				  CASE WHEN is_mm_join = 1 THEN ', Many to Many Merge' ELSE '' END + 
                   CASE WHEN is_nonsargable = 1 THEN ', non-SARGables' ELSE '' END + 
@@ -4987,7 +4987,7 @@ BEGIN
                     1,
                     100,
                     'Execution Pattern',
-                    'Frequently Executed Queries',
+                    'Frequent Execution',
                     'http://brentozar.com/blitzcache/frequently-executed-queries/',
                     'Queries are being executed more than '
                     + CAST (@execution_threshold AS VARCHAR(5))
@@ -5016,7 +5016,7 @@ BEGIN
                     3,
                     50,
                     'Parameterization',
-                    'Forced Plans',
+                    'Forced Plan',
                     'http://brentozar.com/blitzcache/forced-plans/',
                     'Execution plans have been compiled with forced plans, either through FORCEPLAN, plan guides, or forced parameterization. This will make general tuning efforts less effective.');
 
@@ -5029,7 +5029,7 @@ BEGIN
                     4,
                     200,
                     'Cursors',
-                    'Cursors',
+                    'Cursor',
                     'http://brentozar.com/blitzcache/cursors-found-slow-queries/',
                     'There are cursors in the plan cache. This is neither good nor bad, but it is a thing. Cursors are weird in SQL Server.');
 
@@ -5111,7 +5111,7 @@ BEGIN
                     6,
                     200,
                     'Execution Plans',
-                    'Parallelism',
+                    'Parallel',
                     'http://brentozar.com/blitzcache/parallel-plans-detected/',
                     'Parallel plans detected. These warrant investigation, but are neither good nor bad.') ;
 
@@ -5137,7 +5137,7 @@ BEGIN
                     8,
                     50,
                     'Execution Plans',
-                    'Query Plan Warnings',
+                    'Plan Warnings',
                     'http://brentozar.com/blitzcache/query-plan-warnings/',
                     'Warnings detected in execution plans. SQL Server is telling you that something bad is going on that requires your attention.') ;
 
@@ -5150,7 +5150,7 @@ BEGIN
                     9,
                     50,
                     'Performance',
-                    'Long Running Queries',
+                    'Long Running Query',
                     'http://brentozar.com/blitzcache/long-running-queries/',
                     'Long running queries have been found. These are queries with an average duration longer than '
                     + CAST(@long_running_query_warning_seconds / 1000 / 1000 AS VARCHAR(5))
@@ -5165,7 +5165,7 @@ BEGIN
                     10,
                     50,
                     'Performance',
-                    'Missing Index Request',
+                    'Missing Indexes',
                     'http://brentozar.com/blitzcache/missing-index-request/',
                     'Queries found with missing indexes.');
 
@@ -5178,7 +5178,7 @@ BEGIN
                     13,
                     200,
                     'Cardinality',
-                    'Legacy Cardinality Estimator in Use',
+                    'Downlevel CE',
                     'http://brentozar.com/blitzcache/legacy-cardinality-estimator/',
                     'A legacy cardinality estimator is being used by one or more queries. Investigate whether you need to be using this cardinality estimator. This may be caused by compatibility levels, global trace flags, or query level trace flags.');
 
@@ -5217,7 +5217,7 @@ BEGIN
                 17,
                 50,
                 'Performance',
-                'Joining to table valued functions',
+                'Function Join',
                 'http://brentozar.com/blitzcache/tvf-join/',
                 'Execution plans have been found that join to table valued functions (TVFs). TVFs produce inaccurate estimates of the number of rows returned and can lead to any number of query plan problems.');
 
@@ -5230,7 +5230,7 @@ BEGIN
                 18,
                 50,
                 'Execution Plans',
-                'Compilation timeout',
+                'Compilation Timeout',
                 'http://brentozar.com/blitzcache/compilation-timeout/',
                 'Query compilation timed out for one or more queries. SQL Server did not find a plan that meets acceptable performance criteria in the time allotted so the best guess was returned. There is a very good chance that this plan isn''t even below average - it''s probably terrible.');
 
@@ -5243,7 +5243,7 @@ BEGIN
                 19,
                 50,
                 'Execution Plans',
-                'Compilation memory limit exceeded',
+                'Compile Memory Limit Exceeded',
                 'http://brentozar.com/blitzcache/compile-memory-limit-exceeded/',
                 'The optimizer has a limited amount of memory available. One or more queries are complex enough that SQL Server was unable to allocate enough memory to fully optimize the query. A best fit plan was found, and it''s probably terrible.');
 
@@ -5256,7 +5256,7 @@ BEGIN
                 20,
                 50,
                 'Execution Plans',
-                'No join predicate',
+                'No Join Predicate',
                 'http://brentozar.com/blitzcache/no-join-predicate/',
                 'Operators in a query have no join predicate. This means that all rows from one table will be matched with all rows from anther table producing a Cartesian product. That''s a whole lot of rows. This may be your goal, but it''s important to investigate why this is happening.');
 
@@ -5269,7 +5269,7 @@ BEGIN
                 21,
                 200,
                 'Execution Plans',
-                'Multiple execution plans',
+                'Multiple Plans',
                 'http://brentozar.com/blitzcache/multiple-plans/',
                 'Queries exist with multiple execution plans (as determined by query_plan_hash). Investigate possible ways to parameterize these queries or otherwise reduce the plan count.');
 
@@ -5282,7 +5282,7 @@ BEGIN
                 22,
                 100,
                 'Performance',
-                'Unmatched indexes',
+                'Unmatched Indexes',
                 'http://brentozar.com/blitzcache/unmatched-indexes',
                 'An index could have been used, but SQL Server chose not to use it - likely due to parameterization and filtered indexes.');
 
@@ -5295,7 +5295,7 @@ BEGIN
                 23,
                 100,
                 'Parameterization',
-                'Unparameterized queries',
+                'Unparameterized Query',
                 'http://brentozar.com/blitzcache/unparameterized-queries',
                 'Unparameterized queries found. These could be ad hoc queries, data exploration, or queries using "OPTIMIZE FOR UNKNOWN".');
 
@@ -5334,7 +5334,7 @@ BEGIN
                     26,
                     100,
                     'Execution Plans',
-                    'Expensive Key Lookups',
+                    'Expensive Key Lookup',
                     'http://www.brentozar.com/blitzcache/expensive-key-lookups/',
                     'There''s a key lookup in your plan that costs >=50% of the total plan cost.') ;	
 
@@ -5372,8 +5372,8 @@ BEGIN
             VALUES (@@SPID,
                     30,
                     100,
-                    'Unused memory grants',
-                    'Queries are asking for more memory than they''re using',
+                    'Memory Grant',
+                    'Unused Memory Grant',
                     'https://www.brentozar.com/blitzcache/unused-memory-grants/',
                     'Queries have large unused memory grants. This can cause concurrency issues, if queries are waiting a long time to get memory to run.') ;
 
@@ -5386,7 +5386,7 @@ BEGIN
                     31,
                     100,
                     'Compute Scalar That References A Function',
-                    'This could be trouble if you''re using Scalar Functions or MSTVFs',
+                    'Calls Functions',
                     'https://www.brentozar.com/blitzcache/compute-scalar-functions/',
                     'Both of these will force queries to run serially, run at least once per row, and may result in poor cardinality estimates.') ;
 
@@ -5399,7 +5399,7 @@ BEGIN
                     32,
                     100,
                     'Compute Scalar That References A CLR Function',
-                    'This could be trouble if your CLR functions perform data access',
+                    'Calls CLR Functions',
                     'https://www.brentozar.com/blitzcache/compute-scalar-functions/',
                     'May force queries to run serially, run at least once per row, and may result in poor cardinality estimates.') ;
 
@@ -5413,7 +5413,7 @@ BEGIN
                     33,
                     100,
                     'Table Variables detected',
-                    'Beware nasty side effects',
+                    'Table Variables',
                     'https://www.brentozar.com/blitzcache/table-variables/',
                     'All modifications are single threaded, and selects have really low row estimates.') ;
 
@@ -5425,8 +5425,8 @@ BEGIN
             VALUES (@@SPID,
                     35,
                     100,
-                    'Columns with no statistics',
-                    'Poor cardinality estimates may ensue',
+                    'Statistics',
+                    'Columns With No Statistics',
                     'https://www.brentozar.com/blitzcache/columns-no-statistics/',
                     'Sometimes this happens with indexed views, other times because auto create stats is turned off.') ;
 
@@ -5438,8 +5438,8 @@ BEGIN
             VALUES (@@SPID,
                     36,
                     100,
-                    'Operator Warnings',
-                    'SQL is throwing operator level plan warnings',
+                    'Warnings',
+					'Operator Warnings',
                     'http://brentozar.com/blitzcache/query-plan-warnings/',
                     'Check the plan for more details.') ;
 
@@ -5451,8 +5451,8 @@ BEGIN
             VALUES (@@SPID,
                     37,
                     100,
-                    'Table Scans',
-                    'Your database has HEAPs',
+                    'Indexes',
+                    'Table Scans (Heaps)',
                     'https://www.brentozar.com/archive/2012/05/video-heaps/',
                     'This may not be a problem. Run sp_BlitzIndex for more information.') ;
         
@@ -5464,8 +5464,8 @@ BEGIN
             VALUES (@@SPID,
                     38,
                     200,
+                    'Indexes',
                     'Backwards Scans',
-                    'Indexes are being read backwards',
                     'https://www.brentozar.com/blitzcache/backwards-scans/',
                     'This isn''t always a problem. They can cause serial zones in plans, and may need an index to match sort order.') ;
 
@@ -5477,22 +5477,34 @@ BEGIN
             VALUES (@@SPID,
                     39,
                     100,
-                    'Index forcing',
-                    'Someone is using hints to force index usage',
+                    'Indexes',
+                    'Forced Indexes',
                     'https://www.brentozar.com/blitzcache/optimizer-forcing/',
                     'This can cause inefficient plans, and will prevent missing index requests.') ;
 
 		IF EXISTS (SELECT 1/0
                    FROM   ##BlitzCacheProcs p
                    WHERE  p.forced_seek = 1
-				   OR p.forced_scan = 1
 				   AND SPID = @@SPID)
             INSERT INTO ##BlitzCacheResults (SPID, CheckID, Priority, FindingsGroup, Finding, URL, Details)
             VALUES (@@SPID,
                     40,
                     100,
-                    'Seek/Scan forcing',
-                    'Someone is using hints to force index seeks/scans',
+                    'Indexes',
+					'Forced Seeks',
+                    'https://www.brentozar.com/blitzcache/optimizer-forcing/',
+                    'This can cause inefficient plans by taking seek vs scan choice away from the optimizer.') ;
+
+		IF EXISTS (SELECT 1/0
+                   FROM   ##BlitzCacheProcs p
+                   WHERE  p.forced_scan = 1
+				   AND SPID = @@SPID)
+            INSERT INTO ##BlitzCacheResults (SPID, CheckID, Priority, FindingsGroup, Finding, URL, Details)
+            VALUES (@@SPID,
+                    40,
+                    100,
+                    'Indexes',
+                    'Forced Scans',
                     'https://www.brentozar.com/blitzcache/optimizer-forcing/',
                     'This can cause inefficient plans by taking seek vs scan choice away from the optimizer.') ;
 
@@ -5504,8 +5516,8 @@ BEGIN
             VALUES (@@SPID,
                     41,
                     100,
-                    'ColumnStore indexes operating in Row Mode',
-                    'Batch Mode is optimal for ColumnStore indexes',
+                    'Indexes',
+                    'ColumnStore Row Mode',
                     'https://www.brentozar.com/blitzcache/columnstore-indexes-operating-row-mode/',
                     'ColumnStore indexes operating in Row Mode indicate really poor query choices.') ;
 
@@ -5517,8 +5529,8 @@ BEGIN
             VALUES (@@SPID,
                     42,
                     50,
-                    'Computed Columns Referencing Scalar UDFs',
-                    'This makes a whole lot of stuff run serially',
+                    'Functions',
+                    'Computed Column UDF',
                     'https://www.brentozar.com/blitzcache/computed-columns-referencing-functions/',
                     'This can cause a whole mess of bad serializartion problems.') ;
 
@@ -5543,8 +5555,8 @@ BEGIN
              VALUES (@@SPID,
                      44,
                      50,
-                     'Filters Referencing Scalar UDFs',
-                     'This forces serialization',
+                     'Functions',
+                     'Filter UDF',
                      'https://www.brentozar.com/blitzcache/compute-scalar-functions/',
                      'Someone put a Scalar UDF in the WHERE clause!') ;
 
@@ -5556,8 +5568,8 @@ BEGIN
              VALUES (@@SPID,
                      45,
                      100,
-                     'Many Indexes Modified',
-                     'Write Queries Are Hitting >= 5 Indexes',
+                     'Indexes',
+                     '>= 5 Indexes Modified',
                      'https://www.brentozar.com/blitzcache/many-indexes-modified/',
                      'This can cause lots of hidden I/O -- Run sp_BlitzIndex for more information.') ;
 
@@ -5569,8 +5581,8 @@ BEGIN
              VALUES (@@SPID,
                      46,
                      200,
-                     'Plan Confusion',
-                     'Row Level Security is in use',
+                     'Complexity',
+                     'Row Level Security',
                      'https://www.brentozar.com/blitzcache/row-level-security/',
                      'You may see a lot of confusing junk in your query plan.') ;
 
@@ -5582,8 +5594,8 @@ BEGIN
              VALUES (@@SPID,
                      47,
                      200,
-                     'Spatial Abuse',
-                     'You hit a Spatial Index',
+                     'Complexity',
+                     'Spatial Index',
                      'https://www.brentozar.com/blitzcache/spatial-indexes/',
                      'Purely informational.') ;
 
@@ -5595,8 +5607,8 @@ BEGIN
              VALUES (@@SPID,
                      48,
                      150,
+                     'Complexity',
                      'Index DML',
-                     'Indexes were created or dropped',
                      'https://www.brentozar.com/blitzcache/index-dml/',
                      'This can cause recompiles and stuff.') ;
 
@@ -5608,8 +5620,8 @@ BEGIN
              VALUES (@@SPID,
                      49,
                      150,
-                     'Table DML',
-                     'Tables were created or dropped',
+                     'Complexity',
+					 'Table DML',
                      'https://www.brentozar.com/blitzcache/table-dml/',
                      'This can cause recompiles and stuff.') ;
 
@@ -5621,8 +5633,8 @@ BEGIN
              VALUES (@@SPID,
                      50,
                      150,
+                     'Blocking',
                      'Long Running Low CPU',
-                     'You have a query that runs for much longer than it uses CPU',
                      'https://www.brentozar.com/blitzcache/long-running-low-cpu/',
                      'This can be a sign of blocking, linked servers, or poor client application code (ASYNC_NETWORK_IO).') ;
 
@@ -5634,8 +5646,8 @@ BEGIN
              VALUES (@@SPID,
                      51,
                      150,
+                     'Complexity',
                      'Low Cost Query With High CPU',
-                     'You have a low cost query that uses a lot of CPU',
                      'https://www.brentozar.com/blitzcache/low-cost-high-cpu/',
                      'This can be a sign of functions or Dynamic SQL that calls black-box code.') ;
 
@@ -5647,8 +5659,8 @@ BEGIN
              VALUES (@@SPID,
                      52,
                      150,
-                     'Biblical Statistics',
-                     'Statistics used in queries are >7 days old with >100k modifications',
+                     'Statistics',
+                     'Statistics used have > 100k modifications in the last 7 days',
                      'https://www.brentozar.com/blitzcache/stale-statistics/',
                      'Ever heard of updating statistics?') ;
 
@@ -5660,10 +5672,10 @@ BEGIN
              VALUES (@@SPID,
                      53,
                      200,
-                     'Adaptive joins',
-                     'This is pretty cool -- you''re living in the future.',
+                     'Complexity',
+					 'Adaptive joins',
                      'https://www.brentozar.com/blitzcache/adaptive-joins/',
-                     'Joe Sack rules.') ;	
+                     'This join will sometimes do seeks, and sometimes do scans.') ;	
 
         IF EXISTS (SELECT 1/0
                     FROM   ##BlitzCacheProcs p
@@ -5673,8 +5685,8 @@ BEGIN
              VALUES (@@SPID,
                      54,
                      150,
+                     'Indexes',
                      'Expensive Index Spool',
-                     'You have an index spool, this is usually a sign that there''s an index missing somewhere.',
                      'https://www.brentozar.com/blitzcache/eager-index-spools/',
                      'Check operator predicates and output for index definition guidance') ;	
 
@@ -5686,8 +5698,8 @@ BEGIN
              VALUES (@@SPID,
                      55,
                      150,
-                     'Index Spools Many Rows',
-                     'You have an index spool that spools more rows than the query returns',
+                     'Indexes',
+					 'Large Index Row Spool',
                      'https://www.brentozar.com/blitzcache/eager-index-spools/',
                      'Check operator predicates and output for index definition guidance') ;
 					 
@@ -5699,10 +5711,10 @@ BEGIN
              VALUES (@@SPID,
                      56,
                      100,
-                     'Potentially bad cardinality estimates',
-                     'Estimated rows are different from average rows by a factor of 10000',
+                     'Complexity',
+                     'Row Estimate Mismatch',
                      'https://www.brentozar.com/blitzcache/bad-estimates/',
-                     'This may indicate a performance problem if mismatches occur regularly') ;	
+                     'Estimated rows are different from average rows by a factor of 10000. This may indicate a performance problem if mismatches occur regularly') ;	
 					 					 						 				 
         IF EXISTS (SELECT 1/0
                     FROM   ##BlitzCacheProcs p
@@ -5742,10 +5754,10 @@ BEGIN
              VALUES (@@SPID,
                      58,
                      200,
-                     'Row Goals',
-                     'This query had row goals introduced',
+                     'Complexity',
+					 'Row Goals',
                      'https://www.brentozar.com/go/rowgoals/',
-                     'This can be good or bad, and should be investigated for high read queries') ;	
+                     'This query had row goals introduced, which can be good or bad, and should be investigated for high read queries.') ;	
 
         IF EXISTS (SELECT 1/0
                     FROM   ##BlitzCacheProcs p
@@ -5755,10 +5767,10 @@ BEGIN
              VALUES (@@SPID,
                      59,
                      100,
-                     'tempdb Spills',
-                     'This query spills >500mb to tempdb on average',
+                     'TempDB',
+					 '>500mb Spills',
                      'https://www.brentozar.com/blitzcache/tempdb-spills/',
-                     'One way or another, this query didn''t get enough memory') ;	
+                     'This query spills >500mb to tempdb on average. One way or another, this query didn''t get enough memory') ;	
 
 
 			END; 
@@ -5771,8 +5783,8 @@ BEGIN
              VALUES (@@SPID,
                      60,
                      100,
-                     'MSTVFs',
-                     'These have many of the same problems scalar UDFs have',
+                     'Functions',
+					 'MSTVFs',
                      'http://brentozar.com/blitzcache/tvf-join/',
 					 'Execution plans have been found that join to table valued functions (TVFs). TVFs produce inaccurate estimates of the number of rows returned and can lead to any number of query plan problems.');	
 
@@ -5784,10 +5796,10 @@ BEGIN
              VALUES (@@SPID,
                      61,
                      100,
-                     'Many to Many Merge',
-                     'These use secret worktables that could be doing lots of reads',
+                     'Complexity',
+					 'Many to Many Merge',
                      'https://www.brentozar.com/archive/2018/04/many-mysteries-merge-joins/',
-					 'Occurs when join inputs aren''t known to be unique. Can be really bad when parallel.');	
+					 'These use secret worktables that could be doing lots of reads. Occurs when join inputs aren''t known to be unique. Can be really bad when parallel.');	
 
         IF EXISTS (SELECT 1/0
                     FROM   ##BlitzCacheProcs p
@@ -5798,7 +5810,7 @@ BEGIN
                      62,
                      50,
                      'Non-SARGable queries',
-                     'Queries may have non-SARGable predicates',
+                     'non-SARGables',
                      'https://www.brentozar.com/blitzcache/non-sargable-predicates/',
 					 'Looks for intrinsic functions and expressions as predicates, and leading wildcard LIKE searches.');	
 
@@ -5810,10 +5822,10 @@ BEGIN
              VALUES (@@SPID,
                      63,
                      100,
-                     'High Compile Time',
-                     'Queries taking >5 seconds to compile',
+                     'Complexity',
+					 'Long Compile Time',
                      'https://www.brentozar.com/blitzcache/high-compilers/',
-					 'This can be normal for large plans, but be careful if they compile frequently');	
+					 'Queries are taking >5 seconds to compile. This can be normal for large plans, but be careful if they compile frequently');	
 
         IF EXISTS (SELECT 1/0
                     FROM   ##BlitzCacheProcs p
@@ -5823,10 +5835,10 @@ BEGIN
              VALUES (@@SPID,
                      64,
                      50,
+                     'Complexity',
                      'High Compile CPU',
-                     'Queries taking >5 seconds of CPU to compile',
                      'https://www.brentozar.com/blitzcache/high-compilers/',
-					 'If CPU is high and plans like this compile frequently, they may be related');
+					 'Queries taking >5 seconds of CPU to compile. If CPU is high and plans like this compile frequently, they may be related');
 
         IF EXISTS (SELECT 1/0
                     FROM   ##BlitzCacheProcs p
@@ -5837,10 +5849,10 @@ BEGIN
              VALUES (@@SPID,
                      65,
                      50,
+                     'Complexity',
                      'High Compile Memory',
-                     'Queries taking 10% of Max Compile Memory',
                      'https://www.brentozar.com/blitzcache/high-compilers/',
-					 'If you see high RESOURCE_SEMAPHORE_QUERY_COMPILE waits, these may be related');
+					 'Queries taking 10% of Max Compile Memory. If you see high RESOURCE_SEMAPHORE_QUERY_COMPILE waits, these may be related');
 
         IF EXISTS (SELECT 1/0
                     FROM   ##BlitzCacheProcs p
@@ -5850,8 +5862,8 @@ BEGIN
              VALUES (@@SPID,
                      66,
                      50,
+					 'Complexity',
                      'Selects w/ Writes',
-                     'Read queries are causing writes',
                      'https://dba.stackexchange.com/questions/191825/',
 					 'This is thrown when reads cause writes that are not already flagged as big spills (2016+) or index spools.');
 


### PR DESCRIPTION
Making the warning names in the description result set match what we're showing in the Warnings column. Closes #2212.