### PR TITLE
sp_Blitz: warn if Automatic Tuning is in a non-default state (closes #3800)

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 274.
-If you want to add a new one, start at 275.
+CURRENT HIGH CHECKID: 275.
+If you want to add a new one, start at 276.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -278,6 +278,7 @@ If you want to add a new one, start at 275.
 | 210 | Non-Default Database Config | Trustworthy Enabled | https://www.BrentOzar.com/go/dbdefaults | 137 |
 | 210 | Non-Default Database Config | Broker Enabled | https://www.BrentOzar.com/go/dbdefaults | 230 |
 | 210 | Non-Default Database Config | Honor Broker Priority Enabled | https://www.BrentOzar.com/go/dbdefaults | 231 |
+| 210 | Non-Default Database Config | Automatic Tuning | https://learn.microsoft.com/en-us/sql/relational-databases/automatic-tuning/automatic-tuning | 275 |
 | 210 | Non-Default Database Scoped Config | MAXDOP | https://www.BrentOzar.com/go/dbscope | 194 |
 | 210 | Non-Default Database Scoped Config | Legacy CE | https://www.BrentOzar.com/go/dbscope | 195 |
 | 210 | Non-Default Database Scoped Config | Parameter Sniffing | https://www.BrentOzar.com/go/dbscope | 196 |


### PR DESCRIPTION
Added check for non-default Automatic Tuning settings. Closes #3800.

Many relevant views not touched, as mentioned on the issue.

Might need a re-design if Microsoft add more than one possible row per database in `sys.database_automatic_tuning_options`. In particular, I am unsure if `'Automatic Tuning'' AS Finding` should have the Automatic Tuning setting's name appended to it or not. This currently isn't an issue because there is only one Automatic Tuning setting.

Adding this was pretty easy, once I realised that I could just copy and paste from the resumable index stuff.

I didn't do much smart to test this. I just ran a bunch of permutation of the below.
```sql
CREATE DATABASE NewDb;

ALTER DATABASE NewDb
SET QUERY_STORE = ON;

ALTER DATABASE NewDb
SET AUTOMATIC_TUNING ( FORCE_LAST_GOOD_PLAN = ON ); 

ALTER DATABASE NewDb
SET QUERY_STORE = OFF;

ALTER DATABASE NewDb
SET AUTOMATIC_TUNING ( FORCE_LAST_GOOD_PLAN = OFF ); 

EXEC sp_blitz;
```

The most interesting case is turning Query Store and Automatic Tuning on, then turning Query Store off. That way, you can make your desired state and actual state mismatch.