### PR TITLE
#3736 Add JSON index support in sp_BlitzIndex

### DIFF
--- a/Documentation/sp_BlitzIndex_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzIndex_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 128
-If you want to add a new check, start at 129.
+CURRENT HIGH CHECKID: 129
+If you want to add a new check, start at 130.
 
 | Priority | FindingsGroup           | Finding                                                         | URL                                                                                            | CheckID |
 | -------- | ----------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------- |
@@ -47,6 +47,7 @@ If you want to add a new check, start at 129.
 | 150      | Abnormal Design Pattern | In-Memory OLTP                                                  | https://www.brentozar.com/go/AbnormalPsychology                                                | 73      |
 | 150      | Abnormal Design Pattern | Non-Aligned Index on a Partitioned Table                        | https://www.brentozar.com/go/AbnormalPsychology                                                | 65      |
 | 150      | Abnormal Design Pattern | Partitioned Index                                               | https://www.brentozar.com/go/AbnormalPsychology                                                | 64      |
+| 150      | Abnormal Design Pattern | JSON Index                                                      | https://www.brentozar.com/go/AbnormalPsychology                                                | 129     |
 | 150      | Abnormal Design Pattern | Spatial Index                                                   | https://www.brentozar.com/go/AbnormalPsychology                                                | 62      |
 | 150      | Abnormal Design Pattern | XML Index                                                       | https://www.brentozar.com/go/AbnormalPsychology                                                | 60      |
 | 150      | Over-Indexing           | Approximate: Wide Indexes (7 or More Columns)                   | https://www.brentozar.com/go/IndexHoarder                                                      | 23      |

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -5895,7 +5895,7 @@ BEGIN
                     SELECT  129 AS check_id,
                             i.index_sanity_id,
                             150 AS Priority,
-                            N'Feature-Dependent Indexes' AS findings_group,
+                            N'Abnormal Design Pattern' AS findings_group,
                             N'JSON Index' AS finding,
                             [database_name] AS [Database Name],
                             N'https://www.brentozar.com/go/AbnormalPsychology' AS URL,


### PR DESCRIPTION
## Summary
- **JSON index sizes**: Query `sys.internal_tables` with `internal_type_desc = 'JSON_INDEX_TABLE'` joined to `sys.dm_db_partition_stats` to get row counts and size (reserved, LOB, row overflow MB) for JSON indexes, populating the existing `index_size_summary` column
- **JSON index column names**: Populate `key_column_names` for JSON indexes (which have `key_ordinal = 0` in `sys.index_columns`, so the standard column name logic skips them)
- **Usage summary**: Show "Not Tracked" for JSON indexes since `sys.dm_db_index_usage_stats` doesn't track them (similar to spatial indexes)
- **Inactive index filter fix**: Prevent JSON indexes from being filtered out when `@IncludeInactiveIndexes = 0`, since they have no usage stats
- **Check_id 129**: Report JSON indexes as "Feature-Dependent Indexes" (like spatial indexes get check_id 62), at Priority 150
- **Create TSQL**: Generate `CREATE JSON INDEX` statements for JSON indexes
- **Drop TSQL**: Already worked with no changes needed

## Test plan
- [ ] Run `sp_BlitzIndex @DatabaseName = 'StackOverflow', @SchemaName = 'dbo', @TableName = 'Users_JSON_Indexed'` and verify JSON index shows size, column name, create TSQL, and drop TSQL
- [ ] Run `sp_BlitzIndex @DatabaseName = 'StackOverflow'` in mode 0 and verify check_id 129 appears for JSON indexes
- [ ] Verify JSON indexes are not filtered out when `@IncludeInactiveIndexes = 0`
- [ ] Test on a database with no JSON indexes to confirm no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)