### PR TITLE
sp_Blitz: Added checks for missing read-only routing URL or list

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 272.
-If you want to add a new one, start at 273.
+CURRENT HIGH CHECKID: 274.
+If you want to add a new one, start at 275.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -127,6 +127,8 @@ If you want to add a new one, start at 273.
 | 150 | Performance | Stats Updated Asynchronously | https://www.BrentOzar.com/go/asyncstats | 17 |
 | 150 | Performance | Triggers on Tables | https://www.BrentOzar.com/go/trig | 32 |
 | 150 | Performance | Inconsistent Query Store metadata |  | 235 |
+| 150 | Performance | Missing Read-Only Routing URL | https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/configure-read-only-routing-for-an-availability-group-sql-server?view=sql-server-ver17#RORReplicaProperties | 273 |
+| 150 | Performance | Missing Read-Only Routing List | https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/configure-read-only-routing-for-an-availability-group-sql-server?view=sql-server-ver17#RORReplicaProperties | 274 |
 | 170 | File Configuration | File growth set to 1MB | https://www.BrentOzar.com/go/percentgrowth | 158 |
 | 170 | File Configuration | File growth set to percent | https://www.BrentOzar.com/go/percentgrowth | 82 |
 | 170 | File Configuration | High VLF Count | https://www.BrentOzar.com/go/vlf | 69 |


### PR DESCRIPTION
# Changes

Added checks for missing read-only routing URL or list. Closes #3749.

Did not intend to add the read-only routing list check. However, the URL I gave mentions it as a requirement to make read-only routing work so there was no reason to not add it. Besides, it is pretty simple.

I was not too sure where to put these checks in the code, but they are near the most relevant check I could find.

My only concern is that this could return a lot of rows if somebody has something extreme like an 8-node cluster hosting 6 different AGs.

# Demo

The change is much shorter than the demo. I promise!

