### PR TITLE
Fix issue #3745 VSCode parsing a THROW in sp_BlitzFirst

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -2587,7 +2587,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 											 N' this is likely due to an Index operation in Progress', -1;
 					END
 					ELSE
-					BEGIN
+					BEGIN;
 						THROW;
 					END
 				END CATCH


### PR DESCRIPTION
Added a semicolon at the end of previous line for a THROW statement that VSCode + MSSQL extension was reporting as a problem.