### PR TITLE
Update sp_blitzcache to remove unqualified join

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1614,9 +1614,9 @@ SELECT m.duplicate_plan_handles,
        CONVERT(DECIMAL(5,2), s.single_use_plan_count / (1. * NULLIF(t.total_plans, 0))) * 100. AS percent_single,
        t.total_plans,
 	   @@SPID
-FROM   many_plans AS m, 
-       single_use_plans AS s, 
-       total_plans AS t;
+FROM   	many_plans AS m
+		CROSS APPLY single_use_plans AS s 
+		CROSS APPLY total_plans AS t;
 
 
 UPDATE #plan_usage


### PR DESCRIPTION
Changing unqualified join to a cross apply (as Microsoft data migration wizard complains about it "Starting with database compatibility level 90 and higher, in rare occasions, the 'unqualified join' syntax can cause 'missing join predicate' warnings, leading to long running queries.").  There may be more but there was an awful lot of "from"s to look through in the SP so only spotted this one.