### PR TITLE
Use DATETIME2 in filter when checking dbi_LastLogBackupTime

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1090,7 +1090,7 @@ AS
 												)
 												OR
 												(
-													Convert(datetime,ll.Value) < DATEADD(dd,-7, GETDATE())
+													Convert(datetime2, ll.Value) < DATEADD(dd,-7, GETDATE())
 												)
 
 											);


### PR DESCRIPTION
Running sp_blitz raises an error doing the date filter on dbi_LastLogBackupTime. This address that issue.

SELECT CONVERT(DATETIME, '2021-06-14 09:58:08.793')     --> this one fails to convert to datetime
SELECT CONVERT(DATETIME2, '2021-06-14 09:58:08.793')   --> this one converts ok.