### PR TITLE
Need to CAST to prevent truncation

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1523,15 +1523,15 @@ BEGIN TRY
 				FROM	sys.dm_db_missing_index_details AS id_inner
 				CROSS APPLY(
 					SELECT	LTRIM(RTRIM(v.value(''(./text())[1]'', ''varchar(max)''))) AS ColumnName, ''Equality'' AS IndexColumnType
-					FROM	(VALUES (CONVERT(XML, ''<x>'' + REPLACE(id_inner.equality_columns, '','', ''</x><x>'')+''</x>''))) x(n)
+					FROM	(VALUES (CONVERT(XML, ''<x>'' + CAST(REPLACE(id_inner.equality_columns, '','', ''</x><x>'') AS NVARCHAR(MAX)) + ''</x>''))) x(n)
 					CROSS APPLY n.nodes(''x'') node(v)
 				UNION ALL
 					SELECT	LTRIM(RTRIM(v.value(''(./text())[1]'', ''varchar(max)''))) AS ColumnName, ''Inequality'' AS IndexColumnType
-					FROM	(VALUES (CONVERT(XML, ''<x>'' + REPLACE(id_inner.inequality_columns, '','', ''</x><x>'')+''</x>''))) x(n)
+					FROM	(VALUES (CONVERT(XML, ''<x>'' + CAST(REPLACE(id_inner.inequality_columns, '','', ''</x><x>'') AS NVARCHAR(MAX)) + ''</x>''))) x(n)
 					CROSS APPLY n.nodes(''x'') node(v)
 				UNION ALL
 					SELECT	LTRIM(RTRIM(v.value(''(./text())[1]'', ''varchar(max)''))) AS ColumnName, ''Included'' AS IndexColumnType
-					FROM	(VALUES (CONVERT(XML, ''<x>'' + REPLACE(id_inner.included_columns, '','', ''</x><x>'')+''</x>''))) x(n)
+					FROM	(VALUES (CONVERT(XML, ''<x>'' + CAST(REPLACE(id_inner.included_columns, '','', ''</x><x>'') AS NVARCHAR(MAX)) + ''</x>''))) x(n)
 					CROSS APPLY n.nodes(''x'') node(v)
 			)AS cn_inner'
 		+ /*split the string otherwise dsql cuts some of it out*/
@@ -1545,15 +1545,15 @@ BEGIN TRY
             FROM sys.dm_db_missing_index_details AS id
            CROSS APPLY(
 						SELECT	LTRIM(RTRIM(v.value(''(./text())[1]'', ''varchar(max)''))) AS ColumnName, ''Equality'' AS IndexColumnType
-						FROM	(VALUES (CONVERT(XML, ''<x>'' + REPLACE(id.equality_columns, '','', ''</x><x>'')+''</x>''))) x(n)
+						FROM	(VALUES (CONVERT(XML, ''<x>'' + CAST(REPLACE(id.equality_columns, '','', ''</x><x>'') AS NVARCHAR(MAX)) + ''</x>''))) x(n)
 						CROSS APPLY n.nodes(''x'') node(v)
 				    UNION ALL
 						SELECT	LTRIM(RTRIM(v.value(''(./text())[1]'', ''varchar(max)''))) AS ColumnName, ''Inequality'' AS IndexColumnType
-						FROM	(VALUES (CONVERT(XML, ''<x>'' + REPLACE(id.inequality_columns, '','', ''</x><x>'')+''</x>''))) x(n)
+						FROM	(VALUES (CONVERT(XML, ''<x>'' + CAST(REPLACE(id.inequality_columns, '','', ''</x><x>'') AS NVARCHAR(MAX)) + ''</x>''))) x(n)
 						CROSS APPLY n.nodes(''x'') node(v)
 				    UNION ALL
 						SELECT	LTRIM(RTRIM(v.value(''(./text())[1]'', ''varchar(max)''))) AS ColumnName, ''Included'' AS IndexColumnType
-						FROM	(VALUES (CONVERT(XML, ''<x>'' + REPLACE(id.included_columns, '','', ''</x><x>'')+''</x>''))) x(n)
+						FROM	(VALUES (CONVERT(XML, ''<x>'' + CAST(REPLACE(id.included_columns, '','', ''</x><x>'') AS NVARCHAR(MAX)) + ''</x>''))) x(n)
 						CROSS APPLY n.nodes(''x'') node(v)
 					)AS cn
 				GROUP BY	id.index_handle,id.object_id,cn.IndexColumnType


### PR DESCRIPTION
Need to CAST the replace to NVARCHAR(MAX), otherwise SQL assumes NVARCHAR(4000) which then truncates the text we're trying to parse into XML to get comma delimited.

Fixes Issue #2533 

I've added repro steps to the bug report so you can test it out. The repro steps are for the included columns, but if you can get those columns into the where clause as EQUALITY or INEQUALITY columns, you'll have the same bug.

I feel sorry for people who have columns named this long or have this many columns in a missing index request.