### PR TITLE
sp_Blitz - correctly check permissions for sys.traces

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -287,8 +287,8 @@ AS
             (
                 SELECT
                     1/0
-                FROM fn_my_permissions(N'sys.traces', N'OBJECT') AS fmp
-                WHERE fmp.permission_name = N'ALTER'
+                FROM fn_my_permissions(NULL, NULL) AS fmp
+                WHERE fmp.permission_name = N'ALTER TRACE'
             )
             BEGIN
                 SET @SkipTrace = 1;


### PR DESCRIPTION
Fix for #3581. The idea here is to check ALTER TRACE permissions on server level and not ALTER on sys.traces itself.

Here is an extended script from the issue. Added third test for sp_Blitz with ALTER TRACE granted. With that we can see DBCC DROPCLEANBUFFERS reported (yeah added it there so no copy, paste, execute into production). It shows the check itself works.

```
USE master

DBCC DROPCLEANBUFFERS

CREATE LOGIN BlitzTest WITH PASSWORD = 'TestBlitz'
CREATE USER BlitzTest FOR LOGIN BlitzTest
GRANT EXECUTE ON sp_Blitz TO BlitzTest
GRANT VIEW SERVER STATE TO BlitzTest
GO

EXECUTE AS LOGIN = 'BlitzTest'

PRINT 'This works'
EXEC sp_Blitz
PRINT 'This worked'

REVERT

GO

ALTER ROLE db_owner ADD MEMBER BlitzTest

EXECUTE AS LOGIN = 'BlitzTest'

PRINT 'This does not works'
EXEC sp_Blitz
PRINT 'Doesn''t reach here'

REVERT

GO

REVERT

GRANT ALTER TRACE TO BlitzTest

EXECUTE AS LOGIN = 'BlitzTest'

PRINT 'Reports DBCC DROPCLEANBUFFERS'
EXEC sp_Blitz

REVERT

GO

--cleanup
REVERT
DROP USER IF EXISTS BlitzTest
DROP LOGIN BlitzTest
```