### PR TITLE
keep the QueryText as it is for not changing line comment context

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -6849,10 +6849,6 @@ END;
 					EXEC sys.sp_executesql @stmt = @AllSortSql, @params = N'@i_DatabaseName NVARCHAR(128), @i_Top INT, @i_SkipAnalysis BIT, @i_OutputDatabaseName NVARCHAR(258), @i_OutputSchemaName NVARCHAR(258), @i_OutputTableName NVARCHAR(258), @i_CheckDateOverride DATETIMEOFFSET, @i_MinutesBack INT ', 
                         @i_DatabaseName = @DatabaseName, @i_Top = @Top, @i_SkipAnalysis = @SkipAnalysis, @i_OutputDatabaseName = @OutputDatabaseName, @i_OutputSchemaName = @OutputSchemaName, @i_OutputTableName = @OutputTableName, @i_CheckDateOverride = @CheckDateOverride, @i_MinutesBack = @MinutesBack;
 
-/* Avoid going into OutputResultsToTable
-   ... otherwise the last result (e.g. spills) would be recorded twice into the output table.
-*/
-RETURN;
 /*End of AllSort section*/
 
 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -6849,6 +6849,10 @@ END;
 					EXEC sys.sp_executesql @stmt = @AllSortSql, @params = N'@i_DatabaseName NVARCHAR(128), @i_Top INT, @i_SkipAnalysis BIT, @i_OutputDatabaseName NVARCHAR(258), @i_OutputSchemaName NVARCHAR(258), @i_OutputTableName NVARCHAR(258), @i_CheckDateOverride DATETIMEOFFSET, @i_MinutesBack INT ', 
                         @i_DatabaseName = @DatabaseName, @i_Top = @Top, @i_SkipAnalysis = @SkipAnalysis, @i_OutputDatabaseName = @OutputDatabaseName, @i_OutputSchemaName = @OutputSchemaName, @i_OutputTableName = @OutputTableName, @i_CheckDateOverride = @CheckDateOverride, @i_MinutesBack = @MinutesBack;
 
+/* Avoid going into OutputResultsToTable
+   ... otherwise the last result (e.g. spills) would be recorded twice into the output table.
+*/
+RETURN;
 /*End of AllSort section*/
 
 


### PR DESCRIPTION
this also includes changes to move the if block for @ExportToExcel = 1 to a later stage and do this for all rows at once. I accidentally included also a fix for a copy and paste error (and not opened an issue of it's own) where avg spills data got the update for the Pattern = ''avg memory grant''.