### PR TITLE
sp_BlitzLock - fix duplicate plans

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -4316,8 +4316,8 @@ BEGIN
                         ) AS deps
                         WHERE deqs.sql_handle = ap.sql_handle
                         AND   deps.dbid = ap.database_id
-                        AND   deqs.statement_start_offset = ap.stmtstart
-                        AND   deqs.statement_end_offset = ap.stmtend
+                        AND   (ap.stmtstart IS NULL OR deqs.statement_start_offset = ap.stmtstart)
+                        AND   (ap.stmtend   IS NULL OR deqs.statement_end_offset = ap.stmtend)
                     ) AS c
                 ) AS ap
                 WHERE ap.query_plan IS NOT NULL


### PR DESCRIPTION
Fix for #3765 (or at least improvements)

Turns out there are many causes of this:
- if there are many statements in procedure we need to use specific statement start and end columns, otherwise we get something close to cartesian join
- We may get duplicate query plans in #deadlock_results -> I take just max query_xml  and group by rest of the columns. Seemed easiest way to fix for me
- one query can have deadlock on many different tables. This caused same SQL to be reported many times. At least that is my interpretation, because removing dow.object_name on line 4145 (which was unused anyway) and aggregating seemed to fix this particular problem.

In the environment where I saw all these problems the number of rows returned dropped from 10k+ to 60. Much more managable in my opinion.

Thanks