### PR TITLE
Update README.md - Fixed internal link for sp_BlitzQueryStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Navigation
  - Performance Tuning:   
    - [sp_BlitzInMemoryOLTP: Hekaton Analysis](#sp_blitzinmemoryoltp-hekaton-analysis) 
    - [sp_BlitzLock: Deadlock Analysis](#sp_blitzlock-deadlock-analysis) 
-   - [sp_BlitzQueryStore: Like BlitzCache, for Query Store](#sp_blitzquerystore-query-store-sale)
+   - [sp_BlitzQueryStore: Like BlitzCache, for Query Store](#sp_blitzquerystore-how-has-a-query-plan-changed-over-time)  
    - [sp_BlitzWho: What Queries are Running Now](#sp_blitzwho-what-queries-are-running-now)   
    - [sp_BlitzAnalysis: Query sp_BlitzFirst output tables](#sp_blitzanalysis-query-sp_BlitzFirst-output-tables) 
  - Backups and Restores:


### PR DESCRIPTION
The hyperlink for the table of contents for `sp_BlitzQueryStore` appears broken. This fixes it.

It may also be the case that the "Like BlitzCache, for Query Store" tagline needs changing, but I'm not sure if that or the section heading of "How Has a Query Plan Changed Over Time" should be used. My opinion is that the second of the two should be used. I find that `sp_BlitzQueryStore` will return the same query on multiple rows even if it only has one plan (and throw a "Multiple Plans" warning at the same time), whereas `sp_BlitzCache` never does. The "How Has a Query Plan Changed Over Time" heading is more faithful to this (because the extra rows are for different time intervals), but the very first line of the docs for `sp_BlitzQueryStore` advertises it as similar to `sp_BlitzCache` so I'm not sure which job `sp_BlitzQueryStore` is actually intended to do. See issue #3440 .