### PR TITLE
sp_BlitzLock fixes for 3276, 3277, 3279

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -383,7 +383,7 @@ BEGIN
                         /*Add wait_resource column*/
                         ALTER TABLE ' +
                         @ObjectFullName +
-                        N' ADD client_option_1 nvarchar(8000) NULL;';
+                        N' ADD client_option_1 varchar(500) NULL;';
 
                 IF @Debug = 1 BEGIN PRINT @StringToExecute; END;
                 EXEC sys.sp_executesql
@@ -399,7 +399,7 @@ BEGIN
                         /*Add wait_resource column*/
                         ALTER TABLE ' +
                         @ObjectFullName +
-                        N' ADD client_option_2 nvarchar(8000) NULL;';
+                        N' ADD client_option_2 varchar(500) NULL;';
 
                 IF @Debug = 1 BEGIN PRINT @StringToExecute; END;
                 EXEC sys.sp_executesql
@@ -462,8 +462,8 @@ BEGIN
                                 waiter_mode nvarchar(256),
                                 lock_mode nvarchar(256),
                                 transaction_count bigint,
-                                client_option_1 varchar(2000),
-                                client_option_2 varchar(2000),
+                                client_option_1 varchar(500),
+                                client_option_2 varchar(500),
                                 login_name nvarchar(256),
                                 host_name nvarchar(256),
                                 client_app nvarchar(1024),
@@ -1024,7 +1024,7 @@ BEGIN
                     CASE WHEN q.clientoption1 & 8192 = 8192 THEN ', NUMERIC_ROUNDABORT' ELSE '' END +
                     CASE WHEN q.clientoption1 & 16384 = 16384 THEN ', XACT_ABORT' ELSE '' END,
                     3,
-                    8000
+                    500
                 ),
             client_option_2 =
                 SUBSTRING
@@ -1046,7 +1046,7 @@ BEGIN
                     CASE WHEN q.clientoption2 & 1073741824 = 1073741824 THEN ', AUTO UPDATE STATISTICS' ELSE '' END +
                     CASE WHEN q.clientoption2 & 1469283328 = 1469283328 THEN ', ALL SETTABLE OPTIONS' ELSE '' END,
                     3,
-                    8000
+                    500
                 ),
             q.process_xml
         INTO #deadlock_process

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -3538,38 +3538,40 @@ BEGIN
             DROP SYNONYM DeadlockFindings; /*done with inserting.*/
         END;
         ELSE /*Output to database is not set output to client app*/
-            SET @d = CONVERT(varchar(40), GETDATE(), 109);
-            RAISERROR('Results to client %s', 0, 1, @d) WITH NOWAIT;
-
-            IF @Debug = 1 BEGIN SET STATISTICS XML ON; END;
-
-            EXEC sys.sp_executesql
-                @deadlock_result;
-
-            IF @Debug = 1
-            BEGIN
-                SET STATISTICS XML OFF;
-                PRINT @deadlock_result;
-            END;
-
-            RAISERROR('Finished at %s', 0, 1, @d) WITH NOWAIT;
-
-            SET @d = CONVERT(varchar(40), GETDATE(), 109);
-            RAISERROR('Returning findings %s', 0, 1, @d) WITH NOWAIT;
-
-            SELECT
-                df.check_id,
-                df.database_name,
-                df.object_name,
-                df.finding_group,
-                df.finding
-            FROM #deadlock_findings AS df
-            ORDER BY df.check_id
-            OPTION(RECOMPILE);
-
-            SET @d = CONVERT(varchar(40), GETDATE(), 109);
-            RAISERROR('Finished at %s', 0, 1, @d) WITH NOWAIT;
-        END; /*done with output to client app.*/
+		BEGIN
+		    SET @d = CONVERT(varchar(40), GETDATE(), 109);
+                RAISERROR('Results to client %s', 0, 1, @d) WITH NOWAIT;
+		    
+                IF @Debug = 1 BEGIN SET STATISTICS XML ON; END;
+		    
+                EXEC sys.sp_executesql
+                    @deadlock_result;
+		    
+                IF @Debug = 1
+                BEGIN
+                    SET STATISTICS XML OFF;
+                    PRINT @deadlock_result;
+                END;
+		    
+                RAISERROR('Finished at %s', 0, 1, @d) WITH NOWAIT;
+		    
+                SET @d = CONVERT(varchar(40), GETDATE(), 109);
+                RAISERROR('Returning findings %s', 0, 1, @d) WITH NOWAIT;
+		    
+                SELECT
+                    df.check_id,
+                    df.database_name,
+                    df.object_name,
+                    df.finding_group,
+                    df.finding
+                FROM #deadlock_findings AS df
+                ORDER BY df.check_id
+                OPTION(RECOMPILE);
+		    
+                SET @d = CONVERT(varchar(40), GETDATE(), 109);
+                RAISERROR('Finished at %s', 0, 1, @d) WITH NOWAIT;
+            END; /*done with output to client app.*/
+		END;
 
         IF @Debug = 1
         BEGIN

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -1813,6 +1813,16 @@ BEGIN
                 N'S',
                 N'IS'
             )
+        OR  dow.owner_mode IN
+            (
+                N'S',
+                N'IS'
+            )
+        OR  dow.waiter_mode IN
+            (
+                N'S',
+                N'IS'
+            )
         AND (dow.database_id = @DatabaseId OR @DatabaseName IS NULL)
         AND (dow.event_date >= @StartDate OR @StartDate IS NULL)
         AND (dow.event_date < @EndDate OR @EndDate IS NULL)


### PR DESCRIPTION
Closes #3276 
Closes #3277
Closes #3279 

For #3277 
* Fixed begin/end issues

For #3277:
* Fixed (blame it on Vegas) `nvarchar(8000)` column
* Realized the max length of all concatenated values is <500 bytes
* Adjusted column and substring lengths to match

For #3279 
* Changed Azure identification method to differentiate between sqldb and mi
* Standardized xml parsing in where clauses to match (axis traversal not necessary)
* Opened up to using other xml deadlock reports
* Added debug mode plan generation in case of perf regressions for a couple queries