### PR TITLE
sp_BlitzFirst: Sample command at end of script: Suppress output when saving to table

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -4747,4 +4747,5 @@ EXEC sp_BlitzFirst
 , @OutputTableNameWaitStats = 'BlitzFirst_WaitStats'
 , @OutputTableNameBlitzCache = 'BlitzCache'
 , @OutputTableNameBlitzWho = 'BlitzWho'
+, @OutputType = 'none'
 */


### PR DESCRIPTION
Addition to #2892 (which added `@OutputType = 'none'` to https://www.brentozar.com/askbrent/).
But just recognized: `@OutputTableNameBlitzWho = 'BlitzWho'` is used in the script but missing on the website.