### PR TITLE
Remove cached_parameter_info from insert column list on SQL2008R2

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -1147,7 +1147,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	,[query_text]
 	,[query_plan]'
     + CASE WHEN @ProductVersionMajor >= 11 THEN N',[live_query_plan]' ELSE N'' END + N'
-	,[cached_parameter_info]'
+	+ CASE WHEN @ProductVersionMajor >= 11 THEN N',[cached_parameter_info]'  ELSE N'' END
 	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]
 	,[status]


### PR DESCRIPTION
Closes this: https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/2875