### PR TITLE
#3692 sp_BlitzFirst memory pressure

### DIFF
--- a/Documentation/sp_BlitzFirst_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzFirst_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 51
-If you want to add a new check, start at 52.
+CURRENT HIGH CHECKID: 52
+If you want to add a new check, start at 53.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|---------------------------------|---------------------------------------|-------------------------------------------------|----------|
@@ -23,6 +23,7 @@ If you want to add a new check, start at 52.
 | 1 | SQL Server Internal Maintenance | Data File Growing | https://www.brentozar.com/go/instant | 4 |
 | 1 | SQL Server Internal Maintenance | Log File Growing | https://www.brentozar.com/go/logsize | 13 |
 | 1 | SQL Server Internal Maintenance | Log File Shrinking | https://www.brentozar.com/go/logsize | 14 |
+| 10 | Server Performance | Memory Dangerously Low Recently | https://www.brentozar.com/go/memhist | 52 |
 | 10 | Server Performance | Poison Wait Detected | https://www.brentozar.com/go/poison | 30 |
 | 10 | Server Performance | Target Memory Lower Than Max | https://www.brentozar.com/go/target | 35 |
 | 10 | Azure Performance | Database is Maxed Out | https://www.brentozar.com/go/maxedout | 41 |

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2617,6 +2617,27 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 			END
 		END
 
+
+
+    /* Server Performance - Memory Dangerously Low Recently - CheckID 52 */
+	IF (@Debug = 1)
+	BEGIN
+		RAISERROR('Running CheckID 52',10,1) WITH NOWAIT;
+	END
+	IF EXISTS (SELECT * FROM sys.all_objects WHERE name = 'dm_os_memory_health_history')
+		BEGIN
+			INSERT INTO #BlitzFirstResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+			SELECT TOP 1 52 AS CheckID,
+				10 AS Priority,
+				'Server Performance' AS FindingGroup,
+				'Memory Dangerously Low Recently' AS Finding,
+				'https://www.brentozar.com/go/memhist' AS URL,
+				N'As recently as ' + CONVERT(NVARCHAR(19), snapshot_time, 120) + N', memory health issues are being reported in sys.dm_os_memory_health, indicating extreme memory pressure.' AS Details
+			FROM sys.dm_os_memory_health_history
+			WHERE severity_level > 1;
+		END
+
+
 	RAISERROR('Finished running investigatory queries',10,1) WITH NOWAIT;
 
 


### PR DESCRIPTION
Adds new warning for sys.dm_os_memory_health_history. Closes #3692.