### PR TITLE
Fix error: Msg 102, Level 15, State 1, Procedure sp_BlitzWho, Line 1148 [Batch Start Line 3]

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -1147,7 +1147,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	,[database_name]
 	,[query_text]
 	,[query_plan]'
-    + CASE WHEN @ProductVersionMajor >= 11 THEN N',[live_query_plan]' ELSE N'' END + N''
+    + CASE WHEN @ProductVersionMajor >= 11 THEN N',[live_query_plan]' ELSE N'' END 
 	+ CASE WHEN @ProductVersionMajor >= 11 THEN N',[cached_parameter_info]'  ELSE N'' END
 	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -1147,7 +1147,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	,[database_name]
 	,[query_text]
 	,[query_plan]'
-    + CASE WHEN @ProductVersionMajor >= 11 THEN N',[live_query_plan]' ELSE N'' END + N'
+    + CASE WHEN @ProductVersionMajor >= 11 THEN N',[live_query_plan]' ELSE N'' END + N''
 	+ CASE WHEN @ProductVersionMajor >= 11 THEN N',[cached_parameter_info]'  ELSE N'' END
 	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]


### PR DESCRIPTION
Msg 102, Level 15, State 1, Procedure sp_BlitzWho, Line 1148 [Batch Start Line 3]
Incorrect syntax near ','.
Msg 102, Level 15, State 1, Procedure sp_BlitzWho, Line 1247 [Batch Start Line 3]
Incorrect syntax near ':'.
Msg 105, Level 15, State 1, Procedure sp_BlitzWho, Line 1268 [Batch Start Line 3]
Unclosed quotation mark after the character string ',
	@CheckDateOverride;

END
GO
'.