### PR TITLE
sp_DatabaseRestore should use the DatabaseName when @RestoreDatabaseN…

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -433,7 +433,8 @@ BEGIN
 	IF @Execute = 'Y' OR @Debug = 1 RAISERROR('Fixing @StandbyUndoPath to add a "/"', 0, 1) WITH NOWAIT;
 	SET @StandbyUndoPath += N'/';
 END;
-IF @RestoreDatabaseName IS NULL
+
+IF @RestoreDatabaseName IS NULL OR @RestoreDatabaseName = N''
 BEGIN
 	SET @RestoreDatabaseName = @Database;
 END;


### PR DESCRIPTION
sp_DatabaseRestore should use the DatabaseName when @RestoreDatabaseName is an empty string

Note: If you try to restore the database with the name ' ' (single space) then this will restore the database with the @DatabaseName instead.

Fixes #2536 