### PR TITLE
Update sp_Blitz.sql

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1862,7 +1862,7 @@ AS
 										'Security' AS FindingsGroup ,
 										'Invalid login defined with Windows Authentication' AS Finding ,
 										'https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-validatelogins-transact-sql' AS URL ,
-										( 'Windows user or group ' + QUOTENAME(LoginName) + ' is mapped to a SQL Server principal but no longer exists in the Windows environment.') AS Details
+										( 'Windows user or group ' + QUOTENAME(LoginName) + ' is mapped to a SQL Server principal but no longer exists in the Windows environment. Sometimes empty AD groups can show up here so check thoroughly.') AS Details
                                 FROM #InvalidLogins
                                 ;
                     END;


### PR DESCRIPTION
Extend details for Invalid Logins - empty AD Groups will occasionally show up here (it's an AD thing), and it's a pain to delete that group and then have to reinstate it in SQL when it turns out you do need it.

This relates to issue https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3648