### PR TITLE
Update sp_BlitzIndex.sql

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1674,6 +1674,7 @@ BEGIN TRY
 				  	  ORDER BY (q.user_seeks + q.user_scans) DESC, s.total_logical_reads DESC
 			      ) q2
 				  CROSS APPLY sys.dm_exec_query_plan(q2.plan_handle) p
+                  WHERE ig.index_group_handle = gs.group_handle
 			  ) '
 		END
         


### PR DESCRIPTION
Filter the list of missing index query plans to just the missing index for this record.

Tries to fix #2883 
**This has about 1 minute of testing on the server that I'm on. It fixes the problem this time, but I'd suggest it needs a fair bit more testing. I'm not going to have time to do that properly anytime soon.**