### PR TITLE
Fix RCSI Isolation level

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -391,8 +391,8 @@ BEGIN
 			   CASE 
 			     WHEN s.transaction_isolation_level = 0 THEN ''Unspecified''
 			     WHEN s.transaction_isolation_level = 1 THEN ''Read Uncommitted''
-			     WHEN s.transaction_isolation_level = 2 AND EXISTS (SELECT 1 FROM sys.dm_tran_active_snapshot_database_transactions AS trn WHERE s.session_id = trn.session_id AND is_snapshot = 0 ) THEN ''Read Committed Snapshot Isolation''
-						  WHEN s.transaction_isolation_level = 2 AND NOT EXISTS (SELECT 1 FROM sys.dm_tran_active_snapshot_database_transactions AS trn WHERE s.session_id = trn.session_id AND is_snapshot = 0 ) THEN ''Read Committed''
+			     WHEN s.transaction_isolation_level = 2 AND EXISTS (SELECT 1 FROM sys.databases WHERE name = DB_NAME(r.database_id) AND is_read_committed_snapshot_on = 1) THEN ''Read Committed Snapshot Isolation''
+			     WHEN s.transaction_isolation_level = 2 THEN ''Read Committed''
 			     WHEN s.transaction_isolation_level = 3 THEN ''Repeatable Read''
 			     WHEN s.transaction_isolation_level = 4 THEN ''Serializable''
 			     WHEN s.transaction_isolation_level = 5 THEN ''Snapshot''
@@ -603,8 +603,8 @@ IF @ProductVersionMajor >= 11
 		        CASE 
 	        WHEN s.transaction_isolation_level = 0 THEN ''Unspecified''
 	        WHEN s.transaction_isolation_level = 1 THEN ''Read Uncommitted''
-	        WHEN s.transaction_isolation_level = 2 AND EXISTS (SELECT 1 FROM sys.dm_tran_active_snapshot_database_transactions AS trn WHERE s.session_id = trn.session_id AND is_snapshot = 0 ) THEN ''Read Committed Snapshot Isolation''
-			        WHEN s.transaction_isolation_level = 2 AND NOT EXISTS (SELECT 1 FROM sys.dm_tran_active_snapshot_database_transactions AS trn WHERE s.session_id = trn.session_id AND is_snapshot = 0 ) THEN ''Read Committed''
+			WHEN s.transaction_isolation_level = 2 AND EXISTS (SELECT 1 FROM sys.databases WHERE name = DB_NAME(r.database_id) AND is_read_committed_snapshot_on = 1) THEN ''Read Committed Snapshot Isolation''
+			WHEN s.transaction_isolation_level = 2 THEN ''Read Committed''
 	        WHEN s.transaction_isolation_level = 3 THEN ''Repeatable Read''
 	        WHEN s.transaction_isolation_level = 4 THEN ''Serializable''
 	        WHEN s.transaction_isolation_level = 5 THEN ''Snapshot''


### PR DESCRIPTION
Fixes #2534 

This replaces the dmv subquery with a call to `sys.databases` to check if RCSI is enabled on the database when the query's transaction level is "read committed". 

# Rationale

The previous approach relied on the query utilizing a snapshot to get categorized as RCSI. This had a major problem: It did not always accurately reflect (too fast or slow) the proper isolation level to the parent query on busy systems with fast queries. 

With this in mind, even if a specific query is not utilizing snapshots at the moment blitzWho is run, I believe it is more accurate and helpful to report back the isolation level that the session is set as, especially when the alternative is to underreport its existence/use.

## Notes
Since `CASE` statements are evaluated top-down, the second read committed related piece can be simplified to reduce subqueries required. 

