### PR TITLE
sp_Blitz: Suppress message if registry key not found

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8690,7 +8690,8 @@ IF @ProductVersionMajor >= 10 AND  NOT EXISTS ( SELECT  1
 								EXEC master.sys.xp_regread @rootkey = 'HKEY_LOCAL_MACHINE',
 														   @key = 'SOFTWARE\Policies\Microsoft\Power\PowerSettings',
 														   @value_name = 'ActivePowerScheme',
-														   @value = @outval OUTPUT;
+														   @value = @outval OUTPUT,
+														   @no_output = 'no_output';
 
 								IF @outval IS NULL /* If power plan was not set by group policy, get local value [Git Hub Issue #1620]*/
 								EXEC master.sys.xp_regread @rootkey = 'HKEY_LOCAL_MACHINE',


### PR DESCRIPTION
In case the power plan is not managed by group policies, the tested registry key SOFTWARE\Policies\Microsoft\Power\PowerSettings is not found on the system, resulting in the message "RegOpenKeyEx() returned error 2, 'The system cannot find the file specified.'". To suppress this message, the very special parameter "@no_output = 'no_output'" can be used.

I have tested this on a system without group policies. I have not yet tested this on a system where the power plan is managed by group policies.

Fixes #2836.