### PR TITLE
sp_Blitz: Add check for very high Query Store memory usage

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 261.
-If you want to add a new one, start at 262.
+CURRENT HIGH CHECKID: 262.
+If you want to add a new one, start at 263.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -65,6 +65,7 @@ If you want to add a new one, start at 262.
 | 50 | Performance | Poison Wait Detected | https://www.BrentOzar.com/go/poison | 107 |
 | 50 | Performance | Poison Wait Detected: CMEMTHREAD & NUMA | https://www.BrentOzar.com/go/poison | 162 |
 | 50 | Performance | Poison Wait Detected: Serializable Locking | https://www.BrentOzar.com/go/serializable | 121 |
+| 50 | Performance | Very High Query Store Memory Usage | | 262 |
 | 50 | Performance | Recovery Interval Not Optimal| https://sqlperformance.com/2020/05/system-configuration/0-to-60-switching-to-indirect-checkpoints | 257 |
 | 50 | Performance | Snapshotting Too Many Databases | https://www.BrentOzar.com/go/toomanysnaps | 236 |
 | 50 | Performance | Too Much Free Memory | https://www.BrentOzar.com/go/freememory | 165 |


### PR DESCRIPTION
Closes item 8 in #3527. Other items in that issue remain open.

I really didn't do anything smart while making this. I just cracked open the docs for [sys.dm_os_memory_clerks](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-memory-clerks-transact-sql?view=sql-server-ver16#types) and searched for references to Query Store.

1 GB was chosen utterly arbitrarily. I have no idea what can reasonably be considered a ridiculously high amount of Query Store memory usage. I've never seen a box crack 0.75 GB.

I've made this a priority 50 issue under the 'Performance' header. If your Query Store is eating a ridiculous amount of memory, then you have something interesting going on and ought to look. Everything with a number higher than 50 under the same header seemed far less important.

No useful URL has come to mind. Online research about Query Store overhead never mentions checking this metric, even though `sys.dm_os_memory_clerks` is the basis for a few of our checks. I could link to a generic guide on how to configure Query Store, but that wouldn't focus on the problem.

This is my first new check for sp_Blitz, so it's quite likely that it's missing something important. It's passed the limited suite of tests that I've tried on my local instance.