### PR TITLE
Add unique constraint awareness

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2413,7 +2413,7 @@ SELECT
                     N'.' + QUOTENAME([object_name]) + 
                     N' ADD CONSTRAINT [' +
                     index_name + 
-                    N'] UNIQUE;'
+                    N'] UNIQUE'
 				WHEN is_CX_columnstore= 1 THEN
                         N'CREATE CLUSTERED COLUMNSTORE INDEX ' + QUOTENAME(index_name) + N' on ' + QUOTENAME([database_name]) + N'.' + QUOTENAME([schema_name]) + N'.' + QUOTENAME([object_name])
             ELSE /*Else not a PK or cx columnstore */ 


### PR DESCRIPTION
This adds `is_unique_constraint` from `sys.indexes` to a couple of the operating modes.

Note that this also adds the new column etc. to the remote server code for Mode 2 as well, and should be announced as a breaking change (of removed, whatever). I don't have a setup to test this part, but the code looks accurate.

This has been tested in modes 0-4, and I've verified that this column exists going back to at least SQL Server 2008.

Closes  #2950 