### PR TITLE
Prevent lock timeout thrown by sp_msforeachdb

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2516,7 +2516,16 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                                     ;
 
 			IF SERVERPROPERTY('EngineEdition') <> 5 /*SERVERPROPERTY('Edition') <> 'SQL Azure'*/
-	            EXEC sp_MSforeachdb @StringToExecute;
+			BEGIN
+				BEGIN TRY
+					EXEC sp_MSforeachdb @StringToExecute;
+				END TRY
+				BEGIN CATCH
+					INSERT INTO #UpdatedStats(HowToStopIt, RowsForSorting)
+					SELECT HowToStopIt = N' No information could be retrieved as the lock timeout was exceeded while iterating databases,' +
+										 N'  this is likely due to an Index operation in Progress', -1;
+				END CATCH
+				END
 			ELSE
 				EXEC(@StringToExecute);
 

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2522,8 +2522,8 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 				END TRY
 				BEGIN CATCH
 					INSERT INTO #UpdatedStats(HowToStopIt, RowsForSorting)
-					SELECT HowToStopIt = N' No information could be retrieved as the lock timeout was exceeded while iterating databases,' +
-										 N'  this is likely due to an Index operation in Progress', -1;
+					SELECT HowToStopIt = N'No information could be retrieved as the lock timeout was exceeded while iterating databases,' +
+										 N' this is likely due to an Index operation in Progress', -1;
 				END CATCH
 			END
 			ELSE

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2525,7 +2525,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 					SELECT HowToStopIt = N' No information could be retrieved as the lock timeout was exceeded while iterating databases,' +
 										 N'  this is likely due to an Index operation in Progress', -1;
 				END CATCH
-				END
+			END
 			ELSE
 				EXEC(@StringToExecute);
 

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2521,9 +2521,16 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 					EXEC sp_MSforeachdb @StringToExecute;
 				END TRY
 				BEGIN CATCH
-					INSERT INTO #UpdatedStats(HowToStopIt, RowsForSorting)
-					SELECT HowToStopIt = N'No information could be retrieved as the lock timeout was exceeded while iterating databases,' +
-										 N' this is likely due to an Index operation in Progress', -1;
+					IF (ERROR_NUMBER() = 1222)
+					BEGIN
+						INSERT INTO #UpdatedStats(HowToStopIt, RowsForSorting)
+						SELECT HowToStopIt = N'No information could be retrieved as the lock timeout was exceeded while iterating databases,' +
+											 N' this is likely due to an Index operation in Progress', -1;
+					END
+					ELSE
+					BEGIN
+						THROW;
+					END
 				END CATCH
 			END
 			ELSE


### PR DESCRIPTION
**What is the current behavior?**

When setting up sp_BlitzFirst in an agent job on a few dozen SQL 2019 with AGs, I was seeing very random periodic job failures caused by lock timeouts. I traced it down to the section where you SET LOCK_TIMEOUT 0 and then look for modified statistics.

You catch the lock timeout error inside the statistics section, but it turns out that sp_msforeachdb is also susceptible to exiting with a lock timeout. By wrapping that in a further try/catch block, I'm able to prevent the job step from failing unnecessarily.

This is nicer than having the job fail randomly, or having to set the job step to exit with success on failure.

**If the current behavior is a bug, please provide the steps to reproduce.**

I couldn't force the behaviour to happen, even wrapping sp_msforeachdb in a GO 10000 loop and failing over servers everywhere. It's something else. For reference on ~20 servers and running every 15 minutes, one execution would fail every few hours.

**What is the expected behavior?**
Not throwing that error.

**Which versions of SQL Server and which OS are affected by this issue? Did this work in previous versions of our procedures?**
SQL 2019 Windows 2016. Unsure if it worked previously.
