### PR TITLE
add target recovery interval check

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -61,10 +61,10 @@ If you want to add a new one, start at 258.
 | 50 | Performance | Poison Wait Detected | https://www.BrentOzar.com/go/poison | 107 |
 | 50 | Performance | Poison Wait Detected: CMEMTHREAD & NUMA | https://www.BrentOzar.com/go/poison | 162 |
 | 50 | Performance | Poison Wait Detected: Serializable Locking | https://www.BrentOzar.com/go/serializable | 121 |
+| 50 | Performance | Recovery Interval Not Optimal| https://sqlperformance.com/2020/05/system-configuration/0-to-60-switching-to-indirect-checkpoints | 257 |
 | 50 | Performance | Snapshotting Too Many Databases | https://www.BrentOzar.com/go/toomanysnaps | 236 |
 | 50 | Performance | Too Much Free Memory | https://www.BrentOzar.com/go/freememory | 165 |
 | 50 | Performance | Wait Stats Cleared Recently| | 205 |
-| 50 | Performance | Suboptimal recovery interval| https://sqlperformance.com/2020/05/system-configuration/0-to-60-switching-to-indirect-checkpoints | 257 |
 | 50 | Reliability | Full Text Indexes Not Updating | https://www.BrentOzar.com/go/fulltext | 113 |
 | 50 | Reliability | Page Verification Not Optimal | https://www.BrentOzar.com/go/torn | 14 |
 | 50 | Reliability | Possibly Broken Log Shipping | https://www.BrentOzar.com/go/shipping | 111 |

--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 256.
-If you want to add a new one, start at 257.
+CURRENT HIGH CHECKID: 257.
+If you want to add a new one, start at 258.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -64,6 +64,7 @@ If you want to add a new one, start at 257.
 | 50 | Performance | Snapshotting Too Many Databases | https://www.BrentOzar.com/go/toomanysnaps | 236 |
 | 50 | Performance | Too Much Free Memory | https://www.BrentOzar.com/go/freememory | 165 |
 | 50 | Performance | Wait Stats Cleared Recently| | 205 |
+| 50 | Performance | Suboptimal recovery interval| https://sqlperformance.com/2020/05/system-configuration/0-to-60-switching-to-indirect-checkpoints | 257 |
 | 50 | Reliability | Full Text Indexes Not Updating | https://www.BrentOzar.com/go/fulltext | 113 |
 | 50 | Reliability | Page Verification Not Optimal | https://www.BrentOzar.com/go/torn | 14 |
 | 50 | Reliability | Possibly Broken Log Shipping | https://www.BrentOzar.com/go/shipping | 111 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -4395,7 +4395,7 @@ IF
                        FindingsGroup = 
                            N''Performance'',
                        Finding =
-                           N''Suboptimal recovery interval'',
+                           N''Recovery Interval Not Optimal'',
                        URL = 
                            N''https://sqlperformance.com/2020/05/system-configuration/0-to-60-switching-to-indirect-checkpoints'',
                        Details = 


### PR DESCRIPTION
Adds a check when available (2012+) to see if target recovery interval is <> 60, and suggest setting it there.

Sure, it could be 61 or something, but I'm not going down that path.

I quoted out the current check for target recovery interval that looks to see if it's not 0 or 60, to not give seemingly conflicting advice.

Right now, the URL is to Aaron's post on the subject. @BrentOzar will need to go code it for uniformity.

I've also updated the documentation to reflect the new high check id, etc.

Closes #2938 