### PR TITLE
Fix for issue 2591 - include live query plan only when parameter included

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -27,7 +27,6 @@ ALTER PROCEDURE [dbo].[sp_DatabaseRestore]
     @StopAt NVARCHAR(14) = NULL,
     @OnlyLogsAfter NVARCHAR(14) = NULL,
     @SimpleFolderEnumeration BIT = 0,
-	@DatabaseOwner SYSNAME = NULL,
 	@SkipBackupsAlreadyInMsdb BIT = 0,
 	@DatabaseOwner sysname = NULL,
 	@SetTrustworthyON BIT = 0,
@@ -1448,8 +1447,6 @@ IF @DatabaseOwner IS NOT NULL
 	BEGIN
 		IF @RunRecovery = 1
 		BEGIN
-			SET @sql = N'ALTER AUTHORIZATION ON DATABASE::' + @RestoreDatabaseName + ' TO [' + @databaseowner + ']';
-			SET @sql = N'ALTER AUTHORIZATION ON DATABASE::' + @RestoreDatabaseName + ' TO [' + @DatabaseOwner + ']';
 			IF EXISTS (SELECT * FROM master.dbo.syslogins WHERE syslogins.loginname = @DatabaseOwner)
 			BEGIN
 				SET @sql = N'ALTER AUTHORIZATION ON DATABASE::' + @RestoreDatabaseName + ' TO [' + @DatabaseOwner + ']';


### PR DESCRIPTION
Added a parameter, default it to 0. Only include the live query plans when the user asks for them. Sometimes shredding the XML causes SQL to kill the session and create a dump file.

Add some text to the column to tell users how to enable the live query plans if they want them.