### PR TITLE
#2526 sp_Blitz skip validate logins on RDS

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -440,6 +440,7 @@ AS
 						INSERT INTO #SkipChecks (CheckID) VALUES (211); /* xp_regread checking for power saving */
 						INSERT INTO #SkipChecks (CheckID) VALUES (212); /* xp_regread */
 						INSERT INTO #SkipChecks (CheckID) VALUES (219);
+						INSERT INTO #SkipChecks (CheckID) VALUES (2301); /* sp_validatelogins called by Invalid login defined with Windows Authentication */
 			            INSERT  INTO #BlitzResults
 			            ( CheckID ,
 				            Priority ,


### PR DESCRIPTION
sp_validatelogins not allowed on Amazon RDS. Closes #2526.