### PR TITLE
Fix sp_BlitzBackups.sql problem where Unicode Database Names get mangled in the output.

### DIFF
--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -237,7 +237,7 @@ CREATE TABLE #Warnings
     Id INT IDENTITY(1, 1) PRIMARY KEY CLUSTERED,
     CheckId INT,
     Priority INT,
-    DatabaseName VARCHAR(128),
+    DatabaseName NVARCHAR(128),
     Finding VARCHAR(256),
     Warning VARCHAR(8000)
 );


### PR DESCRIPTION
Fix problem where Unicode Database Names get mangled in the sp_BlitzBackups output.

You can test this locally by:

```sql
CREATE DATABASE [αβγδε ΑΒΓΔΕ]
GO
--give it a full backup
GO
EXEC sp_BlitzBackups
--the output Database name is mangled into ASCII characters, not Unicode ones.
```