### PR TITLE
#3081 sp_Blitz large log files are OK

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6377,7 +6377,8 @@ IF @ProductVersionMajor >= 10
 		                              FROM [?].sys.database_files WHERE type_desc = ''LOG''
 			                            AND N''?'' <> ''[tempdb]''
 		                              GROUP BY LEFT(physical_name, 1)
-		                              HAVING COUNT(*) > 1 OPTION (RECOMPILE);';
+		                              HAVING COUNT(*) > 1 
+									     AND SUM(size) < 268435456 OPTION (RECOMPILE);';
 					        END;
 
 				        IF NOT EXISTS ( SELECT  1


### PR DESCRIPTION
Multiple log files on the same drive are OK if they're 2TB or larger. Closes #3081.