### PR TITLE
sp_Blitz: drop pre-2016 support and modernize code

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -956,7 +956,14 @@ BEGIN
 
 		DROP TABLE IF EXISTS #DatabaseScopedConfigurationDefaults;
 		CREATE TABLE #DatabaseScopedConfigurationDefaults
-			(ID INT IDENTITY(1,1), configuration_id INT, [name] NVARCHAR(60), default_value sql_variant, default_value_for_secondary sql_variant, CheckID INT, );
+			(
+			  ID INT IDENTITY(1,1),
+			  configuration_id INT,
+			  [name] NVARCHAR(60),
+			  default_value sql_variant,
+			  default_value_for_secondary sql_variant,
+			  CheckID INT
+			);
 
 		DROP TABLE IF EXISTS #DBCCs;
 		CREATE TABLE #DBCCs
@@ -10529,7 +10536,7 @@ IF NOT EXISTS ( SELECT  1
 	DROP TABLE IF EXISTS #AlertInfo;
 
 	/*
-	Reset the Nmumeric_RoundAbort session state back to enabled if it was disabled earlier. 
+	Reset the Numeric_RoundAbort session state back to enabled if it was disabled earlier. 
 	See Github issue #2302 for more info.
 	*/
 	IF @NeedToTurnNumericRoundabortBackOn = 1


### PR DESCRIPTION
## Summary

Closes #3872. Following the sp_BlitzCache modernization in #3870, this applies the same treatment to sp_Blitz.

- Add version gate before procedure creation to reject pre-2016 servers, with Azure SQL DB/MI bypass
- Replace ~27 `IF OBJECT_ID/DROP TABLE` patterns with `DROP TABLE IF EXISTS`
- Remove ~25 always-true version guards (`@@VERSION NOT LIKE '%2005%'`, `@ProductVersionMajor >= 10/11/12`)
- Remove ~200 lines of dead pre-2016 code (pre-2012 #LogInfo, memory clerk `single_pages_kb` paths, SQL 2005 procedure cache block, CheckIDs 129 & 157, dead trace flag branches)
- Simplify CheckID 128 to only check versions 13+
- Rename `#LogInfo2012` to `#LogInfo`
- Simplify remote login timeout default

**Net: 120 insertions, 404 deletions.**

Preserved: `dm_os_host_info` fallback (SQL 2016 needs it), compat level < 90 checks, FOR XML PATH (STRING_AGG is 2017+), all 2016+ CU checks, Azure handling.

## Test plan

- [x] Deployed to SQL Server 2025 Developer Edition and ran `EXEC sp_Blitz @CheckServerInfo = 1, @CheckProcedureCache = 1` - completed successfully with findings
- [x] Verified `@VersionCheckMode = 1` returns version 8.30
- [ ] Test on SQL Server 2016 instance
- [ ] Test on Azure SQL DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)