### PR TITLE
sp_Blitz: Add check for Query Store Wait Stats being turned off

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 261.
-If you want to add a new one, start at 262.
+CURRENT HIGH CHECKID: 262.
+If you want to add a new one, start at 263.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -247,6 +247,7 @@ If you want to add a new one, start at 262.
 | 200 | Performance | Non-Dynamic Memory | https://www.BrentOzar.com/go/memory | 190 |
 | 200 | Performance | Old Compatibility Level | https://www.BrentOzar.com/go/compatlevel | 62 |
 | 200 | Performance | Query Store Disabled | https://www.BrentOzar.com/go/querystore | 163 |
+| 200 | Performance | Query Store Wait Stats Disabled | https://www.sqlskills.com/blogs/erin/query-store-settings/ | 262 |
 | 200 | Performance | Snapshot Backups Occurring | https://www.BrentOzar.com/go/snaps | 178 |
 | 200 | Performance | User-Created Statistics In Place | https://www.BrentOzar.com/go/userstats | 122 |
 | 200 | Performance | SSAS/SSIS/SSRS Installed | https://www.BrentOzar.com/go/services | 224 |


### PR DESCRIPTION
Closes item 5 in #3527  Only items 6 and 7 are now awaiting PRs.

I've added this under the same check number as my other new check, because it's rude to assume that both will get merged.

I've made this a priority 200 issue under the 'Performance' header. This is the consistent with the check for having Query Store completely disabled.

I couldn't find a better URL than the one that I've given. One must surely exist.

This is my first new mutli-database check for `sp_Blitz`, so it's quite likely that it's missing something important. It's passed the limited suite of tests that I've tried on my local instance.