### PR TITLE
sp_BlitzIndex bug: Extra junk output from columnstore visualisation

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2991,7 +2991,7 @@ BEGIN
 						INNER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.columns c ON rg.object_id = c.object_id
 						INNER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.partitions p ON rg.object_id = p.object_id AND rg.partition_number = p.partition_number
 						INNER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.index_columns ic on ic.column_id = c.column_id AND ic.object_id = c.object_id AND ic.index_id = p.index_id 
-                        LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.dm_db_column_store_row_group_physical_stats phys ON rg.row_group_id = phys.row_group_id AND rg.object_id = phys.object_id AND rg.partition_number = phys.partition_number AND p.index_id = phys.index_id ' + CASE WHEN @ShowPartitionRanges = 1 THEN N' 
+                        LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.dm_db_column_store_row_group_physical_stats phys ON rg.row_group_id = phys.row_group_id AND rg.object_id = phys.object_id AND rg.partition_number = phys.partition_number AND rg.index_id = phys.index_id ' + CASE WHEN @ShowPartitionRanges = 1 THEN N' 
 						LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.indexes i ON i.object_id = rg.object_id AND i.index_id = rg.index_id
 						LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
 						LEFT OUTER JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.partition_functions pf ON pf.function_id = ps.function_id


### PR DESCRIPTION
This PR aims to remove extra junk output for the specific case of a columnstore index existing on a partitioned table with at least one other rowstore index.

Output prior to fix on latest version (8.18):
![image](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/assets/99744523/155b2451-f035-4a3f-b73e-0d594a273fb6)

Output after fix applied:
![image](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/assets/99744523/00b573cd-5bde-4398-a279-229e6e55644e)

I have tested this solution on SQL Server 2022 Developer Edition RTM, Azure SQL DB (as of 27/12/2023) and Azure SQL Managed Instance (CU9) and it has corrected it with no issues.

Test script used:
````
CREATE PARTITION FUNCTION TestBlitzIndexPF (CHAR(1))
AS RANGE RIGHT FOR VALUES ('A', 'B')
GO

CREATE PARTITION SCHEME TestBlitzIndexPS
AS PARTITION TestBlitzIndexPF
ALL TO ([Primary])
GO

CREATE TABLE TestBlitzIndex (
	ID INT IDENTITY(1, 1) NOT NULL,
	PartitionColumn CHAR(1) NOT NULL,
	SomeColumn NVARCHAR(100),
	CONSTRAINT [PK_TestBlitzIndex] PRIMARY KEY CLUSTERED (PartitionColumn, ID)
) ON TestBlitzIndexPS (PartitionColumn)
GO

CREATE NONCLUSTERED COLUMNSTORE INDEX [NCI_TestBlitzIndex] ON TestBlitzIndex (SomeColumn)
GO

INSERT INTO TestBlitzIndex (PartitionColumn, SomeColumn) VALUES ('A', N'')
INSERT INTO TestBlitzIndex (PartitionColumn, SomeColumn) VALUES ('B', N'')
GO

ALTER INDEX NCI_TestBlitzIndex ON TestBlitzIndex REBUILD
GO

EXEC sp_BlitzIndex @TableName = 'TestBlitzIndex', @ShowColumnstoreOnly = 1
GO

DROP TABLE TestBlitzIndex
DROP PARTITION SCHEME TestBlitzIndexPS
DROP PARTITION FUNCTION TestBlitzIndexPF
GO
````