### PR TITLE
Add Query Store Parameter to sp_ineachdb

### DIFF
--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -241,7 +241,7 @@ OPTION (MAXRECURSION 0);
   BEGIN
     DELETE dbs FROM #ineachdb AS dbs
 	WHERE EXISTS
-	(
+	 (
        SELECT 1 
          FROM sys.databases AS d
          WHERE d.database_id = dbs.id


### PR DESCRIPTION
This adds a new parameter to allow filtering of databases that have query store either enabled or disabled. This treats the model database as if it has query store disabled since it's marked as enabled in SQL 2022+ but is not a true query store enabled database.