### PR TITLE
#3370 Division by zero in check 20

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -3364,8 +3364,8 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
             'Server Info' AS FindingGroup,
             'Wait Time per Core per Sec' AS Finding,
             'https://www.brentozar.com/go/measure' AS URL,
-            CAST((CAST(waits2.waits_ms - waits1.waits_ms AS MONEY)) / 1000 / i.cpu_count / DATEDIFF(ss, waits1.SampleTime, waits2.SampleTime) AS NVARCHAR(20)) AS Details,
-            (waits2.waits_ms - waits1.waits_ms) / 1000 / i.cpu_count / DATEDIFF(ss, waits1.SampleTime, waits2.SampleTime) AS DetailsInt
+            CAST((CAST(waits2.waits_ms - waits1.waits_ms AS MONEY)) / 1000 / i.cpu_count / ISNULL(NULLIF(DATEDIFF(ss, waits1.SampleTime, waits2.SampleTime), 0), 1) AS NVARCHAR(20)) AS Details,
+            (waits2.waits_ms - waits1.waits_ms) / 1000 / i.cpu_count / ISNULL(NULLIF(DATEDIFF(ss, waits1.SampleTime, waits2.SampleTime), 0), 1) AS DetailsInt
         FROM cores i
           CROSS JOIN waits1
           CROSS JOIN waits2;


### PR DESCRIPTION
Fix for #3370: Division by zero bug if pass 1 and 2 are to close to each other

In check 20 updated the DATEDIFF code with a small piece of code to replace the 0 (zero) with a 1
```tsql
ISNULL(NULLIF( ..., 0), 1)
```
Basically this will NULL the DATEDIFF result if this is a 0 (zero) and then set it to 1 if it is `NULL`

This leaves the function of this piece of code as it was in all other cases other than the scenario reported in issue #3370 
