### PR TITLE
#3823 sp_BlitzCache: split AI config into two tables

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -280,7 +280,9 @@ ALTER PROCEDURE dbo.sp_BlitzCache
     @AIModel VARCHAR(200) = NULL, /* Defaults to gpt-4.1-mini */
     @AIURL VARCHAR(200) = NULL, /* Defaults to https://api.openai.com/v1/chat/completions */
     @AICredential VARCHAR(200) = NULL, /* Defaults to 'https://api.openai.com/' or the root of your AIURL, trailing slash included */
-    @AIConfig NVARCHAR(500) = NULL, /* Table where AI config data is stored - can be in the format db.schema.table, schema.table, or just table. */
+    @AIConfig NVARCHAR(500) = NULL, /* Table where AI provider config is stored - can be in the format db.schema.table, schema.table, or just table. */
+    @AIPromptConfig NVARCHAR(500) = NULL, /* Table where AI prompt templates are stored - db.schema.table, schema.table, or just table. */
+    @AIPromptNickname NVARCHAR(200) = NULL, /* Which prompt to use from the prompts table */
 	@Version     VARCHAR(30) = NULL OUTPUT,
 	@VersionDate DATETIME = NULL OUTPUT,
 	@VersionCheckMode BIT = 0,
@@ -870,22 +872,31 @@ BEGIN
    EXEC(@config_sql);
 END;
 
-CREATE TABLE #ai_configuration
+CREATE TABLE #ai_providers
 (Id INT PRIMARY KEY CLUSTERED,
  AI_Model NVARCHAR(100) INDEX AI_Model,
+ Nickname NVARCHAR(200),
  AI_URL NVARCHAR(500),
  AI_Database_Scoped_Credential_Name NVARCHAR(500),
- AI_System_Prompt_Override NVARCHAR(4000),
  AI_Parameters NVARCHAR(4000),
- Payload_Template_Override NVARCHAR(4000),
  Timeout_Seconds TINYINT,
  Context INT,
  DefaultModel BIT DEFAULT 0);
+
+CREATE TABLE #ai_prompts
+(Id INT PRIMARY KEY CLUSTERED,
+ PromptNickname NVARCHAR(200) INDEX IX_PromptNickname,
+ AI_System_Prompt NVARCHAR(4000),
+ Payload_Template NVARCHAR(4000),
+ DefaultPrompt BIT DEFAULT 0);
 
 DECLARE
     @AIConfigDatabaseName NVARCHAR(128) = CASE WHEN @AIConfig IS NULL THEN NULL ELSE PARSENAME(@AIConfig, 3) END,
     @AIConfigSchemaName NVARCHAR(258) = CASE WHEN @AIConfig IS NULL THEN NULL ELSE PARSENAME(@AIConfig, 2) END,
     @AIConfigTableName NVARCHAR(258) = CASE WHEN @AIConfig IS NULL THEN NULL ELSE PARSENAME(@AIConfig, 1) END,
+    @AIPromptDatabaseName NVARCHAR(128) = CASE WHEN @AIPromptConfig IS NULL THEN NULL ELSE PARSENAME(@AIPromptConfig, 3) END,
+    @AIPromptSchemaName NVARCHAR(258) = CASE WHEN @AIPromptConfig IS NULL THEN NULL ELSE PARSENAME(@AIPromptConfig, 2) END,
+    @AIPromptTableName NVARCHAR(258) = CASE WHEN @AIPromptConfig IS NULL THEN NULL ELSE PARSENAME(@AIPromptConfig, 1) END,
     @AISystemPrompt NVARCHAR(4000),
     @AIParameters NVARCHAR(4000),
     @AIPayloadTemplate NVARCHAR(MAX),
@@ -894,15 +905,32 @@ DECLARE
     @AIContext INT;
 
 
+IF @AIPromptConfig IS NOT NULL AND @AIConfig IS NULL
+BEGIN
+    RAISERROR('@AIPromptConfig requires @AIConfig to also be specified.', 12, 1);
+    RETURN;
+END;
+
 IF @AIConfig IS NOT NULL
 BEGIN
