### PR TITLE
#2581 sp_Blitz too many snaps

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1285,7 +1285,6 @@ AS
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 236 )
-					AND EXISTS (SELECT * FROM #BlitzResults WHERE CheckID = 178) /* We found snapshot backups */
 					BEGIN
 						
 						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 236) WITH NOWAIT;


### PR DESCRIPTION
Take 2. Runs even if you didn't have snapshot backups because we might have a lot of small databases, under the 50GB threshold for check 178. Working on #2581.