### PR TITLE
Replace illegal character & in sp_Blitz for Markdown output result

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8617,7 +8617,7 @@ IF @ProductVersionMajor >= 10
 							SELECT  162 AS CheckID ,
 									50 AS Priority ,
 									'Performance' AS FindingGroup ,
-									'Poison Wait Detected: CMEMTHREAD & NUMA'  AS Finding ,
+									'Poison Wait Detected: CMEMTHREAD and NUMA'  AS Finding ,
 									'https://www.brentozar.com/go/poison' AS URL ,
                                     CONVERT(VARCHAR(10), (MAX([wait_time_ms]) / 1000) / 86400) + ':' + CONVERT(VARCHAR(20), DATEADD(s, (MAX([wait_time_ms]) / 1000), 0), 108) + ' of this wait have been recorded'
                                     + CASE WHEN ts.status = 1 THEN ' despite enabling trace flag 8048 already.'


### PR DESCRIPTION
When I run a procedure with the following parameter "exec dbo.sp_Blitz @OutputType = 'Markdown'", I expected to see the output result in Markdown format. However, I received the following error instead:

_Msg 9421, Level 16, State 1, Procedure dbo.sp_Blitz, Line 10347 [Batch Start Line 0] XML parsing: line 63, character 37, illegal name character._

The issue is caused by an illegal character (&) in the description of the Finding column for CheckID = 162. To resolve this issue, update the description to replace & with and, ensuring XML compatibility.