### PR TITLE
sp_BlitzQueryStore style, comments, and typo edits 

### DIFF
--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -3701,7 +3701,7 @@ OR (@major_version = 13
 
 BEGIN
 
-RAISERROR(N'Beginning 2017 and 2016 SP2 specfic checks', 0, 1) WITH NOWAIT;
+RAISERROR(N'Beginning 2017 and 2016 SP2 specific checks', 0, 1) WITH NOWAIT;
 
 IF @ExpertMode > 0
 BEGIN

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -5670,13 +5670,13 @@ BEGIN
                    gi.total_max_log_bytes_mb, 
                    gi.total_max_tempdb_space,
 				   CONVERT(NVARCHAR(20), gi.flat_date) AS worst_date,
-				   CASE WHEN DATEPART(HOUR, gi.start_range) = 0 THEN ' midnight '
-						WHEN DATEPART(HOUR, gi.start_range) <= 12 THEN CONVERT(NVARCHAR(3), DATEPART(HOUR, gi.start_range)) + 'am '
-						WHEN DATEPART(HOUR, gi.start_range) > 12 THEN CONVERT(NVARCHAR(3), DATEPART(HOUR, gi.start_range) -12) + 'pm '
+				   CASE WHEN DATEPART(HOUR, gi.start_range) = 0 THEN 'midnight'
+						WHEN DATEPART(HOUR, gi.start_range) <= 12 THEN CONVERT(NVARCHAR(3), DATEPART(HOUR, gi.start_range)) + 'am'
+						WHEN DATEPART(HOUR, gi.start_range) > 12 THEN CONVERT(NVARCHAR(3), DATEPART(HOUR, gi.start_range) -12) + 'pm'
 						END AS worst_start_time,
-				   CASE WHEN DATEPART(HOUR, gi.end_range) = 0 THEN ' midnight '
-						WHEN DATEPART(HOUR, gi.end_range) <= 12 THEN CONVERT(NVARCHAR(3), DATEPART(HOUR, gi.end_range)) + 'am '
-						WHEN DATEPART(HOUR, gi.end_range) > 12 THEN CONVERT(NVARCHAR(3),  DATEPART(HOUR, gi.end_range) -12) + 'pm '
+				   CASE WHEN DATEPART(HOUR, gi.end_range) = 0 THEN 'midnight'
+						WHEN DATEPART(HOUR, gi.end_range) <= 12 THEN CONVERT(NVARCHAR(3), DATEPART(HOUR, gi.end_range)) + 'am'
+						WHEN DATEPART(HOUR, gi.end_range) > 12 THEN CONVERT(NVARCHAR(3),  DATEPART(HOUR, gi.end_range) -12) + 'pm'
 						END AS worst_end_time
 			FROM   #grouped_interval AS gi
 			), /*Averages*/

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -538,7 +538,7 @@ SELECT @compatibility_level = d.compatibility_level
 FROM sys.databases AS d
 WHERE d.name = @DatabaseName;
 
-RAISERROR('The @DatabaseName you specified ([%s])is running in compatibility level ([%d]).', 0, 1, @DatabaseName, @compatibility_level) WITH NOWAIT;
+RAISERROR('The @DatabaseName you specified ([%s]) is running in compatibility level ([%d]).', 0, 1, @DatabaseName, @compatibility_level) WITH NOWAIT;
 
 
 /*Making sure top is set to something if NULL*/

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -3045,7 +3045,7 @@ ON ww.plan_id = wm.plan_id
    AND wm.count_compiles > (wm.count_executions * 2)
 OPTION (RECOMPILE);
 
-/*Plans that compile 2x more than they execute*/
+/*Plans that take more than 5 seconds to bind, compile, or optimize*/
 
 RAISERROR(N'Checking for plans that take more than 5 seconds to bind, compile, or optimize', 0, 1) WITH NOWAIT;
 

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -5228,7 +5228,7 @@ BEGIN
                     'Compute Scalar That References A CLR Function',
                     'This could be trouble if your CLR functions perform data access',
                     'https://www.brentozar.com/blitzcache/compute-scalar-functions/',
