### PR TITLE
Issue 3239: Fix dm_exec_query_profiles arithmetic overflow error in check 45

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2163,7 +2163,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                    FROM (
                          SELECT deqp.session_id,
                                 deqp.request_id,
-                                CASE WHEN deqp.row_count > ( deqp.estimate_row_count * 10000 )
+                                CASE WHEN (deqp.row_count/10000) > deqp.estimate_row_count
                                      THEN 1
                                      ELSE 0
                                 END AS estimate_inaccuracy


### PR DESCRIPTION
Check 45 looking for inaccurate query estimates was checking if the actual row count (row_count in dm_exec_query_profiles) was greater than estimate_row_count*10000. This was generating arithmetic overflow errors on queries containing estimates close to the bigint limit. Change the calculation to compare the row count/10000 to the estimate instead - same result but no overflow.