### PR TITLE
sp_BlitzIndex: moved ResumableIndexDisappearAfter > 0 block to the State = 1 branch

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -3443,11 +3443,7 @@ BEGIN
                     CONVERT(NVARCHAR(6), CONVERT(MONEY, iro.percent_complete)) + N'% complete after ' +
                     CONVERT(NVARCHAR(30), iro.total_execution_time) +
                     N' minute(s). ' + 
-                    CASE WHEN @ResumableIndexesDisappearAfter > 0
-                        THEN N' Will be automatically removed by the database server at ' + CONVERT(NVARCHAR(50), (DATEADD(mi, @ResumableIndexesDisappearAfter, iro.last_pause_time)), 121) + N'. '
-                        ELSE N' Will not be automatically removed by the database server. '
-                    END
-                    + N'This blocks DDL and can pile up ghosts.'
+                    N'This blocks DDL and can pile up ghosts.'
                 WHEN 1 THEN
                     N' since ' + CONVERT(NVARCHAR(50), iro.last_pause_time, 120) + N'. ' +
                     CONVERT(NVARCHAR(6), CONVERT(MONEY, iro.percent_complete)) + N'% complete' +
@@ -3461,6 +3457,10 @@ BEGIN
                          THEN N'. It is probably still running, perhaps updating statistics.'
                          ELSE N' after ' + CONVERT(NVARCHAR(30), iro.total_execution_time)
                               + N' minute(s). This blocks DDL, fails transactions needing table-level X locks, and can pile up ghosts.'
+                    END +
+                    CASE WHEN @ResumableIndexesDisappearAfter > 0
+                        THEN N' Will be automatically removed by the database server at ' + CONVERT(NVARCHAR(50), (DATEADD(mi, @ResumableIndexesDisappearAfter, iro.last_pause_time)), 121) + N'. '
+                        ELSE N' Will not be automatically removed by the database server. '
                     END
                 ELSE N' which is an undocumented resumable index state description.'
                 END AS details,


### PR DESCRIPTION
Closes #3812. Almost entirely a cut and paste job.

You can run
```sql
CREATE INDEX IX_Baddy
ON StackOverflow2010.dbo.Posts (tags)
INCLUDE (Body)
WITH (FILLFACTOR = 1, ONLINE = ON, RESUMABLE = ON)
```
in one session and
```sql
EXEC sp_BlitzIndex 'StackOverflow2010.dbo.Posts'
```
in another session to replicate this. To see the paused behaviour, cancel the index creation before completion and run `sp_BlitzIndex` again.

Before the change:

<img width="1877" height="241" alt="image" src="https://github.com/user-attachments/assets/04782015-e45d-4e65-8ab6-32f79e375879" />

After the change:

<img width="1874" height="256" alt="image" src="https://github.com/user-attachments/assets/de447f6d-a607-474c-b97e-144a87d239d5" />
