### PR TITLE
sp_BlitzCache: per-database plan cache findings (#3878)

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1326,10 +1326,11 @@ DROP TABLE IF EXISTS #missing_index_usage;
 DROP TABLE IF EXISTS #missing_index_detail;
 DROP TABLE IF EXISTS #missing_index_pretty;
 DROP TABLE IF EXISTS #index_spool_ugly;
-	
 DROP TABLE IF EXISTS #ReadableDBs;
 DROP TABLE IF EXISTS #plan_usage;
-
+DROP TABLE IF EXISTS #plan_usage_by_database;
+DROP TABLE IF EXISTS #plan_cache_by_db;
+	
 CREATE TABLE #only_query_hashes (
     query_hash BINARY(8)
 );


### PR DESCRIPTION
## Summary
- Add per-database breakdown of single-use and duplicate plan findings so users can immediately identify which database(s) are polluting the plan cache, rather than only seeing server-wide totals
- Refactor plan cache analysis to materialize `dm_exec_query_stats` + `dm_exec_plan_attributes` into a temp table once, eliminating repeated DMV scans (5 passes down to 1)
- New CheckID 1001 (per-database duplicate plans) and 1002 (per-database single-use plans) with a 10% per-database threshold, separate from the existing 5% server-wide threshold

## Example output

| Priority | Finding | Details |
|----------|---------|---------|
| 254 | Duplicate Plans | Server-wide: 2,199 plans, 13% duplicates |
| 254 | Duplicate Plans In PerformanceMonitor | 540 plans, 38% duplicates |
| 254 | Duplicate Plans In msdb | 320 plans, 23% duplicates |
| 254 | Single-Use Plans | Server-wide: 2,199 plans, 32% single-use |
| 1 | Many Single-Use Plans In tempdb | 13 plans, 92% single-use |
| 254 | Single-Use Plans In master | 277 plans, 51% single-use |

## Test plan
- [x] Clean install on SQL Server 2016
- [x] Clean install on SQL Server 2017
- [x] Clean install on SQL Server 2022
- [x] Verified server-wide findings unchanged (CheckID 999)
- [x] Verified per-database findings appear with correct database names
- [x] Verified priority escalation (>75% = Priority 1)
- [x] Verified plan cache age finding still works from materialized temp table

Closes #3878

🤖 Generated with [Claude Code](https://claude.com/claude-code)