This tests with a clusterless AG on Linux, [as requested](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3749#issuecomment-3566428280).

I have not done any Azure tests and probably cannot.

## Destroy

**Only if you mess up**, clear your screen and destroy the containers.
```powershell
# Think before you run this.
# clear; docker stop 2025box1; docker rm 2025box1; docker stop 2025box2; docker rm 2025box2; docker network rm AgMagic
```

## Setup

To start, we create an environment in the broken way we want. This is PowerShell code using dbatools and Docker. If you already have a disposable AG environment, then all that you need to do is delete the read-only routing lists and URLs for that Availability Group and set a replica to be READ_ONLY when secondary. The names that SSMS uses for this don't match what the DMVs use, so don't worry if you're using the GUI for this and have to guess a bit.

Note the one part you need to change.

```powershell
### vvv YOU NEED TO CHANGE THIS TO POINT TO WHERE YOU HAVE StackOverflow2010.mdf and StackOverflow2010_log.ldf
$StackOverflowDataPath = '/MyStuff/SQL/StackOverflow2010/StackOverflow2010.mdf' ### <--YOU NEED TO CHANGE THIS
$StackOverflowLogPath = '/MyStuff/SQL/StackOverflow2010/StackOverflow2010_log.ldf' ### <--YOU NEED TO CHANGE THIS
### ^^^ YOU NEED TO CHANGE THIS

docker pull mcr.microsoft.com/mssql/server:2025-latest

# I could not get the read-only routing to work without adding IPs.
docker network create --subnet 172.20.0.0/24 AgMagic

docker run -e "ACCEPT_EULA=Y" `
-e "MSSQL_ENABLE_HADR=1" `
-e "MSSQL_AGENT_ENABLED=true" `
-e "MSSQL_SA_PASSWORD=ILuvDbat00ls" `
-p 1501:1433 `
--volume shared:/shared:z `
--name 2025box1 --hostname 2025box1 `
--network AgMagic `
--ip 172.20.0.10 `
-d mcr.microsoft.com/mssql/server:2025-latest

docker run -e "ACCEPT_EULA=Y" `
-e "MSSQL_ENABLE_HADR=1" `
-e "MSSQL_AGENT_ENABLED=true" `
-e "MSSQL_SA_PASSWORD=ILuvDbat00ls" `
-p 1502:1433 `
--volume shared:/shared:z `
--name 2025box2 --hostname 2025box2 `
--network AgMagic `
--ip 172.20.0.20 `
-d mcr.microsoft.com/mssql/server:2025-latest

docker start 2025box1
docker start 2025box2

Start-Sleep 10

docker cp $StackOverflowDataPath 2025box1:/var/opt/mssql/data/StackOverflow2010.mdf
docker cp $StackOverflowLogPath 2025box1:/var/opt/mssql/data/StackOverflow2010_log.ldf

$password = ConvertTo-SecureString "ILuvDbat00ls" -AsPlainText
$cred = [PsCredential]::New("sa", $password)
$primary = Connect-DbaInstance -SqlInstance localhost:1501 -SqlCredential $cred -TrustServerCertificate
$secondary = Connect-DbaInstance -SqlInstance localhost:1502 -SqlCredential $cred -TrustServerCertificate

$fileStructure = New-Object System.Collections.Specialized.StringCollection
$fileStructure.Add("/var/opt/mssql/data/StackOverflow2010.mdf")
$filestructure.Add("/var/opt/mssql/data/StackOverflow2010_log.ldf")
Mount-DbaDatabase -SqlInstance $primary -Database StackOverflow2010 -FileStructure $fileStructure

Set-DbaDbRecoveryModel -SqlInstance $primary -Database StackOverflow2010 -RecoveryModel Full -Confirm:$false

New-DbaDbMasterKey -SqlInstance $primary, $secondary -Credential $cred -Confirm:$false

New-DbaDbCertificate -SqlInstance $primary -Name mirror -Subject mirror -Confirm:$false
$cert = (Backup-DbaDbCertificate -SqlInstance $primary -Suffix $null -Certificate mirror -Path '/shared' -EncryptionPassword $password -Confirm:$false).Path
Restore-DbaDbCertificate -SqlInstance $secondary -Path $cert -DecryptionPassword $password -Confirm:$false

New-DbaEndpoint -SqlInstance $primary, $secondary -Name mirror -Certificate mirror -Port 5022
Start-DbaEndpoint -SqlInstance $primary, $secondary -EndPoint mirror

Backup-DbaDatabase -SqlInstance $primary -Database StackOverflow2010

$params = @{
    Primary = $primary
    Secondary = $secondary
    Name = "test-ag"
    Database = "StackOverflow2010"
    ClusterType = "None"
    SeedingMode = "Automatic"
    FailoverMode = "Manual"
    IPAddress = "172.20.0.10" ### IMPORTANT
    Port = 1434 ### IMPORTANT
    ConnectionModeInSecondaryRole = "AllowReadIntentConnectionsOnly" ### IMPORTANT
    Confirm = $false
 }
New-DbaAvailabilityGroup @params

Get-DbaAgDatabase -SqlInstance $primary
Get-DbaAgDatabase -SqlInstance $secondary
```

If the last two lines weren't a total failure, then we are ready.

<img width="451" height="443" alt="image" src="https://github.com/user-attachments/assets/058cb5bc-8cf0-4162-a935-07a43d0d07f4" />

# Verify Broken State

Now that we have a broken environment, confirm it is broken.

Step one, see what the DMVs say.

```powershell
Invoke-DbaQuery -SqlInstance $primary, $secondary -Query 'SELECT replica_server_name, secondary_role_allow_connections_desc, read_only_routing_url FROM sys.availability_replicas' -AppendServerInstance
```
<img width="1706" height="149" alt="image" src="https://github.com/user-attachments/assets/10d0ad71-8674-488d-b677-7d3d5191628e" />

Good. The column that we want to be blank is blank.

Step two, run a query that should hit the replica, but does not.

```powershell
$listener = Connect-DbaInstance -SqlInstance '172.20.0.10:1434' -SqlCredential $cred -TrustServerCertificate -ApplicationIntent ReadOnly
Invoke-DbaQuery -SqlInstance $listener -Query 'SELECT TOP (2) @@SERVERNAME, DisplayName FROM dbo.Users' -Database StackOverflow2010 -ReadOnly -AppendServerInstance
```
<img width="1368" height="139" alt="image" src="https://github.com/user-attachments/assets/161407b8-69bd-4d96-a217-34474491b641" />

Good. It hit box1, which is the primary.

Step three, make sure my first new `sp_Blitz` check works. You need to install my `sp_blitz`, so change the file path.

```powershell
### vvv YOU NEED TO CHANGE THIS
Invoke-DbaQuery -SqlInstance $primary, $secondary -File '/MyStuff/SQL/SQL-Server-First-Responder-Kit/sp_Blitz.sql'
### ^^^ YOU NEED TO CHANGE THIS
Invoke-DbaQuery -SqlInstance $primary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
Invoke-DbaQuery -SqlInstance $secondary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
```
<img width="1875" height="811" alt="image" src="https://github.com/user-attachments/assets/4f907a5c-b4ea-4f7b-b283-071c457c488e" />

This only fires one of the two new check. This is what we expect. Isn't it nice that PowerShell makes this easy to filter and screenshot?

We can also see that the primary and secondary give the same results. That is good.

# Fix it

Step four, fix the listener halfway, so we fire only the second new check.

```powershell
Set-DbaAgReplica -SqlInstance $primary -AvailabilityGroup test-ag -Replica 2025box1 -ReadonlyRoutingConnectionUrl "TCP://172.20.0.1:1501"
Set-DbaAgReplica -SqlInstance $primary -AvailabilityGroup test-ag -Replica 2025box2 -ReadonlyRoutingConnectionUrl "TCP://172.20.0.1:1502"
```

Step five, check `sp_Blitz` again.

```powershell
Invoke-DbaQuery -SqlInstance $primary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
Invoke-DbaQuery -SqlInstance $secondary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
```
<img width="1813" height="748" alt="image" src="https://github.com/user-attachments/assets/5e82fa17-7c01-4c64-a4de-7ee29085d363" />

This is what we expect.

Step six, fix the listener just a little more.

```powershell
# Dbatools has a bug, so I cannot just set 2025box2 in the routing list. See dbatools issue #9987
# Even what is returned by this is wrong. It reports a blank ReadOnlyRoutingList.
Set-DbaAgReplica -SqlInstance $primary -AvailabilityGroup test-ag -Replica 2025box1 -ReadonlyRoutingList @('2025box2', '2025box1')
```

If the above is right, then my new check should fire only for box2.

Step seven, check `sp_Blitz` again.

```powershell
Invoke-DbaQuery -SqlInstance $primary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
Invoke-DbaQuery -SqlInstance $secondary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
```

<img width="1830" height="408" alt="image" src="https://github.com/user-attachments/assets/b20b7a81-0470-4099-bab0-a05aacdf25aa" />

This is as we expected.

Step eight, fix the listener for the last time.

```powershell
Set-DbaAgReplica -SqlInstance $primary -AvailabilityGroup test-ag -Replica 2025box2 -ReadonlyRoutingList @('2025box1', '2025box2')
```

# Prove it is fixed

Step nine, hit the secondary through the listener.

```powershell
Invoke-DbaQuery -SqlInstance $listener -Query 'SELECT TOP (2) @@SERVERNAME, DisplayName FROM dbo.Users' -Database StackOverflow2010 -ReadOnly -AppendServerInstance
```
<img width="1561" height="114" alt="image" src="https://github.com/user-attachments/assets/63e6fd8c-5242-4f9c-a1a9-53eab8c6f4ff" />

This hits box2, as expected. Recall that we hit box1 when we did this earlier.

Step ten, make sure my new `sp_Blitz` checks do not fire.

```powershell
Invoke-DbaQuery -SqlInstance $primary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
Invoke-DbaQuery -SqlInstance $secondary -Query 'EXEC sp_Blitz' | Where CheckID -in (273,274)
```
<img width="876" height="50" alt="image" src="https://github.com/user-attachments/assets/8b10bc46-fef6-4ea9-a434-ca4df6980bad" />

And we're done!

As a bonus, it is good to know that although [SQL Server 2025 lets us revert to the default `READ_ONLY_ROUTING_URL` of `NONE`](https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/configure-read-only-routing-for-an-availability-group-sql-server?view=sql-server-ver17#revert-to-default-routing-behavior), there are safeguards to prevent us breaking a routing list when we do that.
<img width="1903" height="143" alt="image" src="https://github.com/user-attachments/assets/f39eb2e5-5343-4047-b7cd-d410faae61fe" />

To destroy,
```powershell
# Think before you run this.
# clear; docker stop 2025box1; docker rm 2025box1; docker stop 2025box2; docker rm 2025box2; docker network rm AgMagic
```


