### PR TITLE
sp_BlitzIndex: Added warning for persisted sample rates.

### DIFF
--- a/Documentation/sp_BlitzIndex_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzIndex_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 125
-If you want to add a new check, start at 126.
+CURRENT HIGH CHECKID: 126
+If you want to add a new check, start at 127.
 
 | Priority | FindingsGroup           | Finding                                                         | URL                                                              | CheckID |
 | -------- | ----------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
@@ -25,7 +25,7 @@ If you want to add a new check, start at 126.
 | 80       | Abnormal Design Pattern | Filter Columns Not In Index Definition                          | https://www.brentozar.com/go/IndexFeatures                       | 34      |
 | 80       | Abnormal Design Pattern | History Table With NonClustered Index                           | https://sqlserverfast.com/blog/hugo/2023/09/an-update-on-merge/  | 124     |
 | 90       | Statistics Warnings     | Low Sampling Rates                                              | https://www.brentozar.com/go/stats                               | 91      |
-| 90       | Statistics Warnings     | Persisted Sampling Rates                                        | https://www.youtube.com/watch?v=V5illj_KOJg&t=758s               | 125     |
+| 90       | Statistics Warnings     | Persisted Sampling Rates (Unexpected)                           | `https://www.youtube.com/watch?v=V5illj_KOJg&t=758s`             | 125     |
 | 90       | Statistics Warnings     | Statistics Not Updated Recently                                 | https://www.brentozar.com/go/stats                               | 90      |
 | 90       | Statistics Warnings     | Statistics with NO RECOMPUTE                                    | https://www.brentozar.com/go/stats                               | 92      |
 | 100      | Over-Indexing           | NC index with High Writes:Reads                                 | https://www.brentozar.com/go/IndexHoarder                        | 48      |
@@ -62,6 +62,7 @@ If you want to add a new check, start at 126.
 | 200      | Abnormal Design Pattern | Temporal Tables                                                 | https://www.brentozar.com/go/AbnormalPsychology                  | 110     |
 | 200      | Repeated Calculations   | Computed Columns Not Persisted                                  | https://www.brentozar.com/go/serialudf                           | 100     |
 | 200      | Statistics Warnings     | Statistics With Filters                                         | https://www.brentozar.com/go/stats                               | 93      |
+| 200      | Statistics Warnings     | Persisted Sampling Rates (Expected)                             | `https://www.youtube.com/watch?v=V5illj_KOJg&t=758s`             | 126     |
 | 200      | Over-Indexing           | High Ratio of Nulls                                             | https://www.brentozar.com/go/IndexHoarder                        | 25      |
 | 200      | Over-Indexing           | High Ratio of Strings                                           | https://www.brentozar.com/go/IndexHoarder                        | 27      |
 | 200      | Over-Indexing           | Wide Tables: 35+ cols or > 2000 non-LOB bytes                   | https://www.brentozar.com/go/IndexHoarder                        | 26      |

--- a/Documentation/sp_BlitzIndex_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzIndex_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 124
-If you want to add a new check, start at 125.
+CURRENT HIGH CHECKID: 125
+If you want to add a new check, start at 126.
 
 | Priority | FindingsGroup           | Finding                                                         | URL                                                              | CheckID |
 | -------- | ----------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
@@ -25,6 +25,7 @@ If you want to add a new check, start at 125.
 | 80       | Abnormal Design Pattern | Filter Columns Not In Index Definition                          | https://www.brentozar.com/go/IndexFeatures                       | 34      |
 | 80       | Abnormal Design Pattern | History Table With NonClustered Index                           | https://sqlserverfast.com/blog/hugo/2023/09/an-update-on-merge/  | 124     |
 | 90       | Statistics Warnings     | Low Sampling Rates                                              | https://www.brentozar.com/go/stats                               | 91      |
+| 90       | Statistics Warnings     | Persisted Sampling Rates                                        | https://www.youtube.com/watch?v=V5illj_KOJg&t=758s               | 125     |
 | 90       | Statistics Warnings     | Statistics Not Updated Recently                                 | https://www.brentozar.com/go/stats                               | 90      |
 | 90       | Statistics Warnings     | Statistics with NO RECOMPUTE                                    | https://www.brentozar.com/go/stats                               | 92      |
 | 100      | Over-Indexing           | NC index with High Writes:Reads                                 | https://www.brentozar.com/go/IndexHoarder                        | 48      |

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ In addition to the [parameters common to many of the stored procedures](#paramet
 
 * @SkipPartitions = 1 - add this if you want to analyze large partitioned tables. We skip these by default for performance reasons.
 * @SkipStatistics = 0 - right now, by default, we skip statistics analysis because we've had some performance issues on this.
+* @UsualStatisticsSamplingPercent = 100 (default) - By default, @SkipStatistics = 0 with either @Mode = 0 or @Mode = 4 does not inform you of persisted statistics sample rates if that rate is 100. Use a different float if you usually persist a different sample percentage and do not want to be warned about it. Use NULL if you want to hear about every persisted sample rate.
 * @Filter = 0 (default) - 1=No low-usage warnings for objects with 0 reads. 2=Only warn for objects >= 500MB
 * @OutputDatabaseName, @OutputSchemaName, @OutputTableName - these only work for @Mode = 2, index usage detail.
 


### PR DESCRIPTION
Closes #3679 .

<img width="1828" height="355" alt="image" src="https://github.com/user-attachments/assets/1c4d7e4d-562d-41d7-b6a0-82807513d8a7" />

This was disturbingly easy. You will want to check over it very carefully. The only place where I really had to think was the dynamic SQL. I don't have super old versions of SQL Server hanging around, so I have not been able to test any branches other than the one that my 2022 Docker container hits.

The URL that I have given is the best that I could find. I cannot think of anyone who has spoken with the voice of experience about `PERSIST_SAMPLE_PERCENT`.

I might make an issue for us also not having incremental statistics, but the merge conflict will be a pain unless this is merged first.