### PR TITLE
Removed dependency on schedules for evaluating jobs w/o failure emails

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3253,11 +3253,6 @@ AS
 										'The job ' + [name]
 										+ ' has not been set up to notify an operator if it fails.' AS Details
 								FROM    msdb.[dbo].[sysjobs] j
-										INNER JOIN ( SELECT DISTINCT
-															[job_id]
-													 FROM   [msdb].[dbo].[sysjobschedules]
-													 WHERE  next_run_date > 0
-												   ) s ON j.job_id = s.job_id
 								WHERE   j.enabled = 1
 										AND j.notify_email_operator_id = 0
 										AND j.notify_netsend_operator_id = 0


### PR DESCRIPTION
Updates check #94 to evaluate enabled jobs for failure emails regardless of whether or not there's a schedule defined. This also addresses the issue of sp_Blitz ignoring jobs with a schedule type of "Start automatically when SQL Server Agent starts".

Fixes issue #2905.