### PR TITLE
Document the @Version parameters in sp_BlitzCache's and sp_BlitzQueryStore's @Help = 1 output

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -468,7 +468,22 @@ IF @Help = 1
 	UNION ALL
 	SELECT N'@MinutesBack',
 			N'INT',
-			N'How many minutes back to begin plan cache analysis. If you put in a positive number, we''ll flip it to negative.';
+			N'How many minutes back to begin plan cache analysis. If you put in a positive number, we''ll flip it to negative.'
+
+	UNION ALL
+	SELECT N'@Version',
+			N'VARCHAR(30)',
+			N'OUTPUT parameter holding version number'
+	
+	UNION ALL
+	SELECT N'@VersionDate',
+			N'DATETIME',
+			N'OUTPUT parameter holding version date.'
+
+	UNION ALL
+	SELECT N'@VersionCheckMode',
+			N'BIT',
+			N'Setting this to 1 will make the procedure stop after setting @Version and @VersionDate.';
 
 
 	/* Column definitions */

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -473,7 +473,7 @@ IF @Help = 1
 	UNION ALL
 	SELECT N'@Version',
 			N'VARCHAR(30)',
-			N'OUTPUT parameter holding version number'
+			N'OUTPUT parameter holding version number.'
 	
 	UNION ALL
 	SELECT N'@VersionDate',

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -243,6 +243,16 @@ IF @Help = 1
 			N'0',
 			N'When set to 1, more checks are done. Examples: many to many merge joins, row goals, adaptive joins, stats info, bad scans and plan forcing, computed columns that reference scalar UDFs.'
 	UNION ALL
+	SELECT N'@Version',
+			N'VARCHAR(30)',
+			N'NULL',
+			N'OUTPUT parameter holding version number.'
+	UNION ALL
+	SELECT N'@VersionDate',
+			N'DATETIME',
+			N'NULL',
+			N'OUTPUT parameter holding version date.'
+	UNION ALL
 	SELECT N'@VersionCheckMode',
 			N'BIT',
 			N'0',


### PR DESCRIPTION
While working on `sp_BlitzQueryStore`, I noticed that this was missing in `sp_BlitzCache`.