### PR TITLE
Removing incorrect logic from @Bad_Estimate check. Issue #2420

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -1828,8 +1828,6 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                                 deqp.request_id,
                                 CASE WHEN deqp.row_count > ( deqp.estimate_row_count * 10000 )
                                      THEN 1
-                                     WHEN deqp.row_count < ( deqp.estimate_row_count * 10000 )
-                                     THEN 1
                                      ELSE 0
                                 END AS estimate_inaccuracy
                          FROM   sys.dm_exec_query_profiles AS deqp


### PR DESCRIPTION
See long explanation in #2420 discussion.

The short version: row_count < estimate_row_count *10000 leads to alot of false positives, as for instance 7 < 5*10000 while 7 vs 5 is a completly okay estimate.

Also, since the DMV is populated on the fly, I do not see fixing the logic to do a cardinality estimate check in this "direction" as an option as row_count will in the beginning of the execution be very low(sometimes 0) which will then always cause an incorrect red flag, just because it has not had time to process yet. 
Row count > estimate_row_count*10000 is always an incorrect warning so that still makes sense.

Removing this section caused me to no longer be able to reproduce the blaming of sp_blitzfirst that the issue is about which I could before(on 2019).