### PR TITLE
Issue 2280: Skip 0 read, 0 write indexes

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1210,15 +1210,15 @@ BEGIN TRY
                              ELSE N''''
                         END AS filter_definition' ELSE N''''' AS filter_definition' END + N'
                         , ISNULL(us.user_seeks, 0),
-						ISNULL(us.user_scans, 0),
+                        ISNULL(us.user_scans, 0),
                         ISNULL(us.user_lookups, 0),
-						ISNULL(us.user_updates, 0),
-						us.last_user_seek,
-						us.last_user_scan,
+                        ISNULL(us.user_updates, 0),
+                        us.last_user_seek,
+                        us.last_user_scan,
                         us.last_user_lookup,
-						us.last_user_update,
+                        us.last_user_update,
                         so.create_date,
-						so.modify_date
+                        so.modify_date
                 FROM    ' + QUOTENAME(@DatabaseName) + N'.sys.indexes AS si WITH (NOLOCK)
                         JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.objects AS so WITH (NOLOCK) ON si.object_id = so.object_id
                                                AND so.is_ms_shipped = 0 /*Exclude objects shipped by Microsoft*/
@@ -1230,12 +1230,12 @@ BEGIN TRY
                 WHERE    si.[type] IN ( 0, 1, 2, 3, 4, 5, 6 ) 
                 /* Heaps, clustered, nonclustered, XML, spatial, Cluster Columnstore, NC Columnstore */ ' +
                 CASE WHEN @TableName IS NOT NULL THEN N' and so.name=' + QUOTENAME(@TableName,N'''') + N' ' ELSE N'' END +
-				CASE WHEN ( @IncludeInactiveIndexes = 0
-				            OR @Mode NOT IN (0, 4)
-						    OR @TableName IS NOT NULL )
-				     THEN N'AND ( us.user_seeks + us.user_scans + us.user_lookups + us.user_updates ) > 0'
-					 ELSE N''
-			    END
+                CASE WHEN ( @IncludeInactiveIndexes = 0
+                            OR @Mode NOT IN (0, 4)
+                            OR @TableName IS NOT NULL )
+                     THEN N'AND ( us.user_seeks + us.user_scans + us.user_lookups + us.user_updates ) > 0'
+                     ELSE N''
+                END
         + N'OPTION    ( RECOMPILE );
         ';
         IF @dsql IS NULL 

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -31,6 +31,7 @@ ALTER PROCEDURE dbo.sp_BlitzIndex
     @OutputDatabaseName NVARCHAR(256) = NULL ,
     @OutputSchemaName NVARCHAR(256) = NULL ,
     @OutputTableName NVARCHAR(256) = NULL ,
+	@IncludeInactiveIndexes BIT = 0 /* Will skip indexes with no reads or writes */,
     @Help TINYINT = 0,
 	@Debug BIT = 0,
     @Version     VARCHAR(30) = NULL OUTPUT,
@@ -1208,10 +1209,16 @@ BEGIN TRY
                         CASE WHEN si.filter_definition IS NOT NULL THEN si.filter_definition
                              ELSE N''''
                         END AS filter_definition' ELSE N''''' AS filter_definition' END + N'
-                        , ISNULL(us.user_seeks, 0), ISNULL(us.user_scans, 0),
-                        ISNULL(us.user_lookups, 0), ISNULL(us.user_updates, 0), us.last_user_seek, us.last_user_scan,
-                        us.last_user_lookup, us.last_user_update,
-                        so.create_date, so.modify_date
+                        , ISNULL(us.user_seeks, 0),
+						ISNULL(us.user_scans, 0),
+                        ISNULL(us.user_lookups, 0),
+						ISNULL(us.user_updates, 0),
+						us.last_user_seek,
+						us.last_user_scan,
+                        us.last_user_lookup,
+						us.last_user_update,
+                        so.create_date,
+						so.modify_date
                 FROM    ' + QUOTENAME(@DatabaseName) + N'.sys.indexes AS si WITH (NOLOCK)
                         JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.objects AS so WITH (NOLOCK) ON si.object_id = so.object_id
                                                AND so.is_ms_shipped = 0 /*Exclude objects shipped by Microsoft*/
@@ -1222,8 +1229,14 @@ BEGIN TRY
                                                                        AND us.database_id = ' + CAST(@DatabaseID AS NVARCHAR(10)) + N'
                 WHERE    si.[type] IN ( 0, 1, 2, 3, 4, 5, 6 ) 
                 /* Heaps, clustered, nonclustered, XML, spatial, Cluster Columnstore, NC Columnstore */ ' +
-                CASE WHEN @TableName IS NOT NULL THEN N' and so.name=' + QUOTENAME(@TableName,N'''') + N' ' ELSE N'' END + 
-        N'OPTION    ( RECOMPILE );
+                CASE WHEN @TableName IS NOT NULL THEN N' and so.name=' + QUOTENAME(@TableName,N'''') + N' ' ELSE N'' END +
+				CASE WHEN ( @IncludeInactiveIndexes = 0
+				            OR @Mode NOT IN (0, 4)
+						    OR @TableName IS NOT NULL )
+				     THEN N'AND ( us.user_seeks + us.user_scans + us.user_lookups + us.user_updates ) > 0'
+					 ELSE N''
+			    END
+        + N'OPTION    ( RECOMPILE );
         ';
         IF @dsql IS NULL 
             RAISERROR('@dsql is null',16,1);


### PR DESCRIPTION
This pull request SHALL HERETOFORE:
 * Add a parameter to disinclude indexes with no reads OR writes, meaning they are totally inactive
 * De-clutter the select list a little bit so it matches the rest of the statement

Totally inactive indexes will still be listed when:
 * You override the default parameter value
 * You're in mode 1, 2, or 3
 * The `@TableName` parameter is not null

RE The last one: I figure if you're zooming in on a table, you want everything, and who knows? Maybe there's a filtered index on there that hasn't been touched at all?

Closes #2280 