### PR TITLE
Sp blitz disk size

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8346,7 +8346,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												CASE WHEN i.total_MB IS NULL THEN
 													CAST(FORMAT(i.available_MB,'N') AS VARCHAR(30))
 													+ ' MB free on ' + i.drive
-													+ ' drive (Does not containt SQL Server data files)'
+													+ ' drive (Does not contain SQL Server data files)'
 													ELSE CAST(FORMAT(i.available_MB,'N') AS VARCHAR(30))
 													+ ' MB free on ' + i.drive
 													+ ' drive (' + i.logical_volume_name

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8358,8 +8358,8 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 
 									IF (@ProductVersionMajor >= 11)
 									BEGIN
-										SET @StringToExecute=REPLACE(@StringToExecute,'CAST(i.available_MB AS VARCHAR(30))','CAST(FORMAT(i.available_MB,''N'') AS VARCHAR(30))');
-										SET @StringToExecute=REPLACE(@StringToExecute,'CAST(i.total_MB AS VARCHAR(30))','CAST(FORMAT(i.total_MB,''N'') AS VARCHAR(30))');
+										SET @StringToExecute=REPLACE(@StringToExecute,'CAST(i.available_MB/1024 AS NUMERIC(18,2))','FORMAT(i.total_MB/1024,''N2'')');
+										SET @StringToExecute=REPLACE(@StringToExecute,'CAST(i.total_MB/1024 AS NUMERIC(18,2))','FORMAT(i.total_MB/1024,''N2'')');
 									END;
 
 									EXECUTE(@StringToExecute);

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8319,7 +8319,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 									inner join (
 												SELECT DISTINCT
 													SUBSTRING(volume_mount_point, 1, 1) AS volume_mount_point
-													,logical_volume_name
+													,CASE WHEN ISNULL(logical_volume_name,'') = '' THEN '' ELSE ' (' + logical_volume_name + ')' END AS logical_volume_name
 													,total_bytes/1024/1024 AS total_MB
 													,available_bytes/1024/1024 AS available_MB
 													,(CONVERT(DECIMAL(4,2),(total_bytes/1.0 - available_bytes)/total_bytes * 100))  AS used_percent
@@ -8349,8 +8349,8 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 													+ ' drive'
 													ELSE CAST(i.available_MB AS VARCHAR(30))
 													+ ' MB free on ' + i.drive
-													+ ' drive (' + i.logical_volume_name
-													+ ') out of ' + CAST(i.total_MB AS VARCHAR(30))
+													+ ' drive' + i.logical_volume_name
+													+ ' out of ' + CAST(i.total_MB AS VARCHAR(30))
 													+ ' MB total (' + CAST(i.used_percent AS VARCHAR(30)) + '%)' END
 												 AS Details
 										FROM    #driveInfo AS i;

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8307,7 +8307,7 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 										( drive, available_MB )
 										EXEC master..xp_fixeddrives;
 								
-								IF @ProductVersionMajor > 10 OR (@ProductVersionMajor = 10 AND @ProductVersionMinor >= 2500)
+								IF @ProductVersionMajor > 10.5 OR (@ProductVersionMajor = 10.5 AND @ProductVersionMinor >= 2500)
 								BEGIN
 									Update #driveInfo
 									SET

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8344,13 +8344,13 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 												'Drive ' + i.drive + ' Space' AS Finding ,
 												'' AS URL ,
 												CASE WHEN i.total_MB IS NULL THEN
-													CAST(FORMAT(i.available_MB,'N') AS VARCHAR(30))
+													CAST(i.available_MB AS VARCHAR(30))
 													+ ' MB free on ' + i.drive
-													+ ' drive (Does not contain SQL Server data files)'
-													ELSE CAST(FORMAT(i.available_MB,'N') AS VARCHAR(30))
+													+ ' drive'
+													ELSE CAST(i.available_MB AS VARCHAR(30))
 													+ ' MB free on ' + i.drive
 													+ ' drive (' + i.logical_volume_name
-													+ ') out of ' + CAST(FORMAT(i.total_MB,'N') AS VARCHAR(30))
+													+ ') out of ' + CAST(i.total_MB AS VARCHAR(30))
 													+ ' MB total (' + CAST(i.used_percent AS VARCHAR(30)) + '%)' END
 												 AS Details
 										FROM    #driveInfo AS i;


### PR DESCRIPTION
Resolves #2557
Using sys.dm_os_volume_stats, adds the extra information on all drives that have SQL Server files on them. Also adds the disk name if there is one. For versions before 2008R2 SP1, will just keep the current information provided by xp_fixeddrives.

- Changed the temp table structure
- Used Dynamic SQL for pre-2008R2 SP1 and Azure compatibility for the update
- Changed reporting to GB (to make it consistent with the Data Size check, and because GB seemed the proper disk size unit in 2020)
- Added number formatting for 2012+ to make large disk sizes more readable

Couldn't find a way to remove Master..xp_fixeddrives without using Powershell and that didn't feel like a better solution. One way would be to remove "non SQL Server" drives from sp_Blitz but thats for you to decide, not me.

Tested on SQL Server Enterprise 2019 CU6 and SQL Server 2008 Enterprise