### PR TITLE
Update sp_BlitzIndex.sql

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -4528,7 +4528,7 @@ BEGIN;
 				s.database_name,
 				'' AS URL,
 				'Statistics on this table were last updated ' + 
-					CASE s.last_statistics_update WHEN NULL THEN N' NEVER '
+					CASE WHEN s.last_statistics_update IS NULL THEN N' NEVER '
 					ELSE CONVERT(NVARCHAR(20), s.last_statistics_update) + 
 						' have had ' + CONVERT(NVARCHAR(100), s.modification_counter) +
 						' modifications in that time, which is ' +


### PR DESCRIPTION
Corrected CASE x WHEN NULL THEN statement, which will never be true; syntax in this case is CASE WHEN x IS NULL THEN.