### PR TITLE
Added missing RAISERROR to the check for parallel plans

### DIFF
--- a/sp_BlitzQueryStore.sql
+++ b/sp_BlitzQueryStore.sql
@@ -3022,6 +3022,9 @@ OPTION (RECOMPILE);
 /*
 This looks for parallel plans
 */
+
+RAISERROR(N'Checking for parallel plans', 0, 1) WITH NOWAIT;
+
 UPDATE ww
 SET    ww.is_parallel = 1
 FROM   #working_warnings AS ww


### PR DESCRIPTION
As requested in #3458 , reopened this as a PR that only includes the missing `RAISERROR`. Empty lines aside, this is just a one-line change so there's no need to open an issue or ask for resources.

The check for parallel plans was the only _warning_ check that was missing a `RAISERROR`, so I have added it in for consistency. There are _pattern_ checks that have oddities around what they `RAISERROR`, but that is [a separate issues](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3449) that requires some discussion before writing any code.