### PR TITLE
Addressing 2694 - column order

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1990,8 +1990,8 @@ BEGIN TRY
 			IF @dsql IS NULL 
 			RAISERROR('@dsql is null',16,1);
 			
-			INSERT #TemporalTables ( database_name, database_id, schema_name, table_name, history_table_name, 
-									 history_schema_name, start_column_name, end_column_name, period_name )
+			INSERT #TemporalTables ( database_name, database_id, schema_name, table_name, history_schema_name, 
+									 history_table_name, start_column_name, end_column_name, period_name )
 					
 			EXEC sp_executesql @dsql;
 


### PR DESCRIPTION
I've changed the column order as it was suggested in #2694 

The results look ok now:

`The table [dbo].[Department] is a temporal table, with rows versioned in [dbo].[DepartmentHistory] on History columns [SysStartTime] and [SysEndTime].`