### PR TITLE
sp_BlitzIndex trivial typo (missing hyphen) in Drop_TSql output

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -5221,7 +5221,7 @@ ELSE IF (@Mode=1) /*Summarize*/
 										ISNULL(i.index_name, '''') AS [Index Name],
                                         CASE 
 						                    WHEN i.is_primary_key = 1 AND i.index_definition <> ''[HEAP]''
-							                    THEN N''-ALTER TABLE '' + QUOTENAME(i.[database_name]) + N''.'' + QUOTENAME(i.[schema_name]) + N''.'' + QUOTENAME(i.[object_name]) +
+							                    THEN N''--ALTER TABLE '' + QUOTENAME(i.[database_name]) + N''.'' + QUOTENAME(i.[schema_name]) + N''.'' + QUOTENAME(i.[object_name]) +
 							                         N'' DROP CONSTRAINT '' + QUOTENAME(i.index_name) + N'';''
 						                    WHEN i.is_primary_key = 0 AND i.index_definition <> ''[HEAP]''
 						                        THEN N''--DROP INDEX ''+ QUOTENAME(i.index_name) + N'' ON '' + QUOTENAME(i.[database_name]) + N''.'' +


### PR DESCRIPTION
As mentioned in the issue #2724 I'm seeing output such as this in the Drop_TSql column:

-ALTER TABLE [dbo].[TABLE] DROP CONSTRAINT [CONTRAINT_NAME];

When I paste that into SSMS its not commented. Only happens for heaps:

```
CASE 
	WHEN i.is_primary_key = 1 AND i.index_definition <> ''[HEAP]''
		THEN N''-ALTER TABLE '' + QUOTENAME(i.[database_name]) + N''.'' + QUOTENAME(i.[schema_name]) + N''.'' + 
```

I'd like to fix the missing - in the above. Sorry to log a bug then a PR here, not sure if that's correct proc or not. Danger will robinson: 100% newb to github.