### PR TITLE
Add check (235) for inconsistent query store metadata

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 234.
-If you want to add a new one, start at 235.
+CURRENT HIGH CHECKID: 235.
+If you want to add a new one, start at 236.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -117,6 +117,7 @@ If you want to add a new one, start at 235.
 | 150 | Performance | Slow Storage Writes on Drive <DRIVELETTER> | https://www.BrentOzar.com/go/slow | 37 |
 | 150 | Performance | Stats Updated Asynchronously | https://www.BrentOzar.com/go/asyncstats | 17 |
 | 150 | Performance | Triggers on Tables | https://www.BrentOzar.com/go/trig | 32 |
+| 150 | Performance | Inconsistent Query Store metadata |  | 235 |
 | 170 | File Configuration | File growth set to 1MB | https://www.BrentOzar.com/go/percentgrowth | 158 |
 | 170 | File Configuration | File growth set to percent | https://www.BrentOzar.com/go/percentgrowth | 82 |
 | 170 | File Configuration | High VLF Count | https://www.BrentOzar.com/go/vlf | 69 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6040,7 +6040,7 @@ IF @ProductVersionMajor >= 10
 		                              (''Query store state in master metadata and database specific metadata not in sync.'')
 		                              FROM [?].sys.database_query_store_options dqso
 										join master.sys.databases D on D.name = N''?''
-									  WHERE ((dqso.actual_state = 0 AND D.is_query_store_on = 1) OR (dqso.actual_state = 1 AND D.is_query_store_on = 0))
+									  WHERE ((dqso.actual_state = 0 AND D.is_query_store_on = 1) OR (dqso.actual_state <> 0 AND D.is_query_store_on = 0))
 									  AND N''?'' NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''DWConfiguration'', ''DWDiagnostics'', ''DWQueue'', ''ReportServer'', ''ReportServerTempDB'') OPTION (RECOMPILE)';
 							END;
 

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -5978,7 +5978,7 @@ IF @ProductVersionMajor >= 10
 							END;
 
 						
-							IF @ProductVersionMajor >= 13 AND @ProductVersionMinor < 2149 --CU1 has the fix in it
+						IF @ProductVersionMajor >= 13 AND @ProductVersionMinor < 2149 --CU1 has the fix in it
 							AND NOT EXISTS ( SELECT  1
 											 FROM    #SkipChecks
 											 WHERE   DatabaseName IS NULL AND CheckID = 182 )

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6013,6 +6013,37 @@ IF @ProductVersionMajor >= 10
 							EXECUTE(@StringToExecute);
 							END;
 
+						IF NOT EXISTS ( SELECT  1
+										FROM    #SkipChecks
+										WHERE   DatabaseName IS NULL AND CheckID = 235 )
+                            AND EXISTS(SELECT * FROM sys.all_objects WHERE name = 'database_query_store_options')
+							BEGIN
+
+								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 235) WITH NOWAIT;
+
+								EXEC dbo.sp_MSforeachdb 'USE [?];
+                                        SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+			                            INSERT INTO #BlitzResults
+			                            (CheckID,
+			                            DatabaseName,
+			                            Priority,
+			                            FindingsGroup,
+			                            Finding,
+			                            URL,
+			                            Details)
+		                              SELECT TOP 1 235,
+		                              N''?'',
+		                              150,
+		                              ''Performance'',
+		                              ''Inconsistent Query Store metadata'',
+		                              '''',
+		                              (''Query store state in master metadata and database specific metadata not in sync.'')
+		                              FROM [?].sys.database_query_store_options dqso
+										join master.sys.databases D on D.name = N''?''
+									  WHERE ((dqso.actual_state = 0 AND D.is_query_store_on = 1) OR (dqso.actual_state = 1 AND D.is_query_store_on = 0))
+									  AND N''?'' NOT IN (''master'', ''model'', ''msdb'', ''tempdb'', ''DWConfiguration'', ''DWDiagnostics'', ''DWQueue'', ''ReportServer'', ''ReportServerTempDB'') OPTION (RECOMPILE)';
+							END;
+
 				        IF NOT EXISTS ( SELECT  1
 								        FROM    #SkipChecks
 								        WHERE   DatabaseName IS NULL AND CheckID = 41 )


### PR DESCRIPTION
Fixes #2525 by adding a check for inconsistent metadata between master's is_query_store_on in sys.databases and the actual state of the query store according to the database-specific QS metadata. 

I was able to test with this hacky-AF approach:
```
CREATE DATABASE test_qs;

ALTER DATABASE test_qs SET OFFLINE;
--copy the mdf/ldf
ALTER DATABASE test_qs SET ONLINE;

ALTER DATABASE test_qs SET QUERY_STORE = ON;

ALTER DATABASE test_qs SET OFFLINE;
--restore the (old) mdf/ldf
ALTER DATABASE test_qs SET ONLINE;

--run sp_blitz and check for finding

DROP DATABASE test_qs;
```

(Also tweaked an outdent on an IF in the same check area)