### PR TITLE
sp_BlitzWho: drop pre-2016 support and modernize code

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -1,3 +1,32 @@
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET STATISTICS IO OFF;
+SET STATISTICS TIME OFF;
+GO
+
+IF (
+SELECT
+  CASE
+     WHEN CAST(SERVERPROPERTY('EngineEdition') AS INT) IN (5, 6, 8) THEN 1 /* Azure SQL DB, MI, Synapse */
+     WHEN CONVERT(NVARCHAR(128), SERVERPROPERTY ('PRODUCTVERSION')) LIKE '8%' THEN 0
+     WHEN CONVERT(NVARCHAR(128), SERVERPROPERTY ('PRODUCTVERSION')) LIKE '9%' THEN 0
+     WHEN CONVERT(NVARCHAR(128), SERVERPROPERTY ('PRODUCTVERSION')) LIKE '10%' THEN 0
+     WHEN CONVERT(NVARCHAR(128), SERVERPROPERTY ('PRODUCTVERSION')) LIKE '11%' THEN 0
+     WHEN CONVERT(NVARCHAR(128), SERVERPROPERTY ('PRODUCTVERSION')) LIKE '12%' THEN 0
+	 ELSE 1
+  END
+) = 0
+BEGIN
+	DECLARE @msg VARCHAR(8000);
+	SELECT @msg = 'Sorry, sp_BlitzWho doesn''t work on versions of SQL prior to 2016.' + REPLICATE(CHAR(13), 7933);
+	PRINT @msg;
+	RETURN;
+END;
+
 IF OBJECT_ID('dbo.sp_BlitzWho') IS NULL
 	EXEC ('CREATE PROCEDURE dbo.sp_BlitzWho AS RETURN 0;')
 GO
@@ -54,8 +83,7 @@ versions for free, watch training videos on how it works, get more info on
 the findings, contribute your own code, and more.
 
 Known limitations of this version:
- - Only Microsoft-supported versions of SQL Server. Sorry, 2005 and 2000.
- - Outputting to table is only supported with SQL Server 2012 and higher.
+ - Only SQL Server 2016 and newer. Sorry, 2014 and earlier.
  - If @OutputDatabaseName and @OutputSchemaName are populated, the database and
    schema must already exist. We will not create them, only the table.
    
@@ -88,15 +116,12 @@ END;    /* @Help = 1 */
 DECLARE  @ProductVersion NVARCHAR(128) = CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128))
 		,@EngineEdition INT = CAST(SERVERPROPERTY('EngineEdition') AS INT)
 		,@ProductVersionMajor DECIMAL(10,2)
-		,@ProductVersionMinor DECIMAL(10,2)
 		,@Platform NVARCHAR(8) /* Azure or NonAzure are acceptable */ = (SELECT CASE WHEN @@VERSION LIKE '%Azure%' THEN N'Azure' ELSE N'NonAzure' END AS [Platform])
 		,@AzureSQLDB BIT = (SELECT CASE WHEN SERVERPROPERTY('EngineEdition') = 5 THEN 1 ELSE 0 END)
 		,@CanReadMSDB BIT = (SELECT COUNT(1) FROM fn_my_permissions(N'msdb.dbo.sysjobs', N'OBJECT') AS fmp WHERE fmp.permission_name = N'SELECT')
-		,@EnhanceFlag BIT = 0
 		,@BlockingCheck NVARCHAR(MAX)
 		,@StringToExecute NVARCHAR(MAX)
 		,@OutputTableCleanupDate DATE
-		,@SessionWaits BIT = 0
 		,@SessionWaitsSQL NVARCHAR(MAX) = 
 						 N'LEFT JOIN ( SELECT DISTINCT
 												wait.session_id ,
