### PR TITLE
#2980 sp_BlitzCache arithmetic overflows

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -124,9 +124,9 @@ CREATE TABLE ##BlitzCacheProcs (
             */
         TotalWorkerTimeForType BIGINT,
         TotalElapsedTimeForType BIGINT,
-        TotalReadsForType BIGINT,
+        TotalReadsForType DECIMAL(30),
         TotalExecutionCountForType BIGINT,
-        TotalWritesForType BIGINT,
+        TotalWritesForType DECIMAL(30),
         NumberOfPlans INT,
         NumberOfDistinctPlans INT,
         SerialDesiredMemory FLOAT,
@@ -2110,8 +2110,8 @@ SET @body += N') AS qs
 	   CROSS JOIN(SELECT SUM(execution_count) AS t_TotalExecs,
                          SUM(CAST(total_elapsed_time AS BIGINT) / 1000.0) AS t_TotalElapsed,
                          SUM(CAST(total_worker_time AS BIGINT) / 1000.0) AS t_TotalWorker,
-                         SUM(CAST(total_logical_reads AS BIGINT)) AS t_TotalReads,
-                         SUM(CAST(total_logical_writes AS BIGINT)) AS t_TotalWrites
+                         SUM(CAST(total_logical_reads AS DECIMAL(30))) AS t_TotalReads,
+                         SUM(CAST(total_logical_writes AS DECIMAL(30))) AS t_TotalWrites
                   FROM   sys.#view#) AS t
        CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
        CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st


### PR DESCRIPTION
Using decimal(30) for total reads and writes instead of bigint. Closes #2980.