### PR TITLE
Issue #2970 sp_BlitzWho - Add dm_exec_requests.wait_resource to report and output table

### DIFF
--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -13095,6 +13095,7 @@ SELECT [ServerName]
       ,[query_cost]
       ,[status]
       ,[wait_info]
+      ,[wait_resource]
       ,[top_session_waits]
       ,[blocking_session_id]
       ,[open_transaction_count]
@@ -35517,6 +35518,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	[query_cost] [float] NULL,
 	[status] [nvarchar](30) NOT NULL,
 	[wait_info] [nvarchar](max) NULL,
+	[wait_resource] [nvarchar](max) NULL,
 	[top_session_waits] [nvarchar](max) NULL,
 	[blocking_session_id] [smallint] NULL,
 	[open_transaction_count] [int] NULL,
@@ -35688,6 +35690,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'    [query_cost], ' + @LineFeed 
 				+ N'    [status], ' + @LineFeed 
 				+ N'    [wait_info], ' + @LineFeed 
+				+ N'    [wait_resource], ' + @LineFeed 
 				+ N'    [top_session_waits], ' + @LineFeed 
 				+ N'    [blocking_session_id], ' + @LineFeed 
 				+ N'    [open_transaction_count], ' + @LineFeed 
@@ -35789,6 +35792,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'			       [query_cost], ' + @LineFeed 
 				+ N'			       [status], ' + @LineFeed 
 				+ N'			       [wait_info], ' + @LineFeed 
+				+ N'			       [wait_resource], ' + @LineFeed 
 				+ N'			       [top_session_waits], ' + @LineFeed 
 				+ N'			       [blocking_session_id], ' + @LineFeed 
 				+ N'			       [open_transaction_count], ' + @LineFeed 
@@ -36033,6 +36037,7 @@ BEGIN
 								WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 								ELSE NULL
 							END AS wait_info ,																					
+							r.wait_resource ,
 						    CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
 							       THEN r.blocking_session_id
 							       WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
@@ -36261,7 +36266,8 @@ IF @ProductVersionMajor >= 11
 					CASE
 						WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 						ELSE NULL
-					END AS wait_info ,'
+					END AS wait_info ,
+					r.wait_resource ,'
 						    +
 						    CASE @SessionWaits
 							     WHEN 1 THEN + N'SUBSTRING(wt2.session_wait_info, 0, LEN(wt2.session_wait_info) ) AS top_session_waits ,'
@@ -36591,7 +36597,8 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]
 	,[status]
-	,[wait_info]'
+	,[wait_info]
+	,[wait_resource]'
     + CASE WHEN @ProductVersionMajor >= 11 THEN N',[top_session_waits]' ELSE N'' END + N'
 	,[blocking_session_id]
 	,[open_transaction_count]

--- a/Install-Core-Blitz-No-Query-Store.sql
+++ b/Install-Core-Blitz-No-Query-Store.sql
@@ -10274,6 +10274,7 @@ SELECT [ServerName]
       ,[query_cost]
       ,[status]
       ,[wait_info]
+      ,[wait_resource]
       ,[top_session_waits]
       ,[blocking_session_id]
       ,[open_transaction_count]
@@ -26941,6 +26942,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	[query_cost] [float] NULL,
 	[status] [nvarchar](30) NOT NULL,
 	[wait_info] [nvarchar](max) NULL,
+	[wait_resource] [nvarchar](max) NULL,
 	[top_session_waits] [nvarchar](max) NULL,
 	[blocking_session_id] [smallint] NULL,
 	[open_transaction_count] [int] NULL,
@@ -27112,6 +27114,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'    [query_cost], ' + @LineFeed 
 				+ N'    [status], ' + @LineFeed 
 				+ N'    [wait_info], ' + @LineFeed 
+				+ N'    [wait_resource], ' + @LineFeed 
 				+ N'    [top_session_waits], ' + @LineFeed 
 				+ N'    [blocking_session_id], ' + @LineFeed 
 				+ N'    [open_transaction_count], ' + @LineFeed 
@@ -27213,6 +27216,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'			       [query_cost], ' + @LineFeed 
 				+ N'			       [status], ' + @LineFeed 
 				+ N'			       [wait_info], ' + @LineFeed 
+				+ N'			       [wait_resource], ' + @LineFeed 
 				+ N'			       [top_session_waits], ' + @LineFeed 
 				+ N'			       [blocking_session_id], ' + @LineFeed 
 				+ N'			       [open_transaction_count], ' + @LineFeed 
@@ -27457,6 +27461,7 @@ BEGIN
 								WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 								ELSE NULL
 							END AS wait_info ,																					
+							r.wait_resource ,
 						    CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
 							       THEN r.blocking_session_id
 							       WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
@@ -27685,7 +27690,8 @@ IF @ProductVersionMajor >= 11
 					CASE
 						WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 						ELSE NULL
-					END AS wait_info ,'
+					END AS wait_info ,
+					r.wait_resource ,'
 						    +
 						    CASE @SessionWaits
 							     WHEN 1 THEN + N'SUBSTRING(wt2.session_wait_info, 0, LEN(wt2.session_wait_info) ) AS top_session_waits ,'
@@ -28015,7 +28021,8 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]
 	,[status]
-	,[wait_info]'
+	,[wait_info]
+	,[wait_resource]'
     + CASE WHEN @ProductVersionMajor >= 11 THEN N',[top_session_waits]' ELSE N'' END + N'
 	,[blocking_session_id]
 	,[open_transaction_count]

--- a/Install-Core-Blitz-With-Query-Store.sql
+++ b/Install-Core-Blitz-With-Query-Store.sql
@@ -10274,6 +10274,7 @@ SELECT [ServerName]
       ,[query_cost]
       ,[status]
       ,[wait_info]
