### PR TITLE
4k limit exceeded

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -7006,9 +7006,9 @@ ELSE
 					AvgSpills MONEY,
 					QueryPlanCost FLOAT,
 					JoinKey AS ServerName + Cast(CheckDate AS NVARCHAR(50)),
-					CONSTRAINT [PK_' + REPLACE(REPLACE(@OutputTableName,'[',''),']','') + '] PRIMARY KEY CLUSTERED(ID ASC));
+					CONSTRAINT [PK_' + REPLACE(REPLACE(@OutputTableName,'[',''),']','') + '] PRIMARY KEY CLUSTERED(ID ASC));';
 
-					IF EXISTS(SELECT * FROM '
+			SET @StringToExecute += N'IF EXISTS(SELECT * FROM '
 					+@OutputDatabaseName
 					+N'.INFORMATION_SCHEMA.SCHEMATA WHERE QUOTENAME(SCHEMA_NAME) = '''
 					+@OutputSchemaName

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -7007,7 +7007,6 @@ ELSE
 					QueryPlanCost FLOAT,
 					JoinKey AS ServerName + Cast(CheckDate AS NVARCHAR(50)),
 					CONSTRAINT [PK_' + REPLACE(REPLACE(@OutputTableName,'[',''),']','') + '] PRIMARY KEY CLUSTERED(ID ASC));';
-					CONSTRAINT [PK_' + REPLACE(REPLACE(@OutputTableName,'[',''),']','') + '] PRIMARY KEY CLUSTERED(ID ASC));'
 
 			SET @StringToExecute += N'IF EXISTS(SELECT * FROM '
 					+@OutputDatabaseName


### PR DESCRIPTION
**Version of the script**
SELECT @Version = '7.9999', @VersionDate = '20201114';

**What is the current behavior?**
with longer tablenames script exceeds the 4k limit.

```
Meldung 102, Ebene 15, Status 1, Zeile 83
Falsche Syntax in der Nähe von ",".
```

**If the current behavior is a bug, please provide the steps to reproduce.**
```
exec sp_BlitzCache @sortorder = N'CPU', @OutputDatabaseName = N'rpinet_dbtools', @OutputSchemaName = N'dbo',
@OutputTableName = N'bc_base__cpu__20201116112511', @debug = 1
```

**What is the expected behavior?**
save data to output table

**Which versions of SQL Server and which OS are affected by this issue? Did this work in previous versions of our procedures?**
* Version: 15.0.4063.15. Patch Level: RTM. Cumulative Update: CU7. Edition: Developer Edition (64-bit). Availability Groups Enabled: 0. Availability Groups Manager Status: 2
* Windows Server 2016 Standard, version 10.0
* no problem with 
`SELECT @Version = '7.999', @VersionDate = '20201011';`