### PR TITLE
Issue #3334: sp_Blitz Fails because of permissions

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -306,32 +306,35 @@ AS
             BEGIN
                 SET @SkipValidateLogins = 1;
             END; /*Need execute on sp_validatelogins*/
-
-			IF EXISTS
-            (
-                SELECT 1/0
-                FROM @db_perms
-                WHERE database_name = N'model'
-            )
-            BEGIN
-                BEGIN TRY
-                    IF EXISTS
-                    (
-                        SELECT 1/0
-                        FROM model.sys.objects
-                    )
-                    BEGIN
-                        SET @SkipModel = 0; /*We have read permissions in the model database, and can view the objects*/
-                    END;
-                END TRY
-                BEGIN CATCH
-                    SET @SkipModel = 1; /*We have read permissions in the model database ... oh wait we got tricked, we can't view the objects*/
-                END CATCH;
-            END;
-            ELSE
-            BEGIN
-                SET @SkipModel = 1; /*We don't have read permissions in the model database*/
-            END;
+            
+			IF ISNULL(@SkipModel, 0) != 1 /* If @SkipModel hasn't been set to 1 by the caller */
+			BEGIN
+				IF EXISTS
+            	(
+            	    SELECT 1/0
+            	    FROM @db_perms
+            	    WHERE database_name = N'model'
+            	)
+            	BEGIN
+            	    BEGIN TRY
+            	        IF EXISTS
+            	        (
+            	            SELECT 1/0
+            	            FROM model.sys.objects
+            	        )
+            	        BEGIN
+                            SET @SkipModel = 0; /*We have read permissions in the model database, and can view the objects*/
+            	        END;
+            	    END TRY
+            	    BEGIN CATCH
+            	        SET @SkipModel = 1; /*We have read permissions in the model database ... oh wait we got tricked, we can't view the objects*/
+            	    END CATCH;
+            	END;
+            	ELSE
+            	BEGIN
+            	    SET @SkipModel = 1; /*We don't have read permissions in the model database*/
+            	END;
+			END;
 		END;
 
 		SET @crlf = NCHAR(13) + NCHAR(10);

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -196,10 +196,9 @@ AS
 			,@SkipXPCMDShell bit = 0
 			,@SkipMaster bit = 0
 			,@SkipMSDB bit = 0
-			,@SkipModel bit = 0
+			,@SkipModel BIT = 0
 			,@SkipTempDB bit = 0
-			,@SkipValidateLogins bit = 0
-            ,@SkipModelCheck BIT = 0;
+			,@SkipValidateLogins bit = 0;
 
 			DECLARE
 			    @db_perms table
@@ -322,16 +321,16 @@ AS
                         FROM model.sys.objects
                     )
                     BEGIN
-                        SET @SkipModelCheck = 0; /*We have read permissions in the model database, and can view the objects*/
+                        SET @SkipModel = 0; /*We have read permissions in the model database, and can view the objects*/
                     END;
                 END TRY
                 BEGIN CATCH
-                    SET @SkipModelCheck = 1; /*We have read permissions in the model database ... oh wait we got tricked, we can't view the objects*/
+                    SET @SkipModel = 1; /*We have read permissions in the model database ... oh wait we got tricked, we can't view the objects*/
                 END CATCH;
             END;
             ELSE
             BEGIN
-                SET @SkipModelCheck = 1; /*We don't have read permissions in the model database*/
+                SET @SkipModel = 1; /*We don't have read permissions in the model database*/
             END;
 		END;
 
@@ -497,7 +496,7 @@ AS
         SELECT
             v.*
         FROM (VALUES(NULL, 29, NULL)) AS v (DatabaseName, CheckID, ServerName) /*Looks for user tables in model*/
-        WHERE @SkipModelCheck = 1;
+        WHERE @SkipModel = 1;
 
 		INSERT #SkipChecks (DatabaseName, CheckID, ServerName)
 		SELECT

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -196,7 +196,7 @@ AS
 			,@SkipXPCMDShell bit = 0
 			,@SkipMaster bit = 0
 			,@SkipMSDB bit = 0
-			,@SkipModel BIT = 0
+			,@SkipModel bit = 0
 			,@SkipTempDB bit = 0
 			,@SkipValidateLogins bit = 0;
 
@@ -307,7 +307,7 @@ AS
                 SET @SkipValidateLogins = 1;
             END; /*Need execute on sp_validatelogins*/
             
-			IF ISNULL(@SkipModel, 0) != 1 /* If @SkipModel hasn't been set to 1 by the caller */
+			IF ISNULL(@SkipModel, 0) != 1 /*If @SkipModel hasn't been set to 1 by the caller*/
 			BEGIN
 				IF EXISTS
             	(


### PR DESCRIPTION
Brent's comment from pull request #3335 
> @SkipModel is already a parameter for sp_Blitz, so this feels confusing.
> 
> We'd definitely welcome a pull request that lines up with your original issue notes, though:

My apologies I hadn't noticed the `@SkipModel` parameter.

Changed the code to use the `@SkipModel`  parameter and to the respect the `@SkipModel` value if the caller has set it to 1 by hand, as the old version of the code could override the passed value if we could access the objects in the model database. 
The rest stayed pretty much the same so in the permissions check we still check if we can access the model database and the objects within it.

If `@SkipModel = 1` check 29 will be added to the #SkipChecks table.

Fix for issue #3334 