### PR TITLE
Feature/sort option sp blitz who

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -23,7 +23,7 @@ ALTER PROCEDURE dbo.sp_BlitzWho
 	@Version     VARCHAR(30) = NULL OUTPUT,
 	@VersionDate DATETIME = NULL OUTPUT,
     @VersionCheckMode BIT = 0,
-	@SortBySPID BIT = 0
+	@SortOrder VARCHAR(256) = 'elapsed_time'
 AS
 BEGIN
 	SET NOCOUNT ON;
@@ -1031,18 +1031,12 @@ IF (@MinElapsedSeconds + @MinCPUTime + @MinLogicalReads + @MinPhysicalReads + @M
 	SET @StringToExecute += N' ) ';
 	END
 
-IF @SortBySPID = 1
-BEGIN
-	SET @StringToExecute += 	
-		N' ORDER BY 3 ASC
+SET @StringToExecute +=
+		N' ORDER BY ' + CASE	WHEN @SortOrder = 'elapsed_time'	THEN '[elapsed_time] ASC'
+								WHEN @SortOrder = 'session_id'		THEN '[session_id] DESC'
+																	ELSE '[elapsed_time] ASC'
+						END + '
 		';
-END
-ELSE
-BEGIN
-	SET @StringToExecute += 	
-		N' ORDER BY 2 DESC
-		';
-END
 
 
 IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @OutputTableName IS NOT NULL

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -22,7 +22,8 @@ ALTER PROCEDURE dbo.sp_BlitzWho
 	@CheckDateOverride DATETIMEOFFSET = NULL,
 	@Version     VARCHAR(30) = NULL OUTPUT,
 	@VersionDate DATETIME = NULL OUTPUT,
-    @VersionCheckMode BIT = 0
+    @VersionCheckMode BIT = 0,
+	@SortBySPID BIT = 0
 AS
 BEGIN
 	SET NOCOUNT ON;
@@ -1030,9 +1031,18 @@ IF (@MinElapsedSeconds + @MinCPUTime + @MinLogicalReads + @MinPhysicalReads + @M
 	SET @StringToExecute += N' ) ';
 	END
 
-SET @StringToExecute += 	
-	N' ORDER BY 2 DESC
-	';
+IF @SortBySPID = 1
+BEGIN
+	SET @StringToExecute += 	
+		N' ORDER BY 3 ASC
+		';
+END
+ELSE
+BEGIN
+	SET @StringToExecute += 	
+		N' ORDER BY 2 DESC
+		';
+END
 
 
 IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @OutputTableName IS NOT NULL

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -23,7 +23,7 @@ ALTER PROCEDURE dbo.sp_BlitzWho
 	@Version     VARCHAR(30) = NULL OUTPUT,
 	@VersionDate DATETIME = NULL OUTPUT,
     @VersionCheckMode BIT = 0,
-	@SortOrder VARCHAR(256) = 'elapsed_time'
+	@SortOrder NVARCHAR(256) = 'elapsed_time'
 AS
 BEGIN
 	SET NOCOUNT ON;


### PR DESCRIPTION
I've added @SortOrder with a default of 'elapsed_time' which is what it currently sorts by. The ORDER BY appended at the end handles the two values I find useful, plus ELSE defaults to elapsed_time, again the current behaviour.

This procedure doesn't seem to contain the big explanations of all the possible parameter values so I've not included those.

Running on my machine works with no value specified, 'elapsed_time', nonsense text, and 'session_id'