-                    'May force queries to run serially, run at least once per row, and may result in poor cardinlity estimates.') ;
+                    'May force queries to run serially, run at least once per row, and may result in poor cardinality estimates.') ;
 
 
         IF EXISTS (SELECT 1/0

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -1551,7 +1551,7 @@ RAISERROR(N'Gathering longest duration plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH duration_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1598,7 +1598,7 @@ EXEC sys.sp_executesql  @stmt = @sql_select,
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH duration_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1649,7 +1649,7 @@ RAISERROR(N'Gathering highest cpu plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH cpu_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1696,7 +1696,7 @@ EXEC sys.sp_executesql  @stmt = @sql_select,
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH cpu_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1747,7 +1747,7 @@ RAISERROR(N'Gathering highest logical read plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH logical_reads_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1794,7 +1794,7 @@ EXEC sys.sp_executesql  @stmt = @sql_select,
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH logical_reads_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1845,7 +1845,7 @@ RAISERROR(N'Gathering highest physical read plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH physical_read_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1892,7 +1892,7 @@ EXEC sys.sp_executesql  @stmt = @sql_select,
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH physical_read_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1943,7 +1943,7 @@ RAISERROR(N'Gathering highest write plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH logical_writes_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -1990,7 +1990,7 @@ EXEC sys.sp_executesql  @stmt = @sql_select,
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH logical_writes_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2041,7 +2041,7 @@ RAISERROR(N'Gathering highest memory use plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH memory_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2087,7 +2087,7 @@ EXEC sys.sp_executesql  @stmt = @sql_select,
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH memory_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2138,7 +2138,7 @@ RAISERROR(N'Gathering highest row count plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH rowcount_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2194,7 +2194,7 @@ RAISERROR(N'Gathering highest log byte use plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH rowcount_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2242,7 +2242,7 @@ RAISERROR(N'Gathering highest log byte use plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH rowcount_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2293,7 +2293,7 @@ RAISERROR(N'Gathering highest tempdb use plans', 0, 1) WITH NOWAIT;
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH rowcount_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2339,7 +2339,7 @@ EXEC sys.sp_executesql  @stmt = @sql_select,
 SET @sql_select = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
 SET @sql_select += N'
 WITH rowcount_max
-AS ( SELECT   TOP 1 
+AS ( SELECT   TOP (1) 
               gi.start_range,
               gi.end_range
      FROM     #grouped_interval AS gi
@@ -2781,7 +2781,7 @@ IF @waitstats = 1
 		FROM #working_plan_text AS wpt
 		JOIN (
 			SELECT wws.plan_id,
-				   top_three_waits = STUFF((SELECT TOP 3 N', ' + wws2.wait_category_desc + N' (' + CONVERT(NVARCHAR(20), SUM(CONVERT(BIGINT, wws2.avg_query_wait_time_ms))) + N' ms) '
+				   top_three_waits = STUFF((SELECT TOP (3) N', ' + wws2.wait_category_desc + N' (' + CONVERT(NVARCHAR(20), SUM(CONVERT(BIGINT, wws2.avg_query_wait_time_ms))) + N' ms) '
 												FROM #working_wait_stats AS wws2
 												WHERE wws.plan_id = wws2.plan_id
 												GROUP BY wws2.wait_category_desc
@@ -5644,7 +5644,7 @@ BEGIN
                     'Global Trace Flags Enabled',
                     'You have Global Trace Flags enabled on your server',
                     'https://www.brentozar.com/blitz/trace-flags-enabled-globally/',
-                    'You have the following Global Trace Flags enabled: ' + (SELECT TOP 1 tf.global_trace_flags FROM #trace_flags AS tf WHERE tf.global_trace_flags IS NOT NULL)) ;
+                    'You have the following Global Trace Flags enabled: ' + (SELECT TOP (1) tf.global_trace_flags FROM #trace_flags AS tf WHERE tf.global_trace_flags IS NOT NULL)) ;
 
 
 			/*Return worsts*/
@@ -5681,87 +5681,87 @@ BEGIN
 			FROM   #grouped_interval AS gi
 			), /*Averages*/
 				duration_worst AS (
-			SELECT TOP 1 'Your worst avg duration range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg duration range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_duration_ms DESC
 				), 
 				cpu_worst AS (
-			SELECT TOP 1 'Your worst avg cpu range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg cpu range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_cpu_time_ms DESC
 				), 
 				logical_reads_worst AS (
-			SELECT TOP 1 'Your worst avg logical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg logical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_logical_io_reads_mb DESC
 				), 
 				physical_reads_worst AS (
-			SELECT TOP 1 'Your worst avg physical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg physical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_physical_io_reads_mb DESC
 				), 
 				logical_writes_worst AS (
-			SELECT TOP 1 'Your worst avg logical write range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg logical write range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_logical_io_writes_mb DESC
 				), 
 				memory_worst AS (
-			SELECT TOP 1 'Your worst avg memory range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg memory range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_query_max_used_memory_mb DESC
 				), 
 				rowcount_worst AS (
-			SELECT TOP 1 'Your worst avg row count range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg row count range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_rowcount DESC
 				), 
 				logbytes_worst AS (
-			SELECT TOP 1 'Your worst avg log bytes range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg log bytes range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_log_bytes_mb DESC
 				), 
 				tempdb_worst AS (
-			SELECT TOP 1 'Your worst avg tempdb range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst avg tempdb range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_tempdb_space DESC
 				)/*Maxes*/, 
 				max_duration_worst AS (
-			SELECT TOP 1 'Your worst max duration range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max duration range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_duration_ms DESC
 				), 
 				max_cpu_worst AS (
-			SELECT TOP 1 'Your worst max cpu range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max cpu range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_cpu_time_ms DESC
 				), 
 				max_logical_reads_worst AS (
-			SELECT TOP 1 'Your worst max logical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max logical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_logical_io_reads_mb DESC
 				), 
 				max_physical_reads_worst AS (
-			SELECT TOP 1 'Your worst max physical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max physical read range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_physical_io_reads_mb DESC
 				), 
 				max_logical_writes_worst AS (
-			SELECT TOP 1 'Your worst max logical write range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max logical write range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_logical_io_writes_mb DESC
 				), 
 				max_memory_worst AS (
-			SELECT TOP 1 'Your worst max memory range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max memory range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_query_max_used_memory_mb DESC
 				), 
 				max_logbytes_worst AS (
-			SELECT TOP 1 'Your worst max log bytes range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max log bytes range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_log_bytes_mb DESC
 				), 
 				max_tempdb_worst AS (
-			SELECT TOP 1 'Your worst max tempdb range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
+			SELECT TOP (1) 'Your worst max tempdb range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_max_tempdb_space DESC
 				)

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -625,7 +625,7 @@ RAISERROR(@msg, 0, 1) WITH NOWAIT;
 /*These are the temp tables we use*/
 
 
-/*This one holds the grouped data that helps use figure out which periods to examine*/
+/*This one holds the grouped data that helps us figure out which periods to examine*/
 
 RAISERROR(N'Creating temp tables', 0, 1) WITH NOWAIT;
 

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -4901,7 +4901,7 @@ BEGIN
                     'Cursors',
                     'Dynamic Cursors',
                     'https://www.brentozar.com/blitzcache/cursors-found-slow-queries/',
-                    'Dynamic Cursors inhibit parallelism!.');
+                    'Dynamic Cursors inhibit parallelism!');
 
 		IF EXISTS (SELECT 1/0
                    FROM   #working_warnings
@@ -4914,7 +4914,7 @@ BEGIN
                     'Cursors',
                     'Fast Forward Cursors',
                     'https://www.brentozar.com/blitzcache/cursors-found-slow-queries/',
-                    'Fast forward cursors inhibit parallelism!.');
+                    'Fast forward cursors inhibit parallelism!');
 					
         IF EXISTS (SELECT 1/0
                    FROM   #working_warnings

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -1119,7 +1119,7 @@ CREATE TABLE #conversion_info
 );
 
 
-/*These tables support the Missing Index details clickable*/
+/*These tables make the Missing Index details clickable*/
 DROP TABLE IF EXISTS #missing_index_xml;
 
 CREATE TABLE #missing_index_xml

--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -10,11 +10,11 @@ GO
 
 DECLARE @msg NVARCHAR(MAX) = N'';
 
-	-- Must be a compatible, on-prem version of SQL (2016+)
+	/*Must be a compatible, on-prem version of SQL (2016+) or...*/
 IF  (	(SELECT CONVERT(NVARCHAR(128), SERVERPROPERTY ('EDITION'))) <> 'SQL Azure' 
 	AND (SELECT PARSENAME(CONVERT(NVARCHAR(128), SERVERPROPERTY ('PRODUCTVERSION')), 4)) < 13 
 	)
-	-- or Azure Database (not Azure Data Warehouse), running at database compat level 130+
+	/*...Azure Database (not Azure Data Warehouse), running at database compat level 130+*/
 OR	(	(SELECT CONVERT(NVARCHAR(128), SERVERPROPERTY ('EDITION'))) = 'SQL Azure'
 	AND (SELECT SERVERPROPERTY ('ENGINEEDITION')) NOT IN (5,8)
 	AND (SELECT [compatibility_level] FROM sys.databases WHERE [name] = DB_NAME()) < 130
@@ -679,7 +679,7 @@ CREATE TABLE #working_metrics
 	plan_id BIGINT,
     query_id BIGINT,
     query_id_all_plan_ids VARCHAR(8000),
-	/*these columns are from query_store_query*/
+	/*These columns are from query_store_query*/
 	proc_or_function_name NVARCHAR(258),
 	batch_sql_handle VARBINARY(64),
 	query_hash BINARY(8),
@@ -4620,12 +4620,12 @@ CASE WHEN b.count_executions < 2 THEN 'Too few executions to compare (< 2).'
 				CASE WHEN b.min_dop <> b.max_dop THEN ', Serial sometimes' ELSE '' END +
 				CASE WHEN b.min_dop <> b.max_dop AND b.last_dop = 1  THEN ', Serial last run' ELSE '' END +
 				CASE WHEN b.min_dop <> b.max_dop AND b.last_dop > 1 THEN ', Parallel last run' ELSE '' END +
-				/*tempdb*/
+				/*Space in tempdb*/
 				CASE WHEN b.min_tempdb_space_used * 100 < b.avg_tempdb_space_used THEN ', Low tempdb sometimes' ELSE '' END +
 				CASE WHEN b.max_tempdb_space_used > b.avg_tempdb_space_used * 100 THEN ', High tempdb sometimes' ELSE '' END +
 				CASE WHEN b.last_tempdb_space_used * 100 < b.avg_tempdb_space_used  THEN ', Low tempdb run' ELSE '' END +
 				CASE WHEN b.last_tempdb_space_used > b.avg_tempdb_space_used * 100 THEN ', High tempdb last run' ELSE '' END +
-				/*tlog*/
+				/*Transaction log*/
 				CASE WHEN b.min_log_bytes_used * 100 < b.avg_log_bytes_used THEN ', Low log use sometimes' ELSE '' END +
 				CASE WHEN b.max_log_bytes_used > b.avg_log_bytes_used * 100 THEN ', High log use sometimes' ELSE '' END +
 				CASE WHEN b.last_log_bytes_used * 100 < b.avg_log_bytes_used  THEN ', Low log use run' ELSE '' END +
@@ -5679,7 +5679,7 @@ BEGIN
 						WHEN DATEPART(HOUR, gi.end_range) > 12 THEN CONVERT(NVARCHAR(3),  DATEPART(HOUR, gi.end_range) -12) + 'pm '
 						END AS worst_end_time
 			FROM   #grouped_interval AS gi
-			), /*averages*/
+			), /*Averages*/
 				duration_worst AS (
 			SELECT TOP 1 'Your worst avg duration range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
@@ -5724,7 +5724,7 @@ BEGIN
 			SELECT TOP 1 'Your worst avg tempdb range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
 			ORDER BY worsts.total_avg_tempdb_space DESC
-				)/*maxes*/, 
+				)/*Maxes*/, 
 				max_duration_worst AS (
 			SELECT TOP 1 'Your worst max duration range was on ' + worsts.worst_date + ' between ' + worsts.worst_start_time + ' and ' + worsts.worst_end_time + '.' AS msg
 			FROM worsts
@@ -5766,7 +5766,7 @@ BEGIN
 			ORDER BY worsts.total_max_tempdb_space DESC
 				)
 			INSERT #warning_results ( CheckID, Priority, FindingsGroup, Finding, URL, Details )
-			/*averages*/
+			/*Averages*/
             SELECT 1002, 255, 'Worsts', 'Worst Avg Duration', 'N/A', duration_worst.msg
 			FROM duration_worst
 			UNION ALL
@@ -5794,7 +5794,7 @@ BEGIN
 			SELECT 1002, 255, 'Worsts', 'Worst Avg tempdb', 'N/A', tempdb_worst.msg
 			FROM tempdb_worst
             UNION ALL
-            /*maxes*/
+            /*Maxes*/
             SELECT 1002, 255, 'Worsts', 'Worst Max Duration', 'N/A', max_duration_worst.msg
 			FROM max_duration_worst
 			UNION ALL


### PR DESCRIPTION
I decided to clean up anything that bothered me in `sp_BlitzQueryStore` before beginning any serious work on it. These are largely style changes. Summary:

1. Minor edits to some comments, mostly typo corrections and edits for consistency with surrounding comments.
2. Removed some extra spaces, e.g. double spaces in printed text.
3. Moved repeated calls to `SERVERPROPERTY` in to variables. Some of these originally were `NVARCHAR` and others were `VARCHAR`. I am not sure if there is a good reason behind this, so I have gone with my [the docs](https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?view=sql-server-ver16). `ENGINEEDITION` is an exception to this and has been stored as an `INT`.
4. Ruthlessly made the commenting syntax consistent. The most common form in the original was `/*Foo*/` so I've applied that everywhere other than the multi-line block comments. Previously, it has `--Foo`, `-- Foo`, `/*foo*/`, `/* Foo */`, and
```
/*
I am a single sentence on a single line. This comment block has no other lines of text.
*/
```
5. Added comments for some temp tables that had none.
6. Documented the undocumented `@Version` parameters in the `@Help` text.
7. Switched `SELECT TOP N` to `SELECT TOP (N)` for consistency with other uses of `TOP`. 

I expect that only point 3 has even the slightest chance of breaking anything. Those variables are mostly used for Azure checks, but I don't have an Azure box to test them on.