### PR TITLE
#3350 DBCC DBinfo fires incorrectly

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1109,17 +1109,17 @@ AS
 				least one of the relevant checks is not being skipped then we can extract the
 				dbinfo information.
 				*/
-				IF NOT EXISTS ( SELECT 1 
-							FROM #BlitzResults 
-							WHERE CheckID = 223 AND URL = 'https://aws.amazon.com/rds/sqlserver/')
-					AND (
-							NOT EXISTS ( SELECT  1
-								FROM    #SkipChecks
-								WHERE   DatabaseName IS NULL AND CheckID = 2 )
-							OR NOT EXISTS ( SELECT  1
-								FROM    #SkipChecks
-								WHERE   DatabaseName IS NULL AND CheckID = 68 )
-					)
+				IF NOT EXISTS
+				(
+					SELECT	1/0 
+					FROM	#BlitzResults 
+					WHERE	CheckID = 223 AND URL = 'https://aws.amazon.com/rds/sqlserver/'
+				) AND NOT EXISTS
+				(
+					SELECT  1/0
+					FROM    #SkipChecks
+					WHERE   DatabaseName IS NULL AND CheckID IN (2, 68)
+				)
 					BEGIN
 
 						IF @Debug IN (1, 2) RAISERROR('Extracting DBCC DBINFO data (used in checks 2 and 68).', 0, 1, 68) WITH NOWAIT;


### PR DESCRIPTION
Fix for issue #3350

The old code had an logical error in it:
```
Check 233 is not in #BlitzResults
Check 2 is not in #SkipChecks
Check 68 is in #SkipChecks

It became:
IF True (Check 233 not in #BlitzResults)
AND
(
    True (Check 2 not in #SkipChecks)
    OR
    False (Check 68 in #SkipChecks)
)
```
So the IF returned true and the check fired.
Basically the OR needed to be an AND, this allowed the code to be simplified to:

```tsql
IF NOT EXISTS
(
	SELECT	1/0 
	FROM	#BlitzResults 
	WHERE	CheckID = 223 AND URL = 'https://aws.amazon.com/rds/sqlserver/'
) AND NOT EXISTS
(
	SELECT  1/0
	FROM    #SkipChecks
	WHERE   DatabaseName IS NULL AND CheckID IN (2, 68)
)
```

Easier to read as well.