### PR TITLE
#2946 sp_Blitz query store rtm check

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6158,7 +6158,7 @@ IF @ProductVersionMajor >= 10
 							END;
 
 						
-						IF @ProductVersionMajor >= 13 AND @ProductVersionMinor < 2149 --CU1 has the fix in it
+						IF @ProductVersionMajor = 13 AND @ProductVersionMinor < 2149 --2016 CU1 has the fix in it
 							AND NOT EXISTS ( SELECT  1
 											 FROM    #SkipChecks
 											 WHERE   DatabaseName IS NULL AND CheckID = 182 )


### PR DESCRIPTION
Only alert for SQL Server 2016. Closes #2946.