### PR TITLE
Adds optional @IgnoreAlreadyPresentInMsdb BIT setting

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -26,6 +26,7 @@ ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
     @StopAt NVARCHAR(14) = NULL,
     @OnlyLogsAfter NVARCHAR(14) = NULL,
     @SimpleFolderEnumeration BIT = 0,
+	@IgnoreAlreadyPresentInMsdb BIT = 0,
 	@DatabaseOwner sysname = NULL,
     @Execute CHAR(1) = Y,
     @Debug INT = 0, 
@@ -226,6 +227,7 @@ DECLARE @cmd NVARCHAR(4000) = N'', --Holds xp_cmdshell command
 		@LogRestoreRanking SMALLINT = 1, --Holds Log iteration # when multiple paths & backup files are being stripped
 		@LogFirstLSN NUMERIC(25, 0), --Holds first LSN in log backup headers
 		@LogLastLSN NUMERIC(25, 0), --Holds last LSN in log backup headers
+		@LogLastNameInMsdbAS NVARCHAR(MAX) = N'', -- Holds last TRN file name already restored 
 		@FileListParamSQL NVARCHAR(4000) = N'', --Holds INSERT list for #FileListParameters
 		@BackupParameters NVARCHAR(500) = N'', --Used to save BlockSize, MaxTransferSize and BufferCount
         @RestoreDatabaseID SMALLINT;    --Holds DB_ID of @RestoreDatabaseName
@@ -1182,6 +1184,24 @@ BEGIN
 		END;
 	END 
     /*End folder sanity check*/
+
+	
+IF @IgnoreAlreadyPresentInMsdb = 1
+BEGIN
+	SELECT TOP 1 @LogLastNameInMsdbAS = bf.physical_device_name
+	FROM msdb.dbo.backupmediafamily bf
+	WHERE physical_device_name like @BackupPathLog + '%'
+	ORDER BY physical_device_name DESC
+	
+	IF @Debug = 1
+	BEGIN 
+		SELECT 'Keeping LOG backups with name > : ' + @LogLastNameInMsdbAS
+	END
+	
+	DELETE fl
+	FROM @FileList AS fl
+	WHERE fl.BackupPath + fl.BackupFile <= @LogLastNameInMsdbAS
+END
 
 	IF @Debug = 1
 	BEGIN 

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -26,7 +26,7 @@ ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
     @StopAt NVARCHAR(14) = NULL,
     @OnlyLogsAfter NVARCHAR(14) = NULL,
     @SimpleFolderEnumeration BIT = 0,
-	@IgnoreAlreadyPresentInMsdb BIT = 0,
+	@SkipBackupsAlreadyInMsdb BIT = 0,
 	@DatabaseOwner sysname = NULL,
     @Execute CHAR(1) = Y,
     @Debug INT = 0, 
@@ -1186,7 +1186,7 @@ BEGIN
     /*End folder sanity check*/
 
 	
-IF @IgnoreAlreadyPresentInMsdb = 1
+IF @SkipBackupsAlreadyInMsdb = 1
 BEGIN
 	SELECT TOP 1 @LogLastNameInMsdbAS = bf.physical_device_name
 	FROM msdb.dbo.backupmediafamily bf


### PR DESCRIPTION
We are experiencing serious slow down while restoring backups from distant datacenter, when having a lot of TRN files, because of `RESTORE HEADERONLY FROM DISK` calls on outdated TRN files.

Proposal for https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/2644

This approach is naive, by filtering out TRN with names > to the last one registered in msdb.dbo.backupmediafamily.