### PR TITLE
Update sp_BlitzAnalysis.sql

### DIFF
--- a/sp_BlitzAnalysis.sql
+++ b/sp_BlitzAnalysis.sql
@@ -304,7 +304,7 @@ SET @Sql = N'SELECT
 [wait_time_minutes_per_minute], 
 [signal_wait_time_ms_delta], 
 [waiting_tasks_count_delta],
-CAST(ISNULL((CAST([wait_time_ms_delta] AS MONEY)/NULLIF(CAST([waiting_tasks_count_delta] AS MONEY),0)),0) AS DECIMAL(18,2)) AS [wait_time_ms_per_wait]
+ISNULL((CAST([wait_time_ms_delta] AS DECIMAL(38,2))/NULLIF(CAST([waiting_tasks_count_delta] AS DECIMAL(38,2)),0)),0) AS [wait_time_ms_per_wait]
 FROM 
 (
 	SELECT


### PR DESCRIPTION
Ref https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/2807 - money data type was too small and causing Arithmetic overflow for certain hefty values in our system.  Code developed in conjunction with Ade.