### PR TITLE
#2860 Add partition ranges to columnstore visualization

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2783,9 +2783,9 @@ BEGIN
 				FROM (
 					SELECT c.name AS column_name, p.partition_number,' + IIF(@ShowPartitionRanges = 1, N'
 						CASE WHEN pf.boundary_value_on_right = 0 THEN ''>'' ELSE ''>='' END range_start_op,
-						CASE WHEN pp.system_type_id IN (42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prvs.value, 126) ELSE CAST(prvs.value AS NVARCHAR(4000)) END range_start,
+						CASE WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prvs.value, 126) ELSE CAST(prvs.value AS NVARCHAR(4000)) END range_start,
 						CASE WHEN pf.boundary_value_on_right = 0 THEN ''<='' ELSE ''<'' END range_end_op,
-						CASE WHEN pp.system_type_id IN (42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prve.value, 126) ELSE CAST(prve.value AS NVARCHAR(4000)) END range_end,', '') + N'
+						CASE WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prve.value, 126) ELSE CAST(prve.value AS NVARCHAR(4000)) END range_end,', '') + N'
 						rg.row_group_id, rg.total_rows, rg.deleted_rows,
 						details = CAST(seg.min_data_id AS VARCHAR(20)) + '' to '' + CAST(seg.max_data_id AS VARCHAR(20)) + '', '' + CAST(CAST((seg.on_disk_size / 1024.0 / 1024) AS DECIMAL(18,0)) AS VARCHAR(20)) + '' MB''
 					FROM ' + QUOTENAME(@DatabaseName) + N'.sys.column_store_row_groups rg 

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -34,7 +34,7 @@ ALTER PROCEDURE dbo.sp_BlitzIndex
     @OutputTableName NVARCHAR(256) = NULL ,
 	@IncludeInactiveIndexes BIT = 0 /* Will skip indexes with no reads or writes */,
     @ShowAllMissingIndexRequests BIT = 0 /*Will make all missing index requests show up*/,
-	@ShowPartitionRanges BIT = 1 /* Will add partition range values column to columnstore visualization */,
+	@ShowPartitionRanges BIT = 0 /* Will add partition range values column to columnstore visualization */,
 	@SortOrder NVARCHAR(50) = NULL, /* Only affects @Mode = 2. */
 	@SortDirection NVARCHAR(4) = 'DESC', /* Only affects @Mode = 2. */
     @Help TINYINT = 0,
@@ -2795,6 +2795,7 @@ BEGIN
 							CASE
 								WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN 126
 								WHEN pp.system_type_id IN (59, 62) THEN 3
+								WHEN pp.system_type_id IN (60, 122) THEN 2
 								ELSE NULL END format_type,
 							CASE WHEN pf.boundary_value_on_right = 0 THEN ''>'' ELSE ''>='' END range_start_op,
 							prvs.value range_start_value,

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2783,9 +2783,15 @@ BEGIN
 				FROM (
 					SELECT c.name AS column_name, p.partition_number,' + IIF(@ShowPartitionRanges = 1, N'
 						CASE WHEN pf.boundary_value_on_right = 0 THEN ''>'' ELSE ''>='' END range_start_op,
-						CASE WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prvs.value, 126) ELSE CAST(prvs.value AS NVARCHAR(4000)) END range_start,
+						CASE
+							WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prvs.value, 126)
+							WHEN pp.system_type_id IN (59, 62) THEN CONVERT(NVARCHAR(4000), prvs.value, 3)
+							ELSE CAST(prvs.value AS NVARCHAR(4000)) END range_start,
 						CASE WHEN pf.boundary_value_on_right = 0 THEN ''<='' ELSE ''<'' END range_end_op,
-						CASE WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prve.value, 126) ELSE CAST(prve.value AS NVARCHAR(4000)) END range_end,', '') + N'
+						CASE
+							WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN CONVERT(NVARCHAR(4000), prve.value, 126)
+							WHEN pp.system_type_id IN (59, 62) THEN CONVERT(NVARCHAR(4000), prve.value, 3)
+							ELSE CAST(prve.value AS NVARCHAR(4000)) END range_end,', '') + N'
 						rg.row_group_id, rg.total_rows, rg.deleted_rows,
 						details = CAST(seg.min_data_id AS VARCHAR(20)) + '' to '' + CAST(seg.max_data_id AS VARCHAR(20)) + '', '' + CAST(CAST((seg.on_disk_size / 1024.0 / 1024) AS DECIMAL(18,0)) AS VARCHAR(20)) + '' MB''
 					FROM ' + QUOTENAME(@DatabaseName) + N'.sys.column_store_row_groups rg 

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2778,9 +2778,9 @@ BEGIN
 
 			SET @dsql = N'USE ' + QUOTENAME(@DatabaseName) + N'; 
 				SELECT partition_number, row_group_id, total_rows, deleted_rows, ' + @ColumnList + IIF(@ShowPartitionRanges = 1, N',
-					COALESCE(range_start_op + '' '' + range_start + '' '', '''') + COALESCE(range_end_op + '' '' + range_end, '''') AS partition_range', '') + N'
+					COALESCE(range_start_op + '' '' + range_start + '' '', '''') + COALESCE(range_end_op + '' '' + range_end, '''') AS partition_range
 				FROM (
-					SELECT column_name, partition_number, row_group_id, total_rows, deleted_rows, details' + IIF(@ShowPartitionRanges = 1, N',
+					SELECT column_name, partition_number, row_group_id, total_rows, deleted_rows, details,
 						range_start_op,
 						CASE
 							WHEN format_type IS NULL THEN CAST(range_start_value AS NVARCHAR(4000))
@@ -2811,8 +2811,8 @@ BEGIN
 						LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.partition_range_values prvs ON prvs.function_id = pf.function_id AND prvs.boundary_id = p.partition_number - 1
 						LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.partition_range_values prve ON prve.function_id = pf.function_id AND prve.boundary_id = p.partition_number', '') + N'
 						LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.column_store_segments seg ON p.partition_id = seg.partition_id AND ic.index_column_id = seg.column_id AND rg.row_group_id = seg.segment_id
-						WHERE rg.object_id = @ObjectID
-					) AS y
+						WHERE rg.object_id = @ObjectID' + IIF(@ShowPartitionRanges = 1, N'
+					) AS y', '') + N'
 				) AS x
 				PIVOT (MAX(details) FOR column_name IN ( ' + @ColumnList + N')) AS pivot1
 				ORDER BY partition_number, row_group_id;';


### PR DESCRIPTION
Resolves #2860.  Use @ShowPartitionRanges = 1 to see the new column.  Below is a summary of my testing.  Please let me know if you can think of anything else.

### What was tested
#### Partition function parameter types
- int, bigint, smallint, tinyint
- date, time, smalldatetime, datetime, datetime2, datetimeoffset
- decimal, numeric
- money, smallmoney
- varchar, nvarchar

#### Columnstore index types
- CLUSTERED
- NONCLUSTERED

#### Partition compression
- COLUMNSTORE
- COLUMNSTORE_ARCHIVE

#### Other
- Compatibility levels 100 to 150
- Partition counts from 50 to 5000
