### PR TITLE
(build) Add Matrices for SQL Server Version and Collation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
         matrix:
             SQL_ENGINE_VERSION: [2017,2019]
+            COLLATION: [SQL_Latin1_General_CP1_CS_AS]
         
 
     steps:
@@ -30,7 +31,7 @@ jobs:
           with:
             install: sqlengine
             version: ${{ matrix.SQL_ENGINE_VERSION }}
-            collation: SQL_Latin1_General_CP1_CS_AS
+            collation: ${{ matrix.COLLATION }}
 
         - name: Check SQL Install
           run: | 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            SQL_ENGINE_VERSION: [2017,2019]
+        
 
     steps:
         - name: Checkout repository
@@ -25,7 +29,7 @@ jobs:
           uses: potatoqualitee/mssqlsuite@v1.7
           with:
             install: sqlengine
-            version: 2017
+            version: ${{ matrix.SQL_ENGINE_VERSION }}
             collation: SQL_Latin1_General_CP1_CS_AS
 
         - name: Check SQL Install

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            SQL_ENGINE_VERSION: [2017,2019]
+            SQL_ENGINE_VERSION: [2017,2019,2022]
             COLLATION: [SQL_Latin1_General_CP1_CS_AS]
         
 


### PR DESCRIPTION
Supports #3418.

Saw the blog post, figured I'd try to help a little. :)

This should allow you to specify multiple versions and collations and have them all run as part of a build.

We're not demonstrating this here, but you can also specify specific pairs of values rather than all combinations, if that makes more sense. Happy to adapt according to your needs.