### PR TITLE
sp_BlitzIndex: Added reports of resumable index operations (closes #3609 )

### DIFF
--- a/Documentation/sp_BlitzIndex_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzIndex_Checks_by_Priority.md
@@ -6,13 +6,15 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 121
-If you want to add a new check, start at 122.
+CURRENT HIGH CHECKID: 123
+If you want to add a new check, start at 124.
 
 | Priority | FindingsGroup           | Finding                                                         | URL                                             | CheckID |
 | -------- | ----------------------- | --------------------------------------------------------------- | ----------------------------------------------- | ------- |
 | 10       | Over-Indexing           | Many NC Indexes on a Single Table                               | https://www.brentozar.com/go/IndexHoarder       | 20      |
 | 10       | Over-Indexing           | Unused NC Index with High Writes                                | https://www.brentozar.com/go/IndexHoarder       | 22      |
+| 10       | Resumable Indexing      | Resumable Index Operation Paused                                | https://www.BrentOzar.com/go/resumable          | 122     |
+| 10       | Resumable Indexing      | Resumable Index Operation Running                               | https://www.BrentOzar.com/go/resumable          | 123     |
 | 20       | Redundant Indexes       | Duplicate Keys                                                  | https://www.brentozar.com/go/duplicateindex     | 1       |
 | 30       | Redundant Indexes       | Approximate Duplicate Keys                                      | https://www.brentozar.com/go/duplicateindex     | 2       |
 | 40       | Index Suggestion        | High Value Missing Index                                        | https://www.brentozar.com/go/indexaphobia       | 50      |


### PR DESCRIPTION
Added reports of resumable index operations to the mode 0 and mode 4 outputs, as well as the mode where you name one table. The priority set here is very high, but that seems correct. They can prevent DDL!

[Brent warned](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3609#issuecomment-2693163590) that I should check if the `sys.index_resumable_operations` honours `NOLOCK`, but as far as I can tell it's impossible to put a resumable operation in a transaction.

My production experience of resumable operations is very limited, so the warnings that I have given about them relied on either trusting the documentation or doing what I could easily verify. If there are much nastier things to warn of, then somebody should change my strings.

I think that this is my first contribution to `sp_BlitzIndex`. It is certainly my first non-trivial one. All of my testing says that I've done the work correctly. However, you shouldn't trust a first timer. 

Not included: Any reference to the 2022 feature that auto-kills paused indexes. It is in [the ALTER DATABASE SCOPED CONFIGURATION docs](https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-database-scoped-configuration-transact-sql?view=sql-server-ver16#paused_resumable_index_abort_duration_minutes). I will make an issue for it.