### PR TITLE
Update sp_BlitzCache.sql for double-spill fix

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -6955,6 +6955,11 @@ END;
 					EXEC sys.sp_executesql @stmt = @AllSortSql, @params = N'@i_DatabaseName NVARCHAR(128), @i_Top INT, @i_SkipAnalysis BIT, @i_OutputDatabaseName NVARCHAR(258), @i_OutputSchemaName NVARCHAR(258), @i_OutputTableName NVARCHAR(258), @i_CheckDateOverride DATETIMEOFFSET, @i_MinutesBack INT ', 
                         @i_DatabaseName = @DatabaseName, @i_Top = @Top, @i_SkipAnalysis = @SkipAnalysis, @i_OutputDatabaseName = @OutputDatabaseName, @i_OutputSchemaName = @OutputSchemaName, @i_OutputTableName = @OutputTableName, @i_CheckDateOverride = @CheckDateOverride, @i_MinutesBack = @MinutesBack;
 
+/* Avoid going into OutputResultsToTable
+   ... otherwise the last result (e.g. spills) would be recorded twice into the output table.
+*/
+RETURN;
+
 /*End of AllSort section*/
 
 


### PR DESCRIPTION
For issue #3331.
After iterating over all sort sub procedure calls ... avoid going to OutputResultsToTable ... otherwise the last result (e.g. spills) would be recorded twice into the output table.