### PR TITLE
#3291 FIX: sp_BlitzCache fails when executed on instances with readable secondary replicas

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1579,6 +1579,7 @@ BEGIN
 	RAISERROR('Checking for Read intent databases to exclude',0,0) WITH NOWAIT;
 
     EXEC('INSERT INTO #ReadableDBs (database_id) SELECT DBs.database_id FROM sys.databases DBs INNER JOIN sys.availability_replicas Replicas ON DBs.replica_id = Replicas.replica_id WHERE replica_server_name NOT IN (SELECT DISTINCT primary_replica FROM sys.dm_hadr_availability_group_states States) AND Replicas.secondary_role_allow_connections_desc = ''READ_ONLY'' AND replica_server_name = @@SERVERNAME OPTION (RECOMPILE);');
+    EXEC('INSERT INTO #ReadableDBs VALUES (32767) ;');		-- Exclude internal resource database as well
 END
 
 RAISERROR(N'Checking plan cache age', 0, 1) WITH NOWAIT;


### PR DESCRIPTION
Work for issue [#3291](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3291).

Change: Add internal resource database "32767" in the ReadableDB list for exclusion. This ensures any query plans generated out of queries on this internal database will be taken out first before dm_exec_query_plan DMV gets called.