### PR TITLE
fix a typo ("undre") + update year in 2 spots

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,13 +3,13 @@ MIT License
 Copyright for portions of sp_Blitz are held by Microsoft as part of project 
 tigertoolbox and are provided under the MIT license:
 https://github.com/Microsoft/tigertoolbox
-All other copyrights for sp_Blitz are held by Brent Ozar Unlimited, 2019 as
+All other copyrights for sp_Blitz are held by Brent Ozar Unlimited, 2020 as
 described below.
 
 Copyright for portions of DatabaseRestore are held by GregWhiteDBA as part
 of project MSSQLAutoRestore and are provided under the MIT license:
 https://github.com/GregWhiteDBA/MSSQLAutoRestore
-All other copyrights for DatabaseRestore are held by Brent Ozar Unlimited, 2019
+All other copyrights for DatabaseRestore are held by Brent Ozar Unlimited, 2020
 as described below.
 
 Copyright for sp_BlitzInMemoryOLTP are held by Ned Otter and Konstantin
@@ -17,7 +17,7 @@ Taranov as part of project sqlserver-kit and are provided under the MIT license:
 https://github.com/ktaranov/sqlserver-kit
 
 Copyright for SqlServerVersionScript are held by Josh Darnell as part of
-project SqlServerVersionScript and are provided undre the MIT license:
+project SqlServerVersionScript and are provided under the MIT license:
 https://github.com/jadarnel27/SqlServerVersionScript
 
 


### PR DESCRIPTION
In the license, fix "undre" because it was bothing tf out of me.

Also noticed two spots that list copyright year as 2019, even though main copyright statement is 2020. Fix that too.