### PR TITLE
sp_BlitzIndex: Added an ORDER BY to the temporal table check

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -5650,6 +5650,7 @@ BEGIN
 				'N/A' AS index_usage_summary,
 				'N/A' AS index_size_summary
 		FROM #TemporalTables AS t
+		ORDER BY t.database_name, t.schema_name, t.table_name
 		OPTION    ( RECOMPILE );
 
 		RAISERROR(N'check_id 121: Optimized For Sequential Keys.', 0,1) WITH NOWAIT;


### PR DESCRIPTION
A one-line PR!

Closes #3727. Let the screenshots speak for themselves.

Before
![Before](https://github.com/user-attachments/assets/34c1cd6e-4012-4c34-82a6-58b3bf129132)

After
![After](https://github.com/user-attachments/assets/b6e14ade-b5f3-4faa-beac-904e38ae6c29)

I couldn't be bothered to make my own database packed full of temporal tables, so I put my faith in Microsoft and loaded up [this copy of WideWorldImporters](https://github.com/Microsoft/sql-server-samples/releases/download/wide-world-importers-v1.0/WideWorldImporters-Full.bak). Once you [have that loaded](https://github.com/microsoft/sql-server-samples/issues/740#issuecomment-2094889233), just run `EXEC sp_BlitzIndex @Databasename = 'WideWorldImporters', @Mode = 4;` and you will see the difference.

I unfortunately couldn't use the fix I preferred in the issue. The second part of the `ORDER BY` in the final output sorts by the auto-increment ID column `br.check_id`. I couldn't overcome that sort without making bigger changes. On the bright side, the `check_id` thing is what made this a one-line PR.