### PR TITLE
#2252 sp_BlitzCache avoid plan cache pollution

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -6702,7 +6702,7 @@ BEGIN
 		  AvgSpills MONEY,
 		  QueryPlanCost FLOAT,
           JoinKey AS ServerName + Cast(CheckDate AS NVARCHAR(50)),
-          CONSTRAINT [PK_' +CAST(NEWID() AS NCHAR(36)) + '] PRIMARY KEY CLUSTERED(ID))';
+          CONSTRAINT [PK_' +REPLACE(REPLACE(@OutputTableName,'[',''),']','') + '] PRIMARY KEY CLUSTERED(ID ASC))';
 
     		IF @Debug = 1
 			BEGIN


### PR DESCRIPTION
Setting output table constraint name to be the table's name rather than a newid. Closes #2252.