### PR TITLE
#2847 sp_BlitzCache: Fix negative CHARINDEX result when ) precedes ( in compile_time_value.

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3982,7 +3982,7 @@ SET    s.variable_datatype = CASE WHEN s.variable_datatype LIKE '%(%)%'
 	   s.compile_time_value = CASE WHEN s.compile_time_value LIKE '%(%)%' 
                                    THEN SUBSTRING(s.compile_time_value, 
 												  CHARINDEX('(', s.compile_time_value) + 1,
-												  CHARINDEX(')', s.compile_time_value) - 1 - CHARINDEX('(', s.compile_time_value)
+												  CHARINDEX(')', s.compile_time_value, CHARINDEX('(', s.compile_time_value) + 1) - 1 - CHARINDEX('(', s.compile_time_value)
 												  )
 									WHEN variable_datatype NOT IN ('bit', 'tinyint', 'smallint', 'int', 'bigint') 
 									AND s.variable_datatype NOT LIKE '%binary%' 


### PR DESCRIPTION
Setting the `starting_position` of the `(` found when retrieving the closing `)` will keep us out of the negative sub-string length if there is a preceding `)`.

**Test Case**
```
DECLARE @compile_time_value NVARCHAR(258) = N'1) (something)';

SELECT CHARINDEX('(', @compile_time_value) + 1 AS [SubString starting_position]
	,CHARINDEX(')', @compile_time_value, CHARINDEX('(', @compile_time_value) + 1) - 1 - CHARINDEX('(', @compile_time_value) AS [SubString length]
    ,SUBSTRING(@compile_time_value, CHARINDEX('(', @compile_time_value) + 1, CHARINDEX(')', @compile_time_value, CHARINDEX('(', @compile_time_value) + 1) - 1 - CHARINDEX('(', @compile_time_value)) As compile_time_value;
```

SubString starting_position|SubString length|compile_time_value
---------------------------|----------------|------------------
5|9|something

If you have an open paren followed by an open paren:
`Set @compile_time_value = N'(1 (something)';`
SubString starting_position|SubString length|compile_time_value
---------------------------|----------------|------------------
2|12|1 (something