### PR TITLE
Add error handling for missing @AIModel in @AIConfigTable

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -917,8 +917,20 @@ BEGIN
         SELECT Id, AI_Model, AI_URL, AI_Database_Scoped_Credential_Name, AI_Parameters, Payload_Template, Timeout_Seconds, Context, DefaultModel FROM '
         + CASE WHEN @AIConfigDatabaseName IS NOT NULL THEN (QUOTENAME(@AIConfigDatabaseName) + N'.') ELSE N'' END
         + CASE WHEN @AIConfigSchemaName IS NOT NULL THEN (QUOTENAME(@AIConfigSchemaName) + N'.') ELSE N'' END
-        + QUOTENAME(@AIConfigTableName) + N' WHERE (@AIModel IS NULL AND DefaultModel = 1) OR @AIModel = AI_Model ; ';
+        + QUOTENAME(@AIConfigTableName) + N' WHERE DefaultModel = 1 OR @AIModel = AI_Model ; ';
    EXEC sp_executesql @config_sql, N'@AIModel NVARCHAR(100)', @AIModel;
+END;
+
+IF @AIModel IS NOT NULL AND @AIConfigTable IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM #ai_providers WHERE AI_Model = @AIModel)
+BEGIN
+    DECLARE @AIModelRequested NVARCHAR(200) = @AIModel;
+    DECLARE @AIFallbackModel NVARCHAR(200);
+    SELECT TOP 1 @AIFallbackModel = AI_Model FROM #ai_providers WHERE DefaultModel = 1 ORDER BY Id;
+    IF @AIFallbackModel IS NULL SET @AIFallbackModel = N'gpt-5-nano';
+    RAISERROR('@AIModel "%s" was not found in configuration table %s. Using "%s" instead.',
+        10, 1, @AIModelRequested, @AIConfigTable, @AIFallbackModel) WITH NOWAIT;
+    SET @AIModel = NULL;
 END;
 
 IF @AIPromptConfigTable IS NOT NULL
@@ -974,6 +986,7 @@ IF @AI > 0
             @AITimeoutSeconds = COALESCE(Timeout_Seconds, 230),
             @AIContext = Context
             FROM #ai_providers
+            WHERE AI_Model = @AIModel
             ORDER BY Id;
 
     /* Check the prompts table */

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1031,8 +1031,20 @@ BEGIN
         SELECT Id, AI_Model, AI_URL, AI_Database_Scoped_Credential_Name, AI_Parameters, Payload_Template, Timeout_Seconds, Context, DefaultModel FROM '
         + CASE WHEN @AIConfigDatabaseName IS NOT NULL THEN (QUOTENAME(@AIConfigDatabaseName) + N'.') ELSE N'' END
         + CASE WHEN @AIConfigSchemaName IS NOT NULL THEN (QUOTENAME(@AIConfigSchemaName) + N'.') ELSE N'' END
-        + QUOTENAME(@AIConfigTableName) + N' WHERE (@AIModel IS NULL AND DefaultModel = 1) OR @AIModel = AI_Model ; ';
+        + QUOTENAME(@AIConfigTableName) + N' WHERE DefaultModel = 1 OR @AIModel = AI_Model ; ';
    EXEC sp_executesql @config_sql, N'@AIModel NVARCHAR(100)', @AIModel;
+END;
+
+IF @AIModel IS NOT NULL AND @AIConfigTable IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM #ai_providers WHERE AI_Model = @AIModel)
+BEGIN
+    DECLARE @AIModelRequested NVARCHAR(200) = @AIModel;
+    DECLARE @AIFallbackModel NVARCHAR(200);
+    SELECT TOP 1 @AIFallbackModel = AI_Model FROM #ai_providers WHERE DefaultModel = 1 ORDER BY Id;
+    IF @AIFallbackModel IS NULL SET @AIFallbackModel = N'gpt-5-nano';
+    RAISERROR('@AIModel "%s" was not found in configuration table %s. Using "%s" instead.',
+        10, 1, @AIModelRequested, @AIConfigTable, @AIFallbackModel) WITH NOWAIT;
+    SET @AIModel = NULL;
 END;
 
 IF @AIPromptConfigTable IS NOT NULL
@@ -1083,6 +1095,7 @@ IF @AI > 0
             @AITimeoutSeconds = COALESCE(Timeout_Seconds, 230),
             @AIContext = Context
             FROM #ai_providers
+            WHERE AI_Model = @AIModel
             ORDER BY Id;
 
     /* Check the prompts table */


### PR DESCRIPTION
## Summary
- When `@AIModel` is specified but not found in `@AIConfigTable`, `sp_BlitzCache` and `sp_BlitzIndex` now raise an informational message (severity 10) naming the requested model, the config table searched, and the fallback model being used
- The fallback model is the table's `DefaultModel` row if one exists, otherwise the hard-coded `gpt-5-nano`
- Also filters the ELSE provider lookup to prefer the exact model match, preventing accidental selection of the DefaultModel row when the requested model IS found

## Test plan
- [ ] Call `sp_BlitzCache` with `@AIModel = 'nonexistent'` and a valid `@AIConfigTable` that has a DefaultModel — verify warning names the default model
- [ ] Same test with a config table that has no DefaultModel — verify warning says `gpt-5-nano`
- [ ] Call with a valid `@AIModel` that exists in the table — verify no warning and correct model is used
- [ ] Call with `@AIModel = NULL` — verify DefaultModel is loaded silently as before

Fixes #3839

🤖 Generated with [Claude Code](https://claude.com/claude-code)