### PR TITLE
Added checks 92 and 224 to skipped checks for Azure SQL MI

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -878,6 +878,8 @@ AS
 						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'model');  /* Max file size set */
 						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'msdb');  /* Max file size set */
 						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'tempdb');  /* Max file size set */
+						INSERT INTO #SkipChecks (CheckID) VALUES (224); /* CheckID 224 - Performance - SSRS/SSAS/SSIS Installed */
+						INSERT INTO #SkipChecks (CheckID) VALUES (92); /* CheckID 92 - drive space */
 			            INSERT  INTO #BlitzResults
 			            ( CheckID ,
 				            Priority ,


### PR DESCRIPTION
Hi Brent,

On Azure SQL Managed Instance the following checks should be skipped:
 - 92 - drive info/space usage 
 - 224 - SSRS/SSAS/SSIS Installed

The errors they throw on MI:
- 92 
    ```
    Running CheckId [92].
    Msg 8115, Level 16, State 8, Line 1
    Arithmetic overflow error converting numeric to data type numeric.
    The statement has been terminated.
    ```
- 224 
    ```
    Running CheckId [224].
    Msg 40514, Level 16, State 45, Procedure xp_cmdshell, Line 1 [Batch Start Line 0]
    'xp_cmdshell' is not supported in this version of SQL Server.
    ```
    
   