### PR TITLE
quick fix for #3753

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -141,10 +141,25 @@ SET @DatabaseName = COALESCE(@DatabaseName, PARSENAME(@ObjectName, 3)) /* 3 = Da
 SET @SchemaName   = COALESCE(@SchemaName,   PARSENAME(@ObjectName, 2)) /* 2 = Schema name */
 SET @TableName    = COALESCE(@TableName,    PARSENAME(@ObjectName, 1)) /* 1 = Table name */
 
-/* Handle already quoted input if it wasn't fully qualified*/
-SET @DatabaseName = PARSENAME(@DatabaseName,1);
-SET @SchemaName   = ISNULL(PARSENAME(@SchemaName,1),PARSENAME(@TableName,2));
-SET @TableName    = PARSENAME(@TableName,1);
+/* Handle already quoted input if it wasn't fully qualified - only if @ObjectName is null*/
+IF (@ObjectName IS NULL)
+   BEGIN
+        SELECT @DatabaseName = CASE WHEN @DatabaseName LIKE N'\[%\]' ESCAPE N'\' THEN PARSENAME(@DatabaseName,1) ELSE @DatabaseName 
+                               END,
+               @SchemaName   = ISNULL(
+                                     CASE /*only apply parsename if the schema is actually quoted*/
+                                      WHEN @SchemaName LIKE N'\[%\]' ESCAPE N'\' THEN  PARSENAME(@SchemaName,1) ELSE @SchemaName 
+                                     END,
+                                     CASE /*if we already have @TableName in the form of [some.schema].[some.table]*/
+                                      WHEN @TableName LIKE N'\[%\].\[%\]' ESCAPE N'\' THEN PARSENAME(@TableName,2)
+                                      /*I'm making an assumption here that people who use . in their naming conventions would have one in each object name*/
+                                      WHEN LEN(@TableName)- LEN(REPLACE(@TableName,'.','')) = 1 THEN PARSENAME(@TableName,2) ELSE NULL 
+                                     END),
+               @TableName    = CASE 
+                                 WHEN @TableName LIKE N'\[%\].\[%\]' ESCAPE N'\' OR @TableName LIKE N'\[%\]' ESCAPE N'\' THEN PARSENAME(@TableName,1)
+                                 WHEN LEN(@TableName)- LEN(REPLACE(@TableName,'.','')) = 1 THEN PARSENAME(@TableName,1) ELSE @TableName 
+                                END;
+END;
 
 /* If we're on Azure SQL DB let's cut people some slack */
 IF (@TableName IS NOT NULL AND @AzureSQLDB = 1 AND @DatabaseName IS NULL)


### PR DESCRIPTION
This fix doesn't address the output object names, but I can tackle those those if needed as well.

Behavior with this fix:

```sql
/*These work*/
EXEC sp_BlitzIndex;
EXEC sp_BlitzIndex @GetAllDatabases = 1, @Mode = 0;
EXEC sp_BlitzIndex @GetAllDatabases = 1, @Mode = 1;
EXEC sp_BlitzIndex @GetAllDatabases = 1, @Mode = 2;
EXEC sp_BlitzIndex @GetAllDatabases = 1, @Mode = 3;
EXEC sp_BlitzIndex @GetAllDatabases = 1, @Mode = 4;
EXEC sp_BlitzIndex @DatabaseName = 'StackOverflow', @TableName = 'Users'; 
EXEC sp_BlitzIndex @DatabaseName = 'StackOverflow', @TableName = 'dbo.Users';
EXEC sp_BlitzIndex @DatabaseName = 'StackOverflow', @TableName = '[dbo].Users';
EXEC sp_BlitzIndex @DatabaseName = 'StackOverflow', @TableName = '[dbo].[Users]';
EXEC sp_BlitzIndex 'StackOverflow.dbo.Users';


/*all following variations work*/
EXEC sp_BlitzIndex @DatabaseName = '[Testing.1.2]';
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2'; 
EXEC sp_BlitzIndex '[Testing.1.2].[Very.Bad.Schema].[Very.Bad.Idea]'
EXEC sp_BlitzIndex @DatabaseName = '[Testing.1.2]', @TableName = '[Very.Bad.Schema].[Very.Bad.Idea]' 
EXEC sp_BlitzIndex @DatabaseName = '[Testing.1.2]', @SchemaName = 'Very.Bad.Schema', @TableName = 'Very.Bad.Idea'
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2', @SchemaName = 'Very.Bad.Schema', @TableName = 'Very.Bad.Idea'
EXEC sp_BlitzIndex @DatabaseName = '[Testing.1.2]', @SchemaName = '[Very.Bad.Schema]', @TableName = '[Very.Bad.Idea]'
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2', @SchemaName = '[Very.Bad.Schema]', @TableName = '[Very.Bad.Idea]'
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2', @SchemaName = '[Very.Bad.Schema]', @TableName = 'Very.Bad.Idea'
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2', @TableName = '[Very.Bad.Idea]'; /*will not work if the same table name exists in multiple schemas*/
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2', @TableName = 'Very.Bad.Idea'; /*will not work if the same table name exists in multiple schemas*/

/*This does not work due to not finding schema or object (at this point, this is the lesser evil) */
EXEC sp_BlitzIndex @DatabaseName = '[Testing.1.2]', @TableName = 'Very.Bad.Schema.Very.Bad.Idea';
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2', @TableName = '[Very.Bad.Schema].Very.Bad.Idea'; 
EXEC sp_BlitzIndex @DatabaseName = 'Testing.1.2', @TableName = 'Very.Bad.Schema.[Very.Bad.Idea]';


/*It doesn't error out, but it outputs Mode = 0 for the database in which sp_BlitzIndex lives, completely ignoring the input*/
EXEC sp_BlitzIndex 'Testing.1.2.Very.Bad.Schema.Very.Bad.Idea';
```