### PR TITLE
sp_BlitzFirst - #2505 Warn when there are running queries with a memory grant exceeding x% of the workspace 

### DIFF
--- a/Documentation/sp_BlitzFirst_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzFirst_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 45
-If you want to add a new check, start at 46
+CURRENT HIGH CHECKID: 46
+If you want to add a new check, start at 47
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|---------------------------------|---------------------------------------|-------------------------------------------------|----------|
@@ -43,6 +43,7 @@ If you want to add a new check, start at 46
 | 100 | Query Problems | Suboptimal Plans/Sec High | https://BrentOzar.com/go/suboptimal | 33 |
 | 100 | Query Problems | Bad Estimates | https://brentozar.com/go/skewedup | 42 |
 | 100 | Query Problems | Skewed Parallelism | https://brentozar.com/go/skewedup | 43 |
+| 100 | Query Problems | Query with a memory grant exceeding @MemoryGrantThresholdPct | https://www.brentozar.com/memory-grants-sql-servers-public-toilet/ | 46 |
 | 200 | Wait Stats | (One per wait type) | https://BrentOzar.com/sql/wait-stats/#(waittype) | 6 |
 | 210 | Query Stats | Plan Cache Analysis Skipped | https://BrentOzar.com/go/topqueries | 18 |
 | 210 | Query Stats | Top Resource-Intensive Queries | https://BrentOzar.com/go/topqueries | 17 |

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -1798,7 +1798,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 
 	/* Query Problems - Queries with high memory grants - CheckID 46 */
 	INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, Details, URL, QueryText, QueryPlan)
-	SELECT 100 AS CheckID,
+	SELECT 46 AS CheckID,
 	    100 AS Priority,
 	    'Query Problems' AS FindingGroup,
 	    'Query with memory a grant exceeding '

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -28,6 +28,7 @@ ALTER PROCEDURE [dbo].[sp_BlitzFirst]
     @SinceStartup TINYINT = 0 ,
     @ShowSleepingSPIDs TINYINT = 0 ,
     @BlitzCacheSkipAnalysis BIT = 1 ,
+	@MemoryGrantThresholdPct DECIMAL(5,2) = 15.00,
     @LogMessageCheckID INT = 38,
     @LogMessagePriority TINYINT = 1,
     @LogMessageFindingsGroup VARCHAR(50) = 'Logged Message',
@@ -1794,6 +1795,31 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 		(SELECT COUNT(*) FROM sys.dm_exec_query_memory_grants WHERE queue_id IS NULL) AS DetailsInt,
 		'http://www.BrentOzar.com/askbrent/' AS URL
 	FROM sys.dm_exec_query_memory_grants AS Grants;
+
+	/* Query Problems - Queries with high memory grants - CheckID 46 */
+	INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, Details, URL, QueryText, QueryPlan)
+	SELECT 100 AS CheckID,
+	    100 AS Priority,
+	    'Query Problems' AS FindingGroup,
+	    'Query with memory a grant exceeding '
+		+CAST(@MemoryGrantThresholdPct AS NVARCHAR(15))
+		+'%' AS Finding,
+		'Granted size: '+ CAST(CAST(Grants.granted_memory_kb / 1024 AS INT) AS NVARCHAR(50))
+		+N'MB '
+		 + @LineFeed
+		+N'Granted pct: ' 
+		+ CAST(ISNULL((CAST(Grants.granted_memory_kb / 1024 AS MONEY)
+		                              / CAST(@MaxWorkspace AS MONEY)) * 100, 0) AS NVARCHAR(50)) + '%' 
+		+ @LineFeed
+		+N'SQLHandle: '
+		+CONVERT(NVARCHAR(128),Grants.[sql_handle],1),
+		'https://www.brentozar.com/memory-grants-sql-servers-public-toilet/' AS URL,
+		SQLText.[text],
+		QueryPlan.query_plan
+	FROM sys.dm_exec_query_memory_grants AS Grants
+	OUTER APPLY sys.dm_exec_sql_text(Grants.[sql_handle]) AS SQLText
+	OUTER APPLY sys.dm_exec_query_plan(Grants.[plan_handle]) AS QueryPlan
+	WHERE Grants.granted_memory_kb > ((@MemoryGrantThresholdPct/100.00)*(@MaxWorkspace*1024));
 
     /* Query Problems - Memory Leak in USERSTORE_TOKENPERM Cache */
     IF EXISTS (SELECT * FROM sys.all_columns WHERE object_id = OBJECT_ID('sys.dm_os_memory_clerks') AND name = 'pages_kb')


### PR DESCRIPTION
#2505 - Added a new check (CheckID 46) to check for running queries with a memory grant greater than x% with x being a new parameter @MemoryGrantThresholdPct which defaults to 15.00.
If a query is identified whilst running sp_BlitzFirst you will get a row per query with priority 100 which includes the Grant size, Percent , sql handle, sql text and xml query plan.

![image](https://user-images.githubusercontent.com/33764798/92524158-86545780-f219-11ea-84b6-42bbbb9cc0eb.png)
