### PR TITLE
sp_BlitzIndex: drop pre-2016 support and modernize code (#3876)

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1466,16 +1466,6 @@ BEGIN TRY
         DECLARE @d VARCHAR(19) = CONVERT(VARCHAR(19), GETDATE(), 121);
         RAISERROR (N'starting at %s',0,1, @d) WITH NOWAIT;
 
-        --Validate SQL Server Version
-
-        IF (SELECT LEFT(@SQLServerProductVersion,
-              CHARINDEX('.',@SQLServerProductVersion,0)-1
-              )) <= 12
-        BEGIN
-            SET @msg=N'sp_BlitzIndex is only supported on SQL Server 2016 and higher. The version of this instance is: ' + @SQLServerProductVersion;
-            RAISERROR(@msg,16,1);
-        END;
-
         --Short circuit here if database name does not exist.
         IF @DatabaseName IS NULL OR @DatabaseID IS NULL
         BEGIN


### PR DESCRIPTION
## Summary
- Add pre-procedure version gate rejecting SQL Server versions prior to 2016 (allows Azure SQL DB, MI, Synapse)
- Replace 27 `IF OBJECT_ID/DROP TABLE` patterns with `DROP TABLE IF EXISTS`
- Remove 8 `NOT LIKE '9%'` version checks for columns that always exist in 2016+ (`is_sparse`, `is_filestream`, `filter_definition`, `data_compression_desc`, `has_filter`)
- Remove 3 `PARSENAME > 12` checks for features always available in 2016+ (`min_grant_percent`, `hobt_id`)
- Remove the entire old statistics branch (~90 lines) using deprecated `sysindexes`/`STATS_DATE()` syntax
- Remove version guards for computed columns (`>= 10`) and temporal tables (`>= 13`)
- Update inner version gate from SQL 2008 to SQL 2016 minimum

Follows the same pattern as #3872 (sp_Blitz) and #3874 (sp_BlitzWho).

Preserved: `@OptimizeForSequentialKey` (SQL 2019+), `sys.index_resumable_operations` (SQL 2017+), columnstore dynamic detection, `persisted_sample_percent`/`is_incremental` detection, and the 2147483647 performance tuning toggle.

Closes #3876

## Test plan
- [ ] Compile the procedure on SQL Server 2016, 2017, 2019, and 2022 instances
- [ ] Run with `@Mode = 0` (Diagnose), `@Mode = 1` (Summarize), `@Mode = 2` (Index Usage Detail), `@Mode = 3` (Missing Index Detail), `@Mode = 4` (Diagnose Details)
- [ ] Run with `@SkipStatistics = 0` to exercise the statistics code path
- [ ] Run with `@SkipPartitions = 0` to exercise partition code
- [ ] Run with `@ShowColumnstoreOnly = 1` on a table with columnstore indexes
- [ ] Verify the pre-procedure gate returns the correct error message on SQL 2014

🤖 Generated with [Claude Code](https://claude.com/claude-code)