@@ -124,8 +149,7 @@ DECLARE  @ProductVersion NVARCHAR(128) = CAST(SERVERPROPERTY('ProductVersion') A
 /* Let's get @SortOrder set to lower case here for comparisons later */
 SET @SortOrder = REPLACE(LOWER(@SortOrder), N' ', N'_');
 
-SELECT @ProductVersionMajor = SUBSTRING(@ProductVersion, 1,CHARINDEX('.', @ProductVersion) + 1 ),
-    @ProductVersionMinor = PARSENAME(CONVERT(VARCHAR(32), @ProductVersion), 2)
+SELECT @ProductVersionMajor = SUBSTRING(@ProductVersion, 1,CHARINDEX('.', @ProductVersion) + 1 )
 
 SELECT
 	@OutputTableNameQueryStats_View = QUOTENAME(PARSENAME(@OutputTableName,1) + '_Deltas'),
@@ -573,8 +597,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 
  END
 
- IF OBJECT_ID('tempdb..#WhoReadableDBs') IS NOT NULL 
-	DROP TABLE #WhoReadableDBs;
+ DROP TABLE IF EXISTS #WhoReadableDBs;
 
 CREATE TABLE #WhoReadableDBs 
 (
@@ -613,64 +636,7 @@ SELECT @BlockingCheck = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 						FROM sys.sysprocesses AS sys1
 						JOIN sys.sysprocesses AS sys2
 						ON sys1.spid = sys2.blocked;
-						'+CASE
-							WHEN (@GetOuterCommand = 1 AND (NOT EXISTS(SELECT 1 FROM sys.all_objects WHERE [name] = N'dm_exec_input_buffer'))) THEN N'
-						DECLARE @session_id SMALLINT;
-						DECLARE @Sessions TABLE 
-						(
-							session_id INT
-						);
-
-						DECLARE @inputbuffer TABLE 
-						(
-						ID INT IDENTITY(1,1),
-						session_id INT,
-						event_type	NVARCHAR(30),
-						parameters	SMALLINT,
-						event_info	NVARCHAR(4000)
-						);
-
-						DECLARE inputbuffer_cursor
-						
-						CURSOR LOCAL FAST_FORWARD
-						FOR 
-						SELECT session_id
-						FROM sys.dm_exec_sessions
-						WHERE session_id <> @@SPID
-						AND is_user_process = 1;
-						
-						OPEN inputbuffer_cursor;
-						
-						FETCH NEXT FROM inputbuffer_cursor INTO @session_id;
-						
-						WHILE (@@FETCH_STATUS = 0)
-						BEGIN;
-							BEGIN TRY;
-
-								INSERT INTO @inputbuffer ([event_type],[parameters],[event_info])
-								EXEC sp_executesql
-									N''DBCC INPUTBUFFER(@session_id) WITH NO_INFOMSGS;'',
-									N''@session_id SMALLINT'',
-									@session_id;
-						
-								UPDATE @inputbuffer 
-								SET session_id = @session_id 
-								WHERE ID = SCOPE_IDENTITY();
-
-							END TRY
-							BEGIN CATCH
-								RAISERROR(''DBCC inputbuffer failed for session %d'',0,0,@session_id) WITH NOWAIT;
-							END CATCH;
-						
-							FETCH NEXT FROM inputbuffer_cursor INTO @session_id
-						
-						END;
-						
-						CLOSE inputbuffer_cursor;
-						DEALLOCATE inputbuffer_cursor;'
-						ELSE N''
-						END+
-						N' 
+						'+N'
 
 						DECLARE @LiveQueryPlans TABLE
 						(
@@ -690,230 +656,10 @@ BEGIN
 END
 
 
-IF @ProductVersionMajor > 9 and @ProductVersionMajor < 11
-BEGIN
-    /* Think of the StringToExecute as starting with this, but we'll set this up later depending on whether we're doing an insert or a select:
-    SELECT @StringToExecute = N'SELECT  GETDATE() AS run_date ,
-    */
-    SET @StringToExecute = N' CASE WHEN YEAR(s.last_request_start_time) = 1900 THEN NULL ELSE COALESCE( RIGHT(''00'' + CONVERT(VARCHAR(20), (ABS(r.total_elapsed_time) / 1000) / 86400), 2) + '':'' + CONVERT(VARCHAR(20), (DATEADD(SECOND, (r.total_elapsed_time / 1000), 0) + DATEADD(MILLISECOND, (r.total_elapsed_time % 1000), 0)), 114), RIGHT(''00'' + CONVERT(VARCHAR(20), DATEDIFF(SECOND, s.last_request_start_time, GETDATE()) / 86400), 2) + '':'' + CONVERT(VARCHAR(20), DATEADD(SECOND, DATEDIFF(SECOND, s.last_request_start_time, GETDATE()), 0), 114) ) END AS [elapsed_time] ,
-			       s.session_id ,
-					CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
-							THEN r.blocking_session_id
-							WHEN r.blocking_session_id <> 0 AND s.session_id <> blocked.blocking_session_id 
-							THEN blocked.blocking_session_id
-							WHEN r.blocking_session_id = 0 AND s.session_id = blocked.session_id 
-							THEN blocked.blocking_session_id
-							WHEN r.blocking_session_id <> 0 AND s.session_id = blocked.blocking_session_id 
-							THEN r.blocking_session_id
-							ELSE NULL 
-						END AS blocking_session_id,
-						    COALESCE(DB_NAME(r.database_id), DB_NAME(blocked.dbid), ''N/A'') AS database_name,
-			       ISNULL(SUBSTRING(dest.text,
-			            ( r.statement_start_offset / 2 ) + 1,
-			            ( ( CASE r.statement_end_offset
-			               WHEN -1 THEN DATALENGTH(dest.text)
-			               ELSE r.statement_end_offset
-			             END - r.statement_start_offset )
-			              / 2 ) + 1), dest.text) AS query_text ,
-						  '+CASE
-								WHEN @GetOuterCommand = 1 THEN N'CAST(event_info AS NVARCHAR(4000)) AS outer_command,'
-							ELSE N''
-							END+N'
-			       derp.query_plan ,
-						    qmg.query_cost ,										   		   
-						    s.status ,
-							CASE
-								WHEN s.status <> ''sleeping'' THEN COALESCE(wt.wait_info, RTRIM(blocked.lastwaittype) + '' ('' + CONVERT(VARCHAR(10), blocked.waittime) + '')'' ) 
-								ELSE NULL
-							END AS wait_info ,																					
-							r.wait_resource ,
-			       COALESCE(r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,
-						    CASE WHEN EXISTS (  SELECT 1 
-               FROM sys.dm_tran_active_transactions AS tat
-               JOIN sys.dm_tran_session_transactions AS tst
-               ON tst.transaction_id = tat.transaction_id
-               WHERE tat.name = ''implicit_transaction''
-               AND s.session_id = tst.session_id 
-               )  THEN 1 
-            ELSE 0 
-          END AS is_implicit_transaction ,
-					     s.nt_domain ,
-			       s.host_name ,
-			       s.login_name ,
-			       s.nt_user_name ,'
-		IF @Platform = 'NonAzure' AND @CanReadMSDB = 1
-		BEGIN
-		SET @StringToExecute +=
-				   N'program_name = COALESCE((
-					SELECT REPLACE(program_name,Substring(program_name,30,34),''"''+j.name+''"'') 
-					FROM msdb.dbo.sysjobs j WHERE Substring(program_name,32,32) = CONVERT(char(32),CAST(j.job_id AS binary(16)),2)
-					),s.program_name)'
-		END
-		ELSE
-		BEGIN
-		SET @StringToExecute += N's.program_name'
-		END
-						
-    IF @ExpertMode = 1
-    BEGIN
-    SET @StringToExecute += 
-			   N',
-						''DBCC FREEPROCCACHE ('' + CONVERT(NVARCHAR(128), r.plan_handle, 1) + '');'' AS fix_parameter_sniffing,						      		
-			   s.client_interface_name ,
-			   s.login_time ,
-			   r.start_time ,
-			   qmg.request_time ,
-						COALESCE(r.cpu_time, s.cpu_time) AS request_cpu_time,
-			   COALESCE(r.logical_reads, s.logical_reads) AS request_logical_reads,
-			   COALESCE(r.writes, s.writes) AS request_writes,
-			   COALESCE(r.reads, s.reads) AS request_physical_reads ,
-			   s.cpu_time AS session_cpu,
-			   s.logical_reads AS session_logical_reads,
-			   s.reads AS session_physical_reads ,
-			   s.writes AS session_writes,					
-						tempdb_allocations.tempdb_allocations_mb,
-			   s.memory_usage ,
-			   r.estimated_completion_time , 	
-						r.percent_complete , 
-			   r.deadlock_priority ,
-			   CASE 
-			     WHEN s.transaction_isolation_level = 0 THEN ''Unspecified''
-			     WHEN s.transaction_isolation_level = 1 THEN ''Read Uncommitted''
-			     WHEN s.transaction_isolation_level = 2 AND EXISTS (SELECT 1 FROM sys.databases WHERE name = DB_NAME(r.database_id) AND is_read_committed_snapshot_on = 1) THEN ''Read Committed Snapshot Isolation''
-			     WHEN s.transaction_isolation_level = 2 THEN ''Read Committed''
-			     WHEN s.transaction_isolation_level = 3 THEN ''Repeatable Read''
-			     WHEN s.transaction_isolation_level = 4 THEN ''Serializable''
-			     WHEN s.transaction_isolation_level = 5 THEN ''Snapshot''
-			     ELSE ''WHAT HAVE YOU DONE?''
-			   END AS transaction_isolation_level ,				
-						qmg.dop AS degree_of_parallelism ,
-			   COALESCE(CAST(qmg.grant_time AS VARCHAR(20)), ''N/A'') AS grant_time ,
-			   qmg.requested_memory_kb ,
-			   qmg.granted_memory_kb AS grant_memory_kb,
-			   CASE WHEN qmg.grant_time IS NULL THEN ''N/A''
-        WHEN qmg.requested_memory_kb < qmg.granted_memory_kb
-			     THEN ''Query Granted Less Than Query Requested''
-			     ELSE ''Memory Request Granted''
-			   END AS is_request_granted ,
-			   qmg.required_memory_kb ,
-			   qmg.used_memory_kb AS query_memory_grant_used_memory_kb,
-			   qmg.ideal_memory_kb ,
-			   qmg.is_small ,
-			   qmg.timeout_sec ,
-			   qmg.resource_semaphore_id ,
-			   COALESCE(CAST(qmg.wait_order AS VARCHAR(20)), ''N/A'') AS wait_order ,
-			   COALESCE(CAST(qmg.wait_time_ms AS VARCHAR(20)),
-			      ''N/A'') AS wait_time_ms ,
-			   CASE qmg.is_next_candidate
-			     WHEN 0 THEN ''No''
-			     WHEN 1 THEN ''Yes''
-			     ELSE ''N/A''
-			   END AS next_candidate_for_memory_grant ,
-			   qrs.target_memory_kb ,
-			   COALESCE(CAST(qrs.max_target_memory_kb AS VARCHAR(20)),
-			      ''Small Query Resource Semaphore'') AS max_target_memory_kb ,
-			   qrs.total_memory_kb ,
-			   qrs.available_memory_kb ,
-			   qrs.granted_memory_kb ,
-			   qrs.used_memory_kb AS query_resource_semaphore_used_memory_kb,
-			   qrs.grantee_count ,
-			   qrs.waiter_count ,
-			   qrs.timeout_error_count ,
-			   COALESCE(CAST(qrs.forced_grant_count AS VARCHAR(20)),
-			      ''Small Query Resource Semaphore'') AS forced_grant_count,
-						wg.name AS workload_group_name , 
-						rp.name AS resource_pool_name,
- 						CONVERT(VARCHAR(128), r.context_info)  AS context_info
-						'
-	END /* IF @ExpertMode = 1 */
-				
-    SET @StringToExecute += 			 
-	    N'FROM sys.dm_exec_sessions AS s
-			 '+
-			 CASE
-				WHEN @GetOuterCommand = 1 THEN CASE
-													WHEN EXISTS(SELECT 1 FROM sys.all_objects WHERE [name] = N'dm_exec_input_buffer') THEN N'OUTER APPLY sys.dm_exec_input_buffer (s.session_id, 0) AS ib'
-													ELSE N'LEFT JOIN @inputbuffer ib ON s.session_id = ib.session_id'
-												END
-				ELSE N''
-			 END+N'
-			 LEFT JOIN sys.dm_exec_requests AS r
-			 ON   r.session_id = s.session_id
-			 LEFT JOIN ( SELECT DISTINCT
-			      wait.session_id ,
-			      ( SELECT waitwait.wait_type + N'' (''
-			         + CAST(MAX(waitwait.wait_duration_ms) AS NVARCHAR(128))
-			         + N'' ms) ''
-			        FROM   sys.dm_os_waiting_tasks AS waitwait
-			        WHERE  waitwait.session_id = wait.session_id
-			        GROUP BY  waitwait.wait_type
-			        ORDER BY  SUM(waitwait.wait_duration_ms) DESC
-			      FOR
-			        XML PATH('''') ) AS wait_info
-			    FROM sys.dm_os_waiting_tasks AS wait ) AS wt
-			 ON   s.session_id = wt.session_id
-			 LEFT JOIN sys.dm_exec_query_stats AS query_stats
-			 ON   r.sql_handle = query_stats.sql_handle
-						AND r.plan_handle = query_stats.plan_handle
-			   AND r.statement_start_offset = query_stats.statement_start_offset
-			   AND r.statement_end_offset = query_stats.statement_end_offset
-			 LEFT JOIN sys.dm_exec_query_memory_grants qmg
-			 ON   r.session_id = qmg.session_id
-						AND r.request_id = qmg.request_id
-			 LEFT JOIN sys.dm_exec_query_resource_semaphores qrs
-			 ON   qmg.resource_semaphore_id = qrs.resource_semaphore_id
-					 AND qmg.pool_id = qrs.pool_id
-				LEFT JOIN sys.resource_governor_workload_groups wg 
-				ON 		s.group_id = wg.group_id
-				LEFT JOIN sys.resource_governor_resource_pools rp 
-				ON		wg.pool_id = rp.pool_id
-				OUTER APPLY (
-								SELECT TOP 1
-								b.dbid, b.last_batch, b.open_tran, b.sql_handle, 
-								b.session_id, b.blocking_session_id, b.lastwaittype, b.waittime
-								FROM @blocked b
-								WHERE (s.session_id = b.session_id
-										OR s.session_id = b.blocking_session_id)
-							) AS blocked				
-				OUTER APPLY sys.dm_exec_sql_text(COALESCE(r.sql_handle, blocked.sql_handle)) AS dest
-			 OUTER APPLY sys.dm_exec_query_plan(r.plan_handle) AS derp
-				OUTER APPLY (
-						SELECT CONVERT(DECIMAL(38,2), SUM( ((((tsu.user_objects_alloc_page_count - user_objects_dealloc_page_count) + (tsu.internal_objects_alloc_page_count - internal_objects_dealloc_page_count)) * 8) / 1024.)) ) AS tempdb_allocations_mb
-						FROM sys.dm_db_task_space_usage tsu
-						WHERE tsu.request_id = r.request_id
-						AND tsu.session_id = r.session_id
-						AND tsu.session_id = s.session_id
-				) as tempdb_allocations
-			 WHERE s.session_id <> @@SPID 
-				AND s.host_name IS NOT NULL
-				'
-				+ CASE WHEN @ShowSleepingSPIDs = 0 THEN
-						N' AND COALESCE(DB_NAME(r.database_id), DB_NAME(blocked.dbid)) IS NOT NULL'
-					  WHEN @ShowSleepingSPIDs = 1 THEN
-						N' AND (COALESCE(DB_NAME(r.database_id), DB_NAME(blocked.dbid)) IS NOT NULL OR COALESCE(r.open_transaction_count, blocked.open_tran) >= 1)'
-					 ELSE N'' END;
-END /* IF @ProductVersionMajor > 9 and @ProductVersionMajor < 11 */
-
-IF @ProductVersionMajor >= 11 
-    BEGIN
-    SELECT @EnhanceFlag = 
-	     CASE WHEN @ProductVersionMajor = 11 AND @ProductVersionMinor >= 6020 THEN 1
-		      WHEN @ProductVersionMajor = 12 AND @ProductVersionMinor >= 5000 THEN 1
-		      WHEN @ProductVersionMajor = 13 AND	@ProductVersionMinor >= 1601 THEN 1
-			     WHEN @ProductVersionMajor > 13 THEN 1
-		      ELSE 0 
-	     END
-
-
-    IF OBJECT_ID('sys.dm_exec_session_wait_stats') IS NOT NULL
-    BEGIN
-	    SET @SessionWaits = 1
-    END
-
-    /* Think of the StringToExecute as starting with this, but we'll set this up later depending on whether we're doing an insert or a select:
-    SELECT @StringToExecute = N'SELECT  GETDATE() AS run_date ,
-    */
-    SELECT @StringToExecute = N' CASE WHEN YEAR(s.last_request_start_time) = 1900 THEN NULL ELSE COALESCE( RIGHT(''00'' + CONVERT(VARCHAR(20), (ABS(r.total_elapsed_time) / 1000) / 86400), 2) + '':'' + CONVERT(VARCHAR(20), (DATEADD(SECOND, (r.total_elapsed_time / 1000), 0) + DATEADD(MILLISECOND, (r.total_elapsed_time % 1000), 0)), 114), RIGHT(''00'' + CONVERT(VARCHAR(20), DATEDIFF(SECOND, s.last_request_start_time, GETDATE()) / 86400), 2) + '':'' + CONVERT(VARCHAR(20), DATEADD(SECOND, DATEDIFF(SECOND, s.last_request_start_time, GETDATE()), 0), 114) ) END AS [elapsed_time] ,
+/* Think of the StringToExecute as starting with this, but we'll set this up later depending on whether we're doing an insert or a select:
+SELECT @StringToExecute = N'SELECT  GETDATE() AS run_date ,
+*/
+SELECT @StringToExecute = N' CASE WHEN YEAR(s.last_request_start_time) = 1900 THEN NULL ELSE COALESCE( RIGHT(''00'' + CONVERT(VARCHAR(20), (ABS(r.total_elapsed_time) / 1000) / 86400), 2) + '':'' + CONVERT(VARCHAR(20), (DATEADD(SECOND, (r.total_elapsed_time / 1000), 0) + DATEADD(MILLISECOND, (r.total_elapsed_time % 1000), 0)), 114), RIGHT(''00'' + CONVERT(VARCHAR(20), DATEDIFF(SECOND, s.last_request_start_time, GETDATE()) / 86400), 2) + '':'' + CONVERT(VARCHAR(20), DATEADD(SECOND, DATEDIFF(SECOND, s.last_request_start_time, GETDATE()), 0), 114) ) END AS [elapsed_time] ,
 			       s.session_id ,
 					CASE WHEN r.blocking_session_id <> 0 AND blocked.session_id IS NULL 
 					THEN r.blocking_session_id
@@ -965,10 +711,7 @@ IF @ProductVersionMajor >= 11
 					END AS wait_info ,
 					r.wait_resource ,'
 						    +
-						    CASE @SessionWaits
-							     WHEN 1 THEN + N'SUBSTRING(wt2.session_wait_info, 0, LEN(wt2.session_wait_info) ) AS top_session_waits ,'
-							     ELSE N' NULL AS top_session_waits ,'
-						    END
+						    N'SUBSTRING(wt2.session_wait_info, 0, LEN(wt2.session_wait_info) ) AS top_session_waits ,'
 						    +																	
 						    N'COALESCE(r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,
 						    CASE WHEN EXISTS (  SELECT 1 
@@ -1029,9 +772,7 @@ IF @ProductVersionMajor >= 11
 	        ELSE ''WHAT HAVE YOU DONE?''
         END AS transaction_isolation_level ,
 		        qmg.dop AS degree_of_parallelism ,						'
-		        + 
-		        CASE @EnhanceFlag
-				        WHEN 1 THEN N'query_stats.last_dop,
+		        + N'query_stats.last_dop,
         query_stats.min_dop,
         query_stats.max_dop,
         query_stats.last_grant_kb,
@@ -1049,25 +790,6 @@ IF @ProductVersionMajor >= 11
         query_stats.last_used_threads,
         query_stats.min_used_threads,
         query_stats.max_used_threads,'
-				        ELSE N' NULL AS last_dop,
-        NULL AS min_dop,
-        NULL AS max_dop,
-        NULL AS last_grant_kb,
-        NULL AS min_grant_kb,
-        NULL AS max_grant_kb,
-        NULL AS last_used_grant_kb,
-        NULL AS min_used_grant_kb,
-        NULL AS max_used_grant_kb,
-        NULL AS last_ideal_grant_kb,
-        NULL AS min_ideal_grant_kb,
-        NULL AS max_ideal_grant_kb,
-        NULL AS last_reserved_threads,
-        NULL AS min_reserved_threads,
-        NULL AS max_reserved_threads,
-        NULL AS last_used_threads,
-        NULL AS min_used_threads,
-        NULL AS max_used_threads,'
-		        END 
 
         SET @StringToExecute += 						
 		        N'
@@ -1114,12 +836,8 @@ IF @ProductVersionMajor >= 11
     SET @StringToExecute += 	
 	    N' FROM sys.dm_exec_sessions AS s'+
 			 CASE
-				WHEN @GetOuterCommand = 1 THEN CASE
-													WHEN EXISTS(SELECT 1 FROM sys.all_objects WHERE [name] = N'dm_exec_input_buffer') THEN N'
+				WHEN @GetOuterCommand = 1 THEN N'
 		OUTER APPLY sys.dm_exec_input_buffer (s.session_id, 0) AS ib'
-													ELSE N'
-		LEFT JOIN @inputbuffer ib ON s.session_id = ib.session_id'
-											   END
 				ELSE N''
 			 END+N'
 	    LEFT JOIN sys.dm_exec_requests AS r
@@ -1144,11 +862,8 @@ IF @ProductVersionMajor >= 11
 		    AND r.statement_end_offset = query_stats.statement_end_offset
 	    '
 	    +
-	    CASE @SessionWaits
-			    WHEN 1 THEN @SessionWaitsSQL
-			    ELSE N''
-	    END
-	    + 
+	    @SessionWaitsSQL
+	    +
 	    N'
 	    LEFT JOIN sys.dm_exec_query_memory_grants qmg
 	    ON   r.session_id = qmg.session_id
@@ -1199,8 +914,6 @@ IF @ProductVersionMajor >= 11
 			    N' AND (COALESCE(DB_NAME(r.database_id), DB_NAME(blocked.dbid)) IS NOT NULL OR COALESCE(r.open_transaction_count, blocked.open_tran) >= 1)'
 			    ELSE N'' END;
 
-
-END /* IF @ProductVersionMajor >= 11  */
 
 IF (@MinElapsedSeconds + @MinCPUTime + @MinLogicalReads + @MinPhysicalReads + @MinWrites + @MinTempdbMB + @MinRequestedMemoryKB + @MinBlockingSeconds) > 0
 	BEGIN
@@ -1278,15 +991,16 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	,[database_name]
 	,[query_text]'
 	+ CASE WHEN @GetOuterCommand = 1 THEN N',[outer_command]' ELSE N'' END + N'
-	,[query_plan]'
-    + CASE WHEN @ProductVersionMajor >= 11 THEN N',[live_query_plan]' ELSE N'' END 
-	+ CASE WHEN @ProductVersionMajor >= 11 THEN N',[cached_parameter_info]'  ELSE N'' END
-	+ CASE WHEN @ProductVersionMajor >= 11 AND @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
+	,[query_plan]
+	,[live_query_plan]
+	,[cached_parameter_info]'
+	+ CASE WHEN @ShowActualParameters = 1 THEN N',[Live_Parameter_Info]' ELSE N'' END + N'
 	,[query_cost]
 	,[status]
 	,[wait_info]
-	,[wait_resource]'
-    + CASE WHEN @ProductVersionMajor >= 11 THEN N',[top_session_waits]' ELSE N'' END + N'
+	,[wait_resource]
+	,[top_session_waits]'
+	+ N'
 	,[open_transaction_count]
 	,[is_implicit_transaction]
 	,[nt_domain]
@@ -1313,8 +1027,7 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	,[percent_complete]
 	,[deadlock_priority]
 	,[transaction_isolation_level]
-	,[degree_of_parallelism]'
-    + CASE WHEN @ProductVersionMajor >= 11 THEN N'
+	,[degree_of_parallelism]
 	,[last_dop]
 	,[min_dop]
 	,[max_dop]
@@ -1332,7 +1045,8 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	,[max_reserved_threads]
 	,[last_used_threads]
 	,[min_used_threads]
-	,[max_used_threads]' ELSE N'' END + N'
+	,[max_used_threads]'
+	+ N'
 	,[grant_time]
 	,[requested_memory_kb]
 	,[grant_memory_kb]
@@ -1358,14 +1072,14 @@ IF @OutputDatabaseName IS NOT NULL AND @OutputSchemaName IS NOT NULL AND @Output
 	,[forced_grant_count]
 	,[workload_group_name]
 	,[resource_pool_name]
-	,[context_info]'
-    + CASE WHEN @ProductVersionMajor >= 11 THEN N'
+	,[context_info]
 	,[query_hash]
 	,[query_plan_hash]
 	,[sql_handle]
 	,[plan_handle]
 	,[statement_start_offset]
-	,[statement_end_offset]' ELSE N'' END + N'
+	,[statement_end_offset]'
+	+ N'
 ) 
 	SELECT @@SERVERNAME, COALESCE(@CheckDateOverride, SYSDATETIMEOFFSET()) AS CheckDate , '
 	+ @StringToExecute;
@@ -1374,11 +1088,7 @@ ELSE
 	SET @StringToExecute = @BlockingCheck + N' SELECT  GETDATE() AS run_date , ' + @StringToExecute;
 
 /* If the server has > 50GB of memory, add a max grant hint to avoid getting a giant grant */
-IF (   (@ProductVersionMajor = 11 AND @ProductVersionMinor >= 6020)
-    OR (@ProductVersionMajor = 12 AND @ProductVersionMinor >= 5000 )
-    OR (@ProductVersionMajor >= 13 )
-   )
-    AND 50000000 < (SELECT cntr_value
+IF 50000000 < (SELECT cntr_value
 						FROM sys.dm_os_performance_counters
 						WHERE object_name LIKE '%:Memory Manager%'
 						AND counter_name LIKE 'Target Server Memory (KB)%')


### PR DESCRIPTION
## Summary
Closes #3874. Follows the same modernization pattern as #3872 (sp_Blitz) and #3870 (sp_BlitzCache).

- Add version gate before procedure creation (reject pre-2016, bypass Azure SQL DB/MI/Synapse)
- Add standard session settings header (`SET ANSI_NULLS ON`, etc.)
- Delete entire SQL Server 2008 R2/2010 code branch (~200 lines of dead code)
- Remove DBCC INPUTBUFFER cursor fallback (~55 lines) — `sys.dm_exec_input_buffer` always exists on 2016+
- Remove `@EnhanceFlag` variable — enhanced query stats columns are now unconditional
- Remove `@SessionWaits` variable — `sys.dm_exec_session_wait_stats` join is now unconditional
- Remove `@ProductVersionMinor` — no longer referenced after above simplifications
- Strip always-true `@ProductVersionMajor >= 11` guards from output column mapping
- Simplify memory grant hint to just the memory threshold check (remove version check)
- Replace `IF OBJECT_ID('tempdb..#X') IS NOT NULL DROP TABLE #X` with `DROP TABLE IF EXISTS #X`
- Update help text to reflect 2016+ minimum

Net result: **-346 lines, +56 lines** (~21% reduction) with no functional change for SQL Server 2016+ users.

### What's preserved
- `@ProductVersionMajor` — still used for `@GetLiveQueryPlan` default (>= 16 check)
- `@SessionWaitsSQL` — holds the JOIN fragment, now always used
- Runtime check for `dm_hadr_database_replica_states` — feature-dependent (Always On), not version-dependent
- Runtime check for `dm_exec_query_statistics_xml` — depends on `@GetLiveQueryPlan` parameter

## Test plan
- [ ] Run `EXEC sp_BlitzWho;` on SQL Server 2016+
- [ ] Run `EXEC sp_BlitzWho @ExpertMode = 1, @GetOuterCommand = 1;`
- [ ] Verify output table mode with `@OutputDatabaseName`, `@OutputSchemaName`, `@OutputTableName`
- [ ] Verify on Azure SQL DB (version gate bypass)
- [ ] Attempt install on pre-2016 instance to confirm version gate blocks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)