### PR TITLE
#2426 sp_Blitz exclude NAV license table

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -2200,7 +2200,8 @@ AS
 										  + '. Tables in the master database may not be restored in the event of a disaster.' ) AS Details
 								FROM    master.sys.tables
 								WHERE   is_ms_shipped = 0
-                                  AND   name NOT IN ('CommandLog','SqlServerVersions');
+                                  AND   name NOT IN ('CommandLog','SqlServerVersions','$ndo$srvproperty');
+								  /* That last one is the Dynamics NAV licensing table: https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/2426 */
 					END;
 
 				IF NOT EXISTS ( SELECT  1


### PR DESCRIPTION
Don't throw a warning about the NAV license table in the master database. Closes #2426.