### PR TITLE
3669 sp_BlitzCache AI work continues

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5252,9 +5252,8 @@ Thank you.'
                 
                 IF @Debug = 2
                 BEGIN
-                    SELECT @AIPayload AS AIPayload;
-                    RAISERROR('AI Payload (first 4000 chars):', 0, 1) WITH NOWAIT;
-                    PRINT LEFT(@AIPayload, 4000);
+                    SELECT @CurrentQueryClipped AS CurrentQueryClipped, @AIPayload AS AIPayload, 
+                        LEN(@AIPayload) AS AIPayload_Length, DATALENGTH(@AIPayload) AS AIPayload_DataLength;
                 END;
                 
                 RAISERROR('Calling AI endpoint for query plan analysis on query: ', 0, 1) WITH NOWAIT;


### PR DESCRIPTION
Saves AI data to output tables, easier debugging, skip calls for stored procs with child statements in the result sets, and more. Working on #3669.