### PR TITLE
INT data type prevents reporting indexes < 1 MB

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1462,9 +1462,9 @@ BEGIN TRY
 				, partition_number int
 				, partition_id bigint
 				, row_count bigint
-				, reserved_MB bigint
-				, reserved_LOB_MB bigint
-				, reserved_row_overflow_MB bigint
+				, reserved_MB NUMERIC(29,2)
+				, reserved_LOB_MB NUMERIC(29,2)
+				, reserved_row_overflow_MB NUMERIC(29,2)
 				, lock_escalation_desc nvarchar(60)
 				, data_compression_desc nvarchar(60)
 			)


### PR DESCRIPTION
Updated data type of reserved MB fields in [#dm_db_partition_stats_etc] to match similar fields in other temp tables.
BlitzIndex for a single table will now report "size" for indexes less than 1 MB.