### PR TITLE
sp_ineachdb - Change @is_query_store_on Default Value to NULL

### DIFF
--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -30,7 +30,7 @@ ALTER PROCEDURE [dbo].[sp_ineachdb]
   @VersionDate          datetime       = NULL OUTPUT,
   @VersionCheckMode     bit            = 0,
   @is_ag_writeable_copy bit            = 0,
-  @is_query_store_on	bit            = 0
+  @is_query_store_on	bit            = NULL
 -- WITH EXECUTE AS OWNER – maybe not a great idea, depending on the security of your system
 AS
 BEGIN


### PR DESCRIPTION
Changes the default value of parameter @is_query_store_on from 0 to NULL to avoid excluding non-query store databases by default.

This resolves #3668 to make the addition of this parameter a non-breaking change.