### PR TITLE
sp_DatabaseRestore - add check for CommandExec in current database fix

### DIFF
--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -212,11 +212,15 @@ BEGIN
     RETURN;
 END;
 
-IF NOT EXISTS (SELECT name FROM sys.objects WHERE type = 'P' AND name = 'CommandExecute')
+DECLARE @CurrentDatabaseContext AS VARCHAR(128) = (SELECT DB_NAME());
+DECLARE @CommandExecuteCheck VARCHAR(315)
+
+SET @CommandExecuteCheck = 'IF NOT EXISTS (SELECT name FROM ' +@CurrentDatabaseContext+'.sys.objects WHERE type = ''P'' AND name = ''CommandExecute'')
 BEGIN
-	RAISERROR('DatabaseRestore requires the CommandExecute stored procedure from the OLA Hallengren Maintenance solution, are you using the correct database?', 15, 1);
+	RAISERROR(''DatabaseRestore requires the CommandExecute stored procedure from the OLA Hallengren Maintenance solution, are you using the correct database?'', 15, 1);
 	RETURN;
-END;
+END;'
+EXEC (@CommandExecuteCheck)
 
 DECLARE @cmd NVARCHAR(4000) = N'', --Holds xp_cmdshell command
         @sql NVARCHAR(MAX) = N'', --Holds executable SQL commands

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -212,15 +212,20 @@ BEGIN
     RETURN;
 END;
 
+BEGIN TRY 
 DECLARE @CurrentDatabaseContext AS VARCHAR(128) = (SELECT DB_NAME());
 DECLARE @CommandExecuteCheck VARCHAR(315)
 
 SET @CommandExecuteCheck = 'IF NOT EXISTS (SELECT name FROM ' +@CurrentDatabaseContext+'.sys.objects WHERE type = ''P'' AND name = ''CommandExecute'')
 BEGIN
-	RAISERROR(''DatabaseRestore requires the CommandExecute stored procedure from the OLA Hallengren Maintenance solution, are you using the correct database?'', 15, 1);
+	RAISERROR (''DatabaseRestore requires the CommandExecute stored procedure from the OLA Hallengren Maintenance solution, are you using the correct database?'', 15, 1);
 	RETURN;
 END;'
 EXEC (@CommandExecuteCheck)
+END TRY
+BEGIN CATCH
+THROW;
+END CATCH
 
 DECLARE @cmd NVARCHAR(4000) = N'', --Holds xp_cmdshell command
         @sql NVARCHAR(MAX) = N'', --Holds executable SQL commands


### PR DESCRIPTION
Needed to change the check, as you can execute the blitz scripts from the context of another database, but the previous check would only check if the stored procedure existed in the database where the DatabaseRestore SP resided, and wouldn't check if it existed in the database you were currently using at execution (So it would fail even if the database you were using had it, as it was only checking if it existed where the toolkit was deployed).

Not sure if there was a better way to do this than dynamic SQL... But I've tested this and it resolves the issue I found at least. If there's a better method of doing this, would love to know though.