### PR TITLE
sp_Blitz: Added check for unusual Query Store query capture mode

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 262.
-If you want to add a new one, start at 263.
+CURRENT HIGH CHECKID: 265.
+If you want to add a new one, start at 266.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -248,6 +248,7 @@ If you want to add a new one, start at 263.
 | 200 | Performance | Old Compatibility Level | https://www.BrentOzar.com/go/compatlevel | 62 |
 | 200 | Performance | Query Store Disabled | https://www.BrentOzar.com/go/querystore | 163 |
 | 200 | Performance | Query Store Wait Stats Disabled | https://www.sqlskills.com/blogs/erin/query-store-settings/ | 262 |
+| 200 | Performance | Query Store Unusually Configured | https://www.sqlskills.com/blogs/erin/query-store-best-practices/ | 265 |
 | 200 | Performance | Snapshot Backups Occurring | https://www.BrentOzar.com/go/snaps | 178 |
 | 200 | Performance | User-Created Statistics In Place | https://www.BrentOzar.com/go/userstats | 122 |
 | 200 | Performance | SSAS/SSIS/SSRS Installed | https://www.BrentOzar.com/go/services | 224 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6814,7 +6814,7 @@ IF @ProductVersionMajor >= 10
 		                              ''Performance'',
 		                              ''Query Store Unusually Configured'',
 		                              ''https://www.sqlskills.com/blogs/erin/query-store-best-practices/'',
-		                              (''The '' query_capture_mode_desc + '' query capture mode '' +
+		                              (''The '' + query_capture_mode_desc + '' query capture mode '' +
 											CASE query_capture_mode_desc WHEN
 												''ALL'' THEN '' captures more data than you will probably use. If your workload is heavily ad-hoc, then it can also cause Query Store to capture so much that it turns itself off.''
 												''NONE'' THEN '' stops Query Store capturing data for new queries.''

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6815,10 +6815,10 @@ IF @ProductVersionMajor >= 10
 		                              ''Query Store Unusually Configured'',
 		                              ''https://www.sqlskills.com/blogs/erin/query-store-best-practices/'',
 		                              (''The '' + query_capture_mode_desc + '' query capture mode '' +
-											CASE query_capture_mode_desc WHEN
-												''ALL'' THEN '' captures more data than you will probably use. If your workload is heavily ad-hoc, then it can also cause Query Store to capture so much that it turns itself off.''
-												''NONE'' THEN '' stops Query Store capturing data for new queries.''
-												''CUSTOM'' THEN '' suggests that somebody has gone out of their way to only capture exactly what they want.''
+											CASE query_capture_mode_desc
+												WHEN ''ALL'' THEN '' captures more data than you will probably use. If your workload is heavily ad-hoc, then it can also cause Query Store to capture so much that it turns itself off.''
+												WHEN ''NONE'' THEN '' stops Query Store capturing data for new queries.''
+												WHEN ''CUSTOM'' THEN '' suggests that somebody has gone out of their way to only capture exactly what they want.''
 											ELSE '' is not documented.'' END)
 		                              FROM [?].sys.database_query_store_options
 									  WHERE desired_state <> 0 /* No point in checking this if Query Store is off. */

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6816,10 +6816,10 @@ IF @ProductVersionMajor >= 10
 		                              ''https://www.sqlskills.com/blogs/erin/query-store-best-practices/'',
 		                              (''The '' + query_capture_mode_desc + '' query capture mode '' +
 											CASE query_capture_mode_desc
-												WHEN ''ALL'' THEN '' captures more data than you will probably use. If your workload is heavily ad-hoc, then it can also cause Query Store to capture so much that it turns itself off.''
-												WHEN ''NONE'' THEN '' stops Query Store capturing data for new queries.''
-												WHEN ''CUSTOM'' THEN '' suggests that somebody has gone out of their way to only capture exactly what they want.''
-											ELSE '' is not documented.'' END)
+												WHEN ''ALL'' THEN ''captures more data than you will probably use. If your workload is heavily ad-hoc, then it can also cause Query Store to capture so much that it turns itself off.''
+												WHEN ''NONE'' THEN ''stops Query Store capturing data for new queries.''
+												WHEN ''CUSTOM'' THEN ''suggests that somebody has gone out of their way to only capture exactly what they want.''
+											ELSE ''is not documented.'' END)
 		                              FROM [?].sys.database_query_store_options
 									  WHERE desired_state <> 0 /* No point in checking this if Query Store is off. */
 									  AND query_capture_mode_desc <> ''AUTO''

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -6819,7 +6819,7 @@ IF @ProductVersionMajor >= 10
 												''ALL'' THEN '' captures more data than you will probably use. If your workload is heavily ad-hoc, then it can also cause Query Store to capture so much that it turns itself off.''
 												''NONE'' THEN '' stops Query Store capturing data for new queries.''
 												''CUSTOM'' THEN '' suggests that somebody has gone out of their way to only capture exactly what they want.''
-											ELSE '' is not documented.'')
+											ELSE '' is not documented.'' END)
 		                              FROM [?].sys.database_query_store_options
 									  WHERE desired_state <> 0 /* No point in checking this if Query Store is off. */
 									  AND query_capture_mode_desc <> ''AUTO''


### PR DESCRIPTION
Closes the last open item from #3527 .

I've made this a priority 200 issue under the 'Performance' header. This is the consistent with the check for having Query Store completely disabled. After all, the None mode isn't very different from that.

My claim that the All query capture mode can turn Query Store off is not in the URL provided. The documentation for that is actually [here](https://learn.microsoft.com/en-us/sql/relational-databases/performance/best-practice-with-the-query-store?view=sql-server-ver16#Verify).