### PR TITLE
#3314 sp_BlitzCache high percentage of duplicate plans

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1616,8 +1616,7 @@ WITH total_plans AS
         SELECT
 		    COUNT_BIG(qs.query_plan_hash) AS duplicate_plan_hashes
         FROM sys.dm_exec_query_stats qs
-        LEFT JOIN sys.dm_exec_procedure_stats ps 
-            ON qs.plan_handle = ps.plan_handle
+        LEFT JOIN sys.dm_exec_procedure_stats ps ON qs.plan_handle = ps.plan_handle
         CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) pa
         WHERE pa.attribute = N'dbid'
         AND   qs.query_plan_hash <> 0x0000000000000000

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1617,7 +1617,7 @@ WITH total_plans AS
 		    COUNT_BIG(qs.query_plan_hash) AS duplicate_plan_hashes
         FROM sys.dm_exec_query_stats qs
         LEFT JOIN sys.dm_exec_procedure_stats ps 
-            ON qs.sql_handle = ps.sql_handle
+            ON qs.plan_handle = ps.plan_handle
         CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) pa
         WHERE pa.attribute = N'dbid'
         AND   qs.query_plan_hash <> 0x0000000000000000


### PR DESCRIPTION
Fixes #3314

We had similar issue where it was showing 3 million duplicate plans and the percentage was over 2000%
We originally looked at this because sp_blitzFirst was taking over an hour to run.
Adding this change to the procedure brings the time down to under 1 minute and the duplicate plan percentage went from 2400% to 93%.

Here are our findings.

So why is the query slow on the server, and why does it return query_plan_hashes in millions? 
That’s because of the LEFT JOIN between sys.dm_exec_query_stats and sys.dm_exec_procedure_stats ON sql_handle.

The left input table in the LEFT JOIN i.e., sys.dm_exec_query_stats has thousands of duplicate sql_handles, and so does the right input sys.dm_exec_procedure_stats. Therefore, for each matching sql_handle on the left, it returns every matching row from the right. Hence, this “Cartesian product” of the join results in the output in millions. Apparently, sql_handle is not the best choice to join on as it contains duplicates in the sys.dm_exec_procedure_stats view, unlike plan_handle, which is unique in dm_exec_procedure_stats.

 The Fix? Simply replace the column to join on from sql_handle to plan_handle, and voila. The same original query with only the change to the join column ran in under 1 second compared to the 9+ minutes it ran with the sql_handle as the join column, and it returns an accurate plan_hash count too. Since all plan_handles are unique in dm_exec_procedure_stats (i.e. right side of the join), there’s only one match in the right table, thus avoiding duplicates.

When I put in the original change for this ticket, the run is still long and the duplicate plan percentage is still over 2400, so that change did not fix our problem. Maybe both changes are needed? 
Sorry if I did the change request wrong...i'm new to github.
