### PR TITLE
Pass @OutputType = NONE from sp_BlitzFirst to sp_BlitzCache so that there is really no output

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -369,7 +369,11 @@ IF @Help = 1
 	SELECT N'@ExpertMode',
 			N'TINYINT',
 			N'Default 0. When set to 1, results include more columns. When 2, mode is optimized for Opserver, the open source dashboard.'
-
+    UNION ALL
+	SELECT N'@OutputType',
+			N'NVARCHAR(258)',
+			N'If set to "NONE", this will tell this procedure not to run any query leading to a results set thrown to caller.'
+			
 	UNION ALL
 	SELECT N'@OutputDatabaseName',
 			N'NVARCHAR(128)',

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -3395,15 +3395,34 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 IF @BlitzCacheMinutesBack IS NULL OR @BlitzCacheMinutesBack < 1 OR @BlitzCacheMinutesBack > 60
                     SET @BlitzCacheMinutesBack = 15;
 
-                EXEC sp_BlitzCache
-                    @OutputDatabaseName = @UnquotedOutputDatabaseName,
-                    @OutputSchemaName = @UnquotedOutputSchemaName,
-                    @OutputTableName = @OutputTableNameBlitzCache,
-                    @CheckDateOverride = @StartSampleTime,
-                    @SortOrder = 'all',
-                    @SkipAnalysis = @BlitzCacheSkipAnalysis,
-                    @MinutesBack = @BlitzCacheMinutesBack,
-                    @Debug = @Debug;
+                IF(@OutputType = 'NONE')
+				BEGIN 
+                    EXEC sp_BlitzCache
+                        @OutputDatabaseName = @UnquotedOutputDatabaseName,
+                        @OutputSchemaName = @UnquotedOutputSchemaName,
+                        @OutputTableName = @OutputTableNameBlitzCache,
+                        @CheckDateOverride = @StartSampleTime,
+                        @SortOrder = 'all',
+                        @SkipAnalysis = @BlitzCacheSkipAnalysis,
+                        @MinutesBack = @BlitzCacheMinutesBack,
+                        @Debug = @Debug,
+					    @OutputType = @OutputType
+				    ;
+				END;
+				ELSE
+				BEGIN
+				
+				    EXEC sp_BlitzCache
+                        @OutputDatabaseName = @UnquotedOutputDatabaseName,
+                        @OutputSchemaName = @UnquotedOutputSchemaName,
+                        @OutputTableName = @OutputTableNameBlitzCache,
+                        @CheckDateOverride = @StartSampleTime,
+                        @SortOrder = 'all',
+                        @SkipAnalysis = @BlitzCacheSkipAnalysis,
+                        @MinutesBack = @BlitzCacheMinutesBack,
+                        @Debug = @Debug
+				    ;
+				END;
 
                 /* Delete history older than @OutputTableRetentionDays */
                 SET @StringToExecute = N' IF EXISTS(SELECT * FROM '


### PR DESCRIPTION
Hi, 

There is a parameter in sp_BlitzFirst which tells not to out any data (@OutputType = NONE).
However, when sp_BlitzFirst calls sp_BlitzCache, then sp_BlitzCache starts generating outputs.

This pull request contains little changes to both procedures so that everything works like expected.