### PR TITLE
Removed skipping of model and msdb in check for QS-enabled DBs

### DIFF
--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -443,7 +443,7 @@ IF  (	SELECT COUNT(*)
 		WHERE d.is_query_store_on = 1
 		AND d.user_access_desc='MULTI_USER'
 		AND d.state_desc = 'ONLINE'
-		AND d.name NOT IN ('master', 'model', 'msdb', 'tempdb', '32767') 
+		AND d.name NOT IN ('master', 'tempdb', '32767') 
 		AND d.is_distributor = 0 ) = 0
 	BEGIN
 		SELECT @msg = N'You don''t currently have any databases with Query Store enabled.' + REPLICATE(CHAR(13), 7933);


### PR DESCRIPTION
Although it's sometimes considered a bad idea to turn on Query Store for these databases, that doesn't justify telling people that they haven't done so.