+      ,[wait_resource]
       ,[top_session_waits]
       ,[blocking_session_id]
       ,[open_transaction_count]
@@ -32696,6 +32697,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	[query_cost] [float] NULL,
 	[status] [nvarchar](30) NOT NULL,
 	[wait_info] [nvarchar](max) NULL,
+	[wait_resource] [nvarchar](max) NULL,
 	[top_session_waits] [nvarchar](max) NULL,
 	[blocking_session_id] [smallint] NULL,
 	[open_transaction_count] [int] NULL,
@@ -32867,6 +32869,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'    [query_cost], ' + @LineFeed 
 				+ N'    [status], ' + @LineFeed 
 				+ N'    [wait_info], ' + @LineFeed 
+				+ N'    [wait_resource], ' + @LineFeed 
 				+ N'    [top_session_waits], ' + @LineFeed 
 				+ N'    [blocking_session_id], ' + @LineFeed 
 				+ N'    [open_transaction_count], ' + @LineFeed 
@@ -32968,6 +32971,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'			       [query_cost], ' + @LineFeed 
 				+ N'			       [status], ' + @LineFeed 
 				+ N'			       [wait_info], ' + @LineFeed 
+				+ N'			       [wait_resource], ' + @LineFeed 
 				+ N'			       [top_session_waits], ' + @LineFeed 
 				+ N'			       [blocking_session_id], ' + @LineFeed 
 				+ N'			       [open_transaction_count], ' + @LineFeed 
@@ -33212,6 +33216,7 @@ BEGIN
 								WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 								ELSE NULL
 							END AS wait_info ,																					
+							r.wait_resource ,
 						    CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
 							       THEN r.blocking_session_id
 							       WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
@@ -33440,7 +33445,8 @@ IF @ProductVersionMajor >= 11
 					CASE
 						WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 						ELSE NULL
-					END AS wait_info ,'
+					END AS wait_info ,
+					r.wait_resource ,'
 						    +
 						    CASE @SessionWaits
 							     WHEN 1 THEN + N'SUBSTRING(wt2.session_wait_info, 0, LEN(wt2.session_wait_info) ) AS top_session_waits ,'
@@ -33770,7 +33776,8 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]
 	,[status]
-	,[wait_info]'
+	,[wait_info]
+	,[wait_resource]'
     + CASE WHEN @ProductVersionMajor >= 11 THEN N',[top_session_waits]' ELSE N'' END + N'
 	,[blocking_session_id]
 	,[open_transaction_count]

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -170,6 +170,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	[query_cost] [float] NULL,
 	[status] [nvarchar](30) NOT NULL,
 	[wait_info] [nvarchar](max) NULL,
+	[wait_resource] [nvarchar](max) NULL,
 	[top_session_waits] [nvarchar](max) NULL,
 	[blocking_session_id] [smallint] NULL,
 	[open_transaction_count] [int] NULL,
@@ -341,6 +342,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'    [query_cost], ' + @LineFeed 
 				+ N'    [status], ' + @LineFeed 
 				+ N'    [wait_info], ' + @LineFeed 
+				+ N'    [wait_resource], ' + @LineFeed 
 				+ N'    [top_session_waits], ' + @LineFeed 
 				+ N'    [blocking_session_id], ' + @LineFeed 
 				+ N'    [open_transaction_count], ' + @LineFeed 
@@ -442,6 +444,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 				+ N'			       [query_cost], ' + @LineFeed 
 				+ N'			       [status], ' + @LineFeed 
 				+ N'			       [wait_info], ' + @LineFeed 
+				+ N'			       [wait_resource], ' + @LineFeed 
 				+ N'			       [top_session_waits], ' + @LineFeed 
 				+ N'			       [blocking_session_id], ' + @LineFeed 
 				+ N'			       [open_transaction_count], ' + @LineFeed 
@@ -686,6 +689,7 @@ BEGIN
 								WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 								ELSE NULL
 							END AS wait_info ,																					
+							r.wait_resource ,
 						    CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
 							       THEN r.blocking_session_id
 							       WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
@@ -914,7 +918,8 @@ IF @ProductVersionMajor >= 11
 					CASE
 						WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
 						ELSE NULL
-					END AS wait_info ,'
+					END AS wait_info ,
+					r.wait_resource ,'
 						    +
 						    CASE @SessionWaits
 							     WHEN 1 THEN + N'SUBSTRING(wt2.session_wait_info, 0, LEN(wt2.session_wait_info) ) AS top_session_waits ,'
@@ -1244,7 +1249,8 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]
 	,[status]
-	,[wait_info]'
+	,[wait_info]
+	,[wait_resource]'
     + CASE WHEN @ProductVersionMajor >= 11 THEN N',[top_session_waits]' ELSE N'' END + N'
 	,[blocking_session_id]
 	,[open_transaction_count]


### PR DESCRIPTION
These tests were done for the following stored procedures.

#### BlitzWho, Install-All-Scripts, Install-Core-Blitz-No-Query-Store, Install-Core-Blitz-With-Query-Store

1. Should create procedure.
2. Should show new wait_resource column in both expert and non-expert modes.
3. Should add new wait_resource column and data to output table.
4. Should select new wait_resource column using BlitzWho_Deltas view.

#### BlitzFirst

1. Should successfully run BlitzFirst which executes BlitzWho to...
    a. show new column.
    b. add new column to the output table.

Are there other tests I should do to verify this change?

Tests were done on:

```
Microsoft SQL Server 2016 (SP1-GDR) (KB4458842) - 13.0.4224.16 (X64) Enterprise Edition (64-bit) on Windows Server 2016 Standard 6.3 <X64> (Build 14393: )
```

All versions of SQL Server should be good as the `wait_resource` column exists in SQL Server 2008 R2.