### PR TITLE
Update sp_ineachdb - we forgot an insert

### DIFF
--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -197,7 +197,8 @@ AS (SELECT C.SrcList
     FROM C
     WHERE C.InBracket = 0
           AND C.Name > '')
- SELECT d.database_id
+INSERT #ineachdb(id,name,is_distributor)
+SELECT d.database_id
      , d.name
      , d.is_distributor
 FROM sys.databases AS d


### PR DESCRIPTION
There's an insert missing from the latest version of this proc so we never actually populate #ineachdb