### PR TITLE
#3406 Fixed the Substring command to respect the command syntax

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -7338,16 +7338,16 @@ END ';
                     
                     IF @Debug = 1
                     BEGIN
-                        PRINT SUBSTRING(@StringToExecute, 0, 4000);
-                        PRINT SUBSTRING(@StringToExecute, 4000, 8000);
-                        PRINT SUBSTRING(@StringToExecute, 8000, 12000);
-                        PRINT SUBSTRING(@StringToExecute, 12000, 16000);
-                        PRINT SUBSTRING(@StringToExecute, 16000, 20000);
-                        PRINT SUBSTRING(@StringToExecute, 20000, 24000);
-                        PRINT SUBSTRING(@StringToExecute, 24000, 28000);
-                        PRINT SUBSTRING(@StringToExecute, 28000, 32000);
-                        PRINT SUBSTRING(@StringToExecute, 32000, 36000);
-                        PRINT SUBSTRING(@StringToExecute, 36000, 40000);
+                        PRINT SUBSTRING(@StringToExecute,     1, 4000);
+                        PRINT SUBSTRING(@StringToExecute,  4001, 4000);
+                        PRINT SUBSTRING(@StringToExecute,  8001, 4000);
+                        PRINT SUBSTRING(@StringToExecute, 12001, 4000);
+                        PRINT SUBSTRING(@StringToExecute, 16001, 4000);
+                        PRINT SUBSTRING(@StringToExecute, 20001, 4000);
+                        PRINT SUBSTRING(@StringToExecute, 24001, 4000);
+                        PRINT SUBSTRING(@StringToExecute, 28001, 4000);
+                        PRINT SUBSTRING(@StringToExecute, 32001, 4000);
+                        PRINT SUBSTRING(@StringToExecute, 36001, 4000);
                     END;
 
                     EXEC sp_executesql @StringToExecute, N'@Top INT, @min_duration INT, @min_back INT, @CheckDateOverride DATETIMEOFFSET, @MinimumExecutionCount INT', @Top, @DurationFilter_i, @MinutesBack, @CheckDateOverride, @MinimumExecutionCount;

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1214,16 +1214,16 @@ BEGIN TRY
         RAISERROR (N'Inserting data into #IndexColumns for clustered indexes and heaps',0,1) WITH NOWAIT;
         IF @Debug = 1
             BEGIN
-                PRINT SUBSTRING(@dsql, 0, 4000);
-                PRINT SUBSTRING(@dsql, 4000, 8000);
-                PRINT SUBSTRING(@dsql, 8000, 12000);
-                PRINT SUBSTRING(@dsql, 12000, 16000);
-                PRINT SUBSTRING(@dsql, 16000, 20000);
-                PRINT SUBSTRING(@dsql, 20000, 24000);
-                PRINT SUBSTRING(@dsql, 24000, 28000);
-                PRINT SUBSTRING(@dsql, 28000, 32000);
-                PRINT SUBSTRING(@dsql, 32000, 36000);
-                PRINT SUBSTRING(@dsql, 36000, 40000);
+                PRINT SUBSTRING(@dsql,     1, 4000);
+                PRINT SUBSTRING(@dsql,  4001, 4000);
+                PRINT SUBSTRING(@dsql,  8001, 4000);
+                PRINT SUBSTRING(@dsql, 12001, 4000);
+                PRINT SUBSTRING(@dsql, 16001, 4000);
+                PRINT SUBSTRING(@dsql, 20001, 4000);
+                PRINT SUBSTRING(@dsql, 24001, 4000);
+                PRINT SUBSTRING(@dsql, 28001, 4000);
+                PRINT SUBSTRING(@dsql, 32001, 4000);
+                PRINT SUBSTRING(@dsql, 36001, 4000);
             END;
 		BEGIN TRY
 			INSERT    #IndexColumns ( database_id, [schema_name], [object_id], index_id, key_ordinal, is_included_column, is_descending_key, partition_ordinal,


### PR DESCRIPTION
Closes #3406 I updated the syntax of the debug SUBSTRING in sp_BlitzCache and sp_BlitzIndex to respect the syntax of the `SUBSTRING ( expression, start, length )` command.