-   RAISERROR(N'Reading values from AI Configuration Table', 0, 1) WITH NOWAIT;
-   SET @config_sql = N'INSERT INTO #ai_configuration (Id, AI_Model, AI_URL, AI_Database_Scoped_Credential_Name, AI_System_Prompt_Override, AI_Parameters, Payload_Template_Override, Timeout_Seconds, Context, DefaultModel)
-        SELECT Id, AI_Model, AI_URL, AI_Database_Scoped_Credential_Name, AI_System_Prompt_Override, AI_Parameters, Payload_Template_Override, Timeout_Seconds, Context, DefaultModel FROM '
+   RAISERROR(N'Reading values from AI Provider Configuration Table', 0, 1) WITH NOWAIT;
+   SET @config_sql = N'INSERT INTO #ai_providers (Id, AI_Model, Nickname, AI_URL, AI_Database_Scoped_Credential_Name, AI_Parameters, Timeout_Seconds, Context, DefaultModel)
+        SELECT Id, AI_Model, Nickname, AI_URL, AI_Database_Scoped_Credential_Name, AI_Parameters, Timeout_Seconds, Context, DefaultModel FROM '
         + CASE WHEN @AIConfigDatabaseName IS NOT NULL THEN (QUOTENAME(@AIConfigDatabaseName) + N'.') ELSE N'' END
         + CASE WHEN @AIConfigSchemaName IS NOT NULL THEN (QUOTENAME(@AIConfigSchemaName) + N'.') ELSE N'' END
         + QUOTENAME(@AIConfigTableName) + N' WHERE (@AIModel IS NULL AND DefaultModel = 1) OR @AIModel IN (AI_Model, Nickname) ; ';
    EXEC sp_executesql @config_sql, N'@AIModel NVARCHAR(100)', @AIModel;
+END;
+
+IF @AIPromptConfig IS NOT NULL
+BEGIN
+   RAISERROR(N'Reading values from AI Prompts Table', 0, 1) WITH NOWAIT;
+   SET @config_sql = N'INSERT INTO #ai_prompts (Id, PromptNickname, AI_System_Prompt, Payload_Template, DefaultPrompt)
+        SELECT Id, PromptNickname, AI_System_Prompt, Payload_Template, DefaultPrompt FROM '
+        + CASE WHEN @AIPromptDatabaseName IS NOT NULL THEN (QUOTENAME(@AIPromptDatabaseName) + N'.') ELSE N'' END
+        + CASE WHEN @AIPromptSchemaName IS NOT NULL THEN (QUOTENAME(@AIPromptSchemaName) + N'.') ELSE N'' END
+        + QUOTENAME(@AIPromptTableName) + N' WHERE (@AIPromptNickname IS NULL AND DefaultPrompt = 1) OR @AIPromptNickname = PromptNickname ; ';
+   EXEC sp_executesql @config_sql, N'@AIPromptNickname NVARCHAR(200)', @AIPromptNickname;
 END;
 
 
@@ -913,7 +941,10 @@ IF @AI > 0
     SELECT @ExpertMode = 1, @KeepCRLF = 1;
 
     IF @Debug = 2
-        SELECT N'ai_configuration' AS TableLabel, * FROM #ai_configuration;
+        BEGIN
+        SELECT N'ai_providers' AS TableLabel, * FROM #ai_providers;
+        SELECT N'ai_prompts' AS TableLabel, * FROM #ai_prompts;
+        END
 
     IF @AI = 1 AND NOT EXISTS(SELECT * FROM sys.all_objects WHERE name = 'sp_invoke_external_rest_endpoint')
         BEGIN
@@ -924,28 +955,38 @@ IF @AI > 0
         RAISERROR(N'@AI was set to 1, but sp_invoke_external_rest_endpoint does not exist here, so we can''t call AI services. Setting @AI to 2 instead to just generate prompts.', 0, 1) WITH NOWAIT;
         END
 
+    /* Check the providers table */
     IF @AIModel IS NULL
-        /* Check the config table */
         SELECT TOP 1 @AIModel = AI_Model, @AIURL = AI_URL,
             @AICredential = AI_Database_Scoped_Credential_Name,
-            @AISystemPrompt = AI_System_Prompt_Override,
             @AIParameters = AI_Parameters,
             @AITimeoutSeconds = COALESCE(Timeout_Seconds, 230),
