### PR TITLE
2489 parallel blocked processes not showing a blocking session

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -335,6 +335,16 @@ BEGIN
 							     THEN blocked.blocking_session_id
 							    ELSE NULL 
 						    END AS blocking_session_id , 
+			       COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), 
+						    blocked.waittime) + '')'' ) AS wait_info ,											
+				   CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
+							       THEN r.blocking_session_id
+							       WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
+							       THEN blocked.blocking_session_id
+								   WHEN r.blocking_session_id = 0 AND s.session_id = blocked.session_id 
+								   THEN blocked.blocking_session_id
+							       ELSE NULL 
+						      END AS blocking_session_id,
 			       COALESCE(r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,
 						    CASE WHEN EXISTS (  SELECT 1 
                FROM sys.dm_tran_active_transactions AS tat
@@ -542,6 +552,8 @@ IF @ProductVersionMajor >= 11
 							       THEN r.blocking_session_id
 							       WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
 							       THEN blocked.blocking_session_id
+								   WHEN r.blocking_session_id = 0 AND s.session_id = blocked.session_id 
+								   THEN blocked.blocking_session_id
 							       ELSE NULL 
 						      END AS blocking_session_id,
 			       COALESCE(r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -328,21 +328,15 @@ BEGIN
 							CASE
 								WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 								ELSE NULL
-							END AS wait_info ,											
+							END AS wait_info ,																					
 						    CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
-							     THEN r.blocking_session_id
-							     WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
-							     THEN blocked.blocking_session_id
-							    ELSE NULL 
-						    END AS blocking_session_id , 
-			       COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), 
-						    blocked.waittime) + '')'' ) AS wait_info ,											
-				   CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
 							       THEN r.blocking_session_id
 							       WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
 							       THEN blocked.blocking_session_id
 								   WHEN r.blocking_session_id = 0 AND s.session_id = blocked.session_id 
 								   THEN blocked.blocking_session_id
+								   WHEN r.blocking_session_id <> 0 AND s.session_id = blocked.blocking_session_id 
+							       THEN r.blocking_session_id
 							       ELSE NULL 
 						      END AS blocking_session_id,
 			       COALESCE(r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,
@@ -554,6 +548,8 @@ IF @ProductVersionMajor >= 11
 							       THEN blocked.blocking_session_id
 								   WHEN r.blocking_session_id = 0 AND s.session_id = blocked.session_id 
 								   THEN blocked.blocking_session_id
+								   WHEN r.blocking_session_id <> 0 AND s.session_id = blocked.blocking_session_id 
+							       THEN r.blocking_session_id
 							       ELSE NULL 
 						      END AS blocking_session_id,
 			       COALESCE(r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,


### PR DESCRIPTION
Version of the script
SELECT @Version = '7.97', @VersionDate = '20200712';

What is the current behavior?
If a session running a parallel query is blocked it does not show as being blocked.

If the current behavior is a bug, please provide the steps to reproduce.

/* Query window 1 , Blocking query*/

BEGIN TRAN
UPDATE Users
SET Reputation = Reputation +1
WHERE Id < 100
--ROLLBACK

/* Query window 2 , Parallel query blocked by Query window 1 */

SELECT Location,COUNT(*)
FROM Users
GROUP BY Location

/* Query window 3, run sp_BlitzWho and obeserve the blocking_session_id column */
EXEC sp_BlitzWho;

The blocking_session_id column will show as NULL for Query window two, now if you stop query two and replace it with:

(Single threaded query on my laptop)

SELECT TOP 1 *
FROM Users

run this and then run sp_BlitzWho again and you should see that the blocking_session_id column is now showing correctly.

What is the expected behavior?

blocking_session_id should not be NULL for the blocked session.

Which versions of SQL Server and which OS are affected by this issue? Did this work in previous versions of our procedures?
Tested on SQL2016