### PR TITLE
sp_BlitzCache: return oversized plans inline instead of manual query fallback

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5115,7 +5115,7 @@ SET
     b.Warnings = 'We couldn''t find a plan for this query. More info on possible reasons: https://www.brentozar.com/go/noplans'
 FROM ##BlitzCacheProcs AS b
 WHERE b.QueryPlan IS NULL
-AND   b.Warnings IS NULL
+AND   (b.Warnings IS NULL OR b.Warnings = '')
 AND   b.SPID = @@SPID
 OPTION (RECOMPILE);			  
 


### PR DESCRIPTION
## Summary
- Fixes #3868 — when a plan exceeds 128 levels of XML nesting, `QueryPlan` is now populated with the text plan wrapped in an XML processing instruction (same technique as sp_QuickieStore) instead of staying NULL with a "run this query yourself" warning
- Uses `StatementStartOffset`/`StatementEndOffset` for statement-level plan retrieval instead of hardcoded `0, -1`
- Splits truly missing plans (encrypted, evicted) into a separate UPDATE, fixing an unreachable `ISNULL` branch

## Test plan
- [x] Deployed and executed on SQL2016, SQL2017, SQL2019, SQL2022, SQL2025
- [ ] Test with an actual >128 nesting level plan to confirm the processing instruction is clickable in SSMS and saveable as .sqlplan

🤖 Generated with [Claude Code](https://claude.com/claude-code)