### PR TITLE
Add SQL 2022 RTM PSPO parsing

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3774,7 +3774,7 @@ FROM    ##BlitzCacheProcs p
 				SELECT PATINDEX('%[^0-9]%', c.OptionSubstring) AS ObjectLength
 				) d
 		OUTER APPLY (
-				SELECT	CONVERT(INT, SUBSTRING(OptionSubstring, 1, d.ObjectLength - 1)) AS ObjectId
+				SELECT	TRY_CONVERT(INT, SUBSTRING(OptionSubstring, 1, d.ObjectLength - 1)) AS ObjectId
 				) e
 		JOIN sys.dm_exec_procedure_stats s ON DB_ID(p.DatabaseName) = s.database_id AND e.ObjectId = s.object_id
 WHERE   p.QueryType = 'Statement'

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3774,7 +3774,7 @@ FROM    ##BlitzCacheProcs p
 				SELECT PATINDEX('%[^0-9]%', c.OptionSubstring) AS ObjectLength
 				) d
 		OUTER APPLY (
-				SELECT	TRY_CONVERT(INT, SUBSTRING(OptionSubstring, 1, d.ObjectLength - 1)) AS ObjectId
+				SELECT	TRY_CAST(SUBSTRING(OptionSubstring, 1, d.ObjectLength - 1) AS INT) AS ObjectId
 				) e
 		JOIN sys.dm_exec_procedure_stats s ON DB_ID(p.DatabaseName) = s.database_id AND e.ObjectId = s.object_id
 WHERE   p.QueryType = 'Statement'

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3771,12 +3771,12 @@ FROM    ##BlitzCacheProcs p
 				WHERE	b.OptionStart > 0
 				) c
 		OUTER APPLY (
-				SELECT PATINDEX('%[^0-9]%', c.OptionSubstring) AS ObjectLength
+				SELECT  PATINDEX('%[^0-9]%', c.OptionSubstring) AS ObjectLength
 				) d
 		OUTER APPLY (
 				SELECT	TRY_CAST(SUBSTRING(OptionSubstring, 1, d.ObjectLength - 1) AS INT) AS ObjectId
 				) e
-		JOIN sys.dm_exec_procedure_stats s ON DB_ID(p.DatabaseName) = s.database_id AND e.ObjectId = s.object_id
+		JOIN    sys.dm_exec_procedure_stats s ON DB_ID(p.DatabaseName) = s.database_id AND e.ObjectId = s.object_id
 WHERE   p.QueryType = 'Statement'
 AND		p.SPID = @@SPID
 AND		s.object_id IS NOT NULL


### PR DESCRIPTION
In SQL 2022 RTM when plan sensitive parameter optimization is in use, the query text for statements will be appended with (at least) one of two strings that contain the ObjectID of the parent stored procedure:

```
SELECT TOP 10000 *, dbo.UsersByReputation_Function(@Reputation) AS ReputationPlusOne  FROM dbo.Users  WHERE Reputation=@Reputation  ORDER BY DisplayName  OPTION ( PLAN PER VALUE(ObjectID = 1205579333, QueryVariantID = 2, predicate_range([StackOverflow2013].[dbo].[Users].[Reputation] = @Reputation, 100.0, 1000000.0)), USE HINT('DISABLE_TSQL_SCALAR_UDF_INLINING'))

SELECT TOP 10000 *  FROM dbo.Users  WHERE Reputation=@Reputation  ORDER BY DisplayName option (PLAN PER VALUE(ObjectID = 1157579162, QueryVariantID = 2, predicate_range([StackOverflow2013].[dbo].[Users].[Reputation] = @Reputation, 100.0, 1000000.0)))
```

This PR strips out spaces around quotes and equals and checks the query text for "OPTION(PLAN PER VALUE(ObjectID=", then pulls the corresponding name from the plan cache if it contains the database id and object id.

You can test this on the StackOverflow2013 medium size database. The code below is a modified version of the test code from [PSPO: How SQL Server 2022 Tries to Fix Parameter Sniffing
](https://brentozar.com/go/pspo)

```
ALTER DATABASE CURRENT SET COMPATIBILITY_LEVEL = 160; /* 2022 */
GO
EXEC DropIndexes;
GO
CREATE INDEX Reputation ON dbo.Users(Reputation)
GO
CREATE OR ALTER PROCEDURE dbo.usp_UsersByReputation
  @Reputation int
AS
SELECT TOP 10000 *
FROM dbo.Users
WHERE Reputation=@Reputation
ORDER BY DisplayName;
GO
/*
This is another silly test procedure that calls a dummy function. This was during testing
to see if PSPO was needed for the functions section of the sp_BlitzCache code, but it
doesn't seem necessary. However it did expose the weird case of having spaces around
parenthesis and equals signs, so I've kept it in as a good test.
*/
CREATE OR ALTER PROCEDURE dbo.usp_UsersByReputation_Function
  @Reputation int
AS
SELECT TOP 10000 *, dbo.UsersByReputation_Function(@Reputation) AS ReputationPlusOne
FROM dbo.Users
WHERE Reputation=@Reputation
ORDER BY DisplayName
OPTION (USE HINT('DISABLE_TSQL_SCALAR_UDF_INLINING'));
GO
CREATE OR ALTER FUNCTION dbo.UsersByReputation_Function (@Reputation INT)
RETURNS INT
AS
BEGIN
		RETURN	((SELECT TOP 1 Reputation FROM dbo.Users) + @Reputation + 1);
END
GO

/* Clear and populate the cache */
DBCC FREEPROCCACHE
GO
EXEC dbo.usp_UsersByReputation @Reputation = 2;
GO 5
EXEC dbo.usp_UsersByReputation_Function @Reputation = 2
GO 5

/* Before */
EXEC dbo.sp_BlitzCache 
```

![image](https://user-images.githubusercontent.com/12396330/203267879-996cc95c-c3e8-4109-b571-a2932cfd9831.png)

Then compare the output after applying the PR.

```
/* After */
EXEC dbo.sp_BlitzCache 
```

![image](https://user-images.githubusercontent.com/12396330/203267949-8283f2c0-88cd-4cc9-bffa-49ecca73a7fd.png)