### PR TITLE
Issues 3305, 3306, 3307, 3311

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -3969,7 +3969,7 @@ BEGIN
             OPTION(RECOMPILE);
 
             SELECT
-                table_name = N'ava#dm_exec_query_statsilable_plans',
+                table_name = N'#dm_exec_query_stats',
                 *
             FROM #dm_exec_query_stats
 			OPTION(RECOMPILE);

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -287,7 +287,7 @@ BEGIN
             AND   dxs.create_time IS NOT NULL
         )
         BEGIN
-            RAISERROR('A session with the name %s does not exist or is not currently active.', 11, 1, @session_name) WITH NOWAIT;
+            RAISERROR('A session with the name %s does not exist or is not currently active.', 11, 1, @EventSessionName) WITH NOWAIT;
             RETURN;
         END;
     END;
@@ -305,7 +305,7 @@ BEGIN
             AND   dxs.create_time IS NOT NULL
         )
         BEGIN
-            RAISERROR('A session with the name %s does not exist or is not currently active.', 11, 1, @session_name) WITH NOWAIT;
+            RAISERROR('A session with the name %s does not exist or is not currently active.', 11, 1, @EventSessionName) WITH NOWAIT;
             RETURN;
         END;
     END;

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -856,8 +856,7 @@ BEGIN
            OR e.x.exist('@name[ .= "database_xml_deadlock_report"]') = 1
            OR e.x.exist('@name[ .= "xml_deadlock_report_filtered"]') = 1
           )
-        AND   e.x.exist('@timestamp[. >= sql:variable("@StartDate")]') = 1
-        AND   e.x.exist('@timestamp[. <  sql:variable("@EndDate")]') = 1
+        AND   e.x.exist('@timestamp[. >= sql:variable("@StartDate") and .< sql:variable("@EndDate")]') = 1
         OPTION(RECOMPILE);
 
         SET @d = CONVERT(varchar(40), GETDATE(), 109);
@@ -894,8 +893,7 @@ BEGIN
            OR e.x.exist('@name[ .= "database_xml_deadlock_report"]') = 1
            OR e.x.exist('@name[ .= "xml_deadlock_report_filtered"]') = 1
           )
-        AND   e.x.exist('@timestamp[. >= sql:variable("@StartDate")]') = 1
-        AND   e.x.exist('@timestamp[. <  sql:variable("@EndDate")]') = 1
+        AND   e.x.exist('@timestamp[. >= sql:variable("@StartDate") and .< sql:variable("@EndDate")]') = 1
         OPTION(RECOMPILE);
 
         IF @Debug = 1 BEGIN SET STATISTICS XML OFF; END;
@@ -931,8 +929,7 @@ BEGIN
         ) AS xml
         CROSS APPLY xml.deadlock_xml.nodes('/event') AS e(x)
         WHERE 1 = 1
-        AND   e.x.exist('@timestamp[. >= sql:variable("@StartDate")]') = 1
-        AND   e.x.exist('@timestamp[. <  sql:variable("@EndDate")]') = 1
+        AND   e.x.exist('@timestamp[. >= sql:variable("@StartDate") and .< sql:variable("@EndDate")]') = 1
         OPTION(RECOMPILE);
 
         INSERT

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -293,9 +293,9 @@ BEGIN
                     )
             END;
 
-	SELECT
-	    @StartDateUTC = @StartDate,
-		@EndDateUTC = @EndDate;
+    SELECT
+        @StartDateUTC = @StartDate,
+        @EndDateUTC = @EndDate;
 
     IF @Azure = 0
     BEGIN
@@ -3700,16 +3700,16 @@ BEGIN
 
                 SET @d = CONVERT(varchar(40), GETDATE(), 109);
                 RAISERROR('Getting available execution plans for deadlocks %s', 0, 1, @d) WITH NOWAIT;
-				
+               
                 SELECT DISTINCT
-				    available_plans =
-					    'available_plans',
-				    ds.proc_name,
+                    available_plans =
+                        'available_plans',
+                    ds.proc_name,
                     sql_handle =
                         CONVERT(varbinary(64), ds.sql_handle, 1),
                     dow.database_name,
-					dow.database_id,
-					dow.object_name,
+                    dow.database_id,
+                    dow.object_name,
                     query_xml =
                         TRY_CAST(dr.query_xml AS nvarchar(MAX))
                 INTO #available_plans
@@ -3823,7 +3823,7 @@ BEGIN
                     ap.statement_end_offset
                 FROM
                 (
-                
+               
                     SELECT
                         ap.*,
                         c.statement_start_offset,
@@ -3961,6 +3961,18 @@ BEGIN
                 *
             FROM @sysAssObjId AS s
             OPTION(RECOMPILE);
+
+            SELECT
+                table_name = N'#available_plans',
+                *
+            FROM #available_plans AS ap
+            OPTION(RECOMPILE);
+
+            SELECT
+                table_name = N'ava#dm_exec_query_statsilable_plans',
+                *
+            FROM #dm_exec_query_stats
+			OPTION(RECOMPILE);
 
             SELECT
                 procedure_parameters =

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -3767,11 +3767,7 @@ BEGIN
                     min_used_grant_mb =
                         deqs.min_used_grant_kb * 8. / 1024.,
                     max_used_grant_mb =
-                        deqs.max_used_grant_kb * 8. / 1024.,
-                    min_spills_mb =
-                        deqs.min_spills * 8. / 1024.,
-                    max_spills_mb =
-                        deqs.max_spills * 8. / 1024.,      
+                        deqs.max_used_grant_kb * 8. / 1024.,    
                     deqs.min_reserved_threads,
                     deqs.max_reserved_threads,
                     deqs.min_used_threads,
@@ -3817,8 +3813,6 @@ BEGIN
                     ap.max_grant_mb,
                     ap.min_used_grant_mb,
                     ap.max_used_grant_mb,
-                    ap.min_spills_mb,
-                    ap.max_spills_mb,
                     ap.min_reserved_threads,
                     ap.max_reserved_threads,
                     ap.min_used_threads,
@@ -3849,8 +3843,6 @@ BEGIN
                         c.max_grant_mb,
                         c.min_used_grant_mb,
                         c.max_used_grant_mb,
-                        c.min_spills_mb,
-                        c.max_spills_mb,
                         c.min_reserved_threads,
                         c.max_reserved_threads,
                         c.min_used_threads,


### PR DESCRIPTION
Closes #3305: Does all of the start and end date filtering to a single line
Closes #3306: Adds a check that the session name exists so you don't feel crazy if no results come back
Closes #3307: Makes event XML searches UTC-friendly for easier filtering to specific ranges
Closes #3311: Speeds up plan cache lookups of query plans for queries involved in deadlocks
 