### PR TITLE
Fix sp_BlitzIndex error when scanning a database name of nvarchar(128)

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2177,8 +2177,8 @@ CROSS APPLY (SELECT STUFF( (SELECT N'', '' + c_referenced.name AS fk_columns
 		  AND fk.[object_id]=fkc.constraint_object_id
 		ORDER BY fkc.constraint_column_id /*order by col name, we don''t have anything better*/
 		FOR XML PATH(''''),
-			TYPE).value(''.'', ''nvarchar(max)''), 1, 1, '''')) referenced ( fk_columns )'
-+ CASE WHEN @ObjectID IS NOT NULL THEN
+			TYPE).value(''.'', ''nvarchar(max)''), 1, 1, '''')) referenced ( fk_columns )
+' + CASE WHEN @ObjectID IS NOT NULL THEN
 		'WHERE fk.parent_object_id=' + CAST(@ObjectID AS NVARCHAR(30)) + N' OR fk.referenced_object_id=' + CAST(@ObjectID AS NVARCHAR(30)) + N' ' 
         ELSE N' ' END + '
 ORDER BY parent_object_name, foreign_key_name


### PR DESCRIPTION
When you run sp_BlitzIndex on a database/schema/table that actually has a name of nvarchar(128),
it blows up at the debug step "Inserting data into #ForeignKeys".

I found this was because one of the @dsql values was being truncated when you pass a database name of 128 chars.

The easiest fix was to edit the offending @dsql query to stop using millions of consecutive spaces, and swap instead to tabs and well-formatted code.

You can replicate the problem and test the fix by creating The Horrible Database, Schema, and Table below, and running sp_BlitzIndex in various @Modes.
(the names contain 128 Unicode characters, including some Greek at the start, and a space, to really test your code properly!)

CREATE DATABASE [ΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF] ON PRIMARY (
	 NAME            = N'DATA456789ABCDEFΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
	,FILENAME = N'C:\SQL\DATA456789ABCDEFΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
	,SIZE = 1MB
	,MAXSIZE = 20MB
	,FILEGROWTH = 10MB
	)
LOG ON (
	 NAME            = N'LOG3456789ABCDEFΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
	,FILENAME = N'C:\SQL\LOG3456789ABCDEFΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
	,SIZE = 1MB
	,MAXSIZE = 20MB
	,FILEGROWTH = 10MB
	)
;
USE [ΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF]
GO
CREATE SCHEMA [ΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF]
GO
CREATE TABLE [ΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF]
            .[ΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF]
	(
	[ΑβΓδε 6789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF]
	[tinyint] NOT NULL
	)