### PR TITLE
Fixed SkipChecks bug caused by collation mismatch

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -356,7 +356,7 @@ AS
 					SET @StringToExecute += QUOTENAME(@SkipChecksServer) + N'.';
 					END
 				SET @StringToExecute += QUOTENAME(@SkipChecksDatabase) + N'.' + QUOTENAME(@SkipChecksSchema) + N'.' + QUOTENAME(@SkipChecksTable)
-					+ N' WHERE ServerName IS NULL OR ServerName = SERVERPROPERTY(''ServerName'') OPTION (RECOMPILE);';
+					+ N' WHERE ServerName IS NULL OR ServerName = CAST(SERVERPROPERTY(''ServerName'') AS NVARCHAR(128)) OPTION (RECOMPILE);';
 				EXEC(@StringToExecute);
 			END;
 


### PR DESCRIPTION
In the INSERT INTO #SkipChecks dynamic SQL statement, the WHERE clause includes:
    ServerName = SERVERPROPERTY('ServerName')

This is false when the SkipChecks table is in a (linked) server with a different collation to the server on which sp_Blitz is being executed, because ServerName returns data in one collation (eg. Latin1_General_CI_AS) whereas SERVERPROPERTY('ServerName') returns data in (I believe) the current server or database collation (eg. SQL_Latin1_General_CP1_CI_AS).

Therefore, there is a need to include a COLLATE clause so that equality condition works, ie:
ServerName COLLATE DATABASE_DEFAULT = SERVERPROPERTY('ServerName')