-            @AIContext = Context,
-            @AIPayloadTemplate = Payload_Template_Override
-            FROM #ai_configuration
+            @AIContext = Context
+            FROM #ai_providers
             WHERE DefaultModel = 1
             ORDER BY Id;
     ELSE
-        SELECT TOP 1 @AIModel = AI_Model, 
+        SELECT TOP 1 @AIModel = AI_Model,
             @AIURL = COALESCE(@AIURL, AI_URL),
             @AICredential = COALESCE(@AICredential, AI_Database_Scoped_Credential_Name),
-            @AISystemPrompt = AI_System_Prompt_Override,
             @AIParameters = AI_Parameters,
             @AITimeoutSeconds = COALESCE(Timeout_Seconds, 230),
-            @AIContext = Context,
-            @AIPayloadTemplate = Payload_Template_Override
-            FROM #ai_configuration
+            @AIContext = Context
+            FROM #ai_providers
+            ORDER BY Id;
+
+    /* Check the prompts table */
+    IF @AIPromptNickname IS NULL
+        SELECT TOP 1 @AISystemPrompt = AI_System_Prompt,
+            @AIPayloadTemplate = Payload_Template
+            FROM #ai_prompts
+            WHERE DefaultPrompt = 1
+            ORDER BY Id;
+    ELSE
+        SELECT TOP 1 @AISystemPrompt = AI_System_Prompt,
+            @AIPayloadTemplate = Payload_Template
+            FROM #ai_prompts
+            WHERE PromptNickname = @AIPromptNickname
             ORDER BY Id;
         
     IF @AIModel IS NULL
@@ -1001,6 +1042,12 @@ IF @AI > 0
             SELECT @AIModel AS AIModel, @AIURL AS AIUrl, @AICredential AS AICredential,
                 @AIContext AS AIContext, @AIParameters AS AIParameters, @AITimeoutSeconds AS AITimeoutSeconds,
                 @AISystemPrompt AS AISystemPrompt, @AIPayloadTemplate AS AIPayloadTemplate;
+        END;
+
+    IF @AIPromptNickname IS NOT NULL AND NOT EXISTS (SELECT 1 FROM #ai_prompts WHERE PromptNickname = @AIPromptNickname)
+        BEGIN
+            RAISERROR('@AIPromptNickname was specified but no matching prompt was found in the prompts table.',12,1);
+            RETURN;
         END;
 
     IF @AI = 1 AND (@AIModel IS NULL OR @AIURL IS NULL OR @AISystemPrompt IS NULL OR @AICredential IS NULL OR @AIPayloadTemplate IS NULL)


### PR DESCRIPTION
## Summary
- Split single `#ai_configuration` temp table into `#ai_providers` (provider config) and `#ai_prompts` (prompt templates) to normalize AI configuration
- Added `@AIPromptConfig` parameter for separate prompt table lookup (supports db.schema.table format)
- Added `@AIPromptNickname` parameter to select a specific prompt by name
- Added validation: `@AIPromptConfig` requires `@AIConfig` to also be specified
- Renamed columns: `AI_System_Prompt_Override` → `AI_System_Prompt`, `Payload_Template_Override` → `Payload_Template`
- Added `Nickname` column to providers table and `PromptNickname` column to prompts table

## Test plan
Tested on SQL Server 2025 (RTM-CU2-GDR) Enterprise Developer Edition:

- [x] Basic run (`@AI = 0`) — works normally
- [x] AI prompt-only mode (`@AI = 2`) with no config tables — uses defaults (gpt-5-nano, default system prompt)
- [x] Two-table config with default prompt — loads provider and default prompt from separate tables
- [x] Two-table config with `@AIPromptNickname` — loads correct named prompt
- [x] Debug mode (`@Debug = 2`) — shows both `#ai_providers` and `#ai_prompts` contents
- [x] Validation: `@AIPromptConfig` without `@AIConfig` — raises error as expected
- [x] Provider-only config (no prompt table) — loads provider, falls back to default system prompt

Closes #3823

🤖 Generated with [Claude Code](https://claude.com/claude-code)