### PR TITLE
Update unsupported SQL Versions

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3879,7 +3879,7 @@ AS
 
 							IF (@ProductVersionMajor = 15 AND @ProductVersionMinor < 2000) OR
 							   (@ProductVersionMajor = 14 AND @ProductVersionMinor < 1000) OR
-							   (@ProductVersionMajor = 13 AND @ProductVersionMinor < 5026) OR
+							   (@ProductVersionMajor = 13 AND @ProductVersionMinor < 6300) OR
 							   (@ProductVersionMajor = 12 AND @ProductVersionMinor < 6024) OR
 							   (@ProductVersionMajor = 11 /*AND @ProductVersionMinor < 7001)*/ OR
 							   (@ProductVersionMajor = 10.5 /*AND @ProductVersionMinor < 6000*/) OR

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3881,7 +3881,7 @@ AS
 							   (@ProductVersionMajor = 14 AND @ProductVersionMinor < 1000) OR
 							   (@ProductVersionMajor = 13 AND @ProductVersionMinor < 5026) OR
 							   (@ProductVersionMajor = 12 AND @ProductVersionMinor < 6024) OR
-							   (@ProductVersionMajor = 11 AND @ProductVersionMinor < 7001) OR
+							   (@ProductVersionMajor = 11 /*AND @ProductVersionMinor < 7001)*/ OR
 							   (@ProductVersionMajor = 10.5 /*AND @ProductVersionMinor < 6000*/) OR
 							   (@ProductVersionMajor = 10 /*AND @ProductVersionMinor < 6000*/) OR
 							   (@ProductVersionMajor = 9 /*AND @ProductVersionMinor <= 5000*/)
@@ -3892,7 +3892,7 @@ AS
 								INSERT INTO #BlitzResults(CheckID, Priority, FindingsGroup, Finding, URL, Details)
 									VALUES(128, 20, 'Reliability', 'Unsupported Build of SQL Server', 'https://www.brentozar.com/go/unsupported',
 										'Version ' + CAST(@ProductVersionMajor AS VARCHAR(100)) + 
-										CASE WHEN @ProductVersionMajor >= 11 THEN
+										CASE WHEN @ProductVersionMajor >= 12 THEN
 										'.' + CAST(@ProductVersionMinor AS VARCHAR(100)) + ' is no longer supported by Microsoft. You need to apply a service pack.'
 										ELSE ' is no longer supported by Microsoft. You should be making plans to upgrade to a modern version of SQL Server.' END);
 								END;


### PR DESCRIPTION
- Update script so that it considers SQL 2012 as unsupported [Microsoft Product Lifecycle SQL 2012](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-sql-server-2012)
- Update script so that it considers SQL 2016 < SP3 as unsupported [Microsoft Product Lifecycle for SQL 2016](https://learn.microsoft.com/en-us/lifecycle/products/sql-server-2016)

This also incorporates the change from PR #3271 