### PR TITLE
Fix sp_kill README docs to match proc behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ EXEC sp_kill @SPID = 55, @ExecuteKills = 'Y';
 
 /* Kill sleeping sessions with open transactions idle for 5+ minutes: */
 EXEC sp_kill @HasOpenTran = 'Y', @SPIDState = 'S',
-    @RequestsOlderThanMinutes = 5, @ExecuteKills = 'Y';
+    @RequestsOlderThanSeconds = 300, @ExecuteKills = 'Y';
 
 /* Show what we'd kill for a login, sorted by CPU: */
 EXEC sp_kill @LoginName = 'DOMAIN\TroublesomeUser', @OrderBy = 'cpu';
@@ -358,7 +358,7 @@ EXEC sp_kill @LoginName = 'DOMAIN\TroublesomeUser', @OrderBy = 'cpu';
 
 Parameters for targeting sessions:
 
-* @ExecuteKills = 'Y' or 'N' (default 'N') - whether to actually kill, or just show recommendations. When set to 'Y', you must also specify at least one targeting filter to prevent accidentally killing everything.
+* @ExecuteKills = 'Y' or 'N' (default 'N') - whether to actually kill, or just show recommendations. When set to 'Y' with no targeting filters, all non-system sessions are killed - so always specify at least one filter to avoid killing everything.
 * @SPID - target a specific session ID.
 * @LoginName - kill sessions belonging to this login.
 * @AppName - kill sessions from this application (supports LIKE wildcards).
@@ -366,9 +366,9 @@ Parameters for targeting sessions:
 * @HostName - kill sessions from this host.
 * @LeadBlockers = 'Y' - kill only lead blockers (sessions blocking others but not blocked themselves).
 * @ReadOnly = 'Y' - only kill read-only queries (SELECTs with no writes).
-* @SPIDState - 'S' for sleeping sessions only, 'R' for running only, empty string for both (default).
+* @SPIDState - 'S' for sleeping sessions only, 'R' for running only, NULL for both (default).
 * @HasOpenTran = 'Y' - only target sessions with open transactions. Combine with @SPIDState = 'S' to catch sleeping sessions with forgotten transactions.
-* @RequestsOlderThanMinutes - only target sessions whose last request started at least this many minutes ago.
+* @RequestsOlderThanSeconds - only target sessions whose last request started at least this many seconds ago.
 * @OmitLogin - exclude sessions belonging to this login from kill recommendations.
 * @OrderBy - sort order for kill recommendations: duration (default), cpu, reads, writes, tempdb, transactions. Useful when you want to kill the worst offenders one by one.
 


### PR DESCRIPTION
## Summary
Addresses Copilot review feedback from #3885 (sp_kill docs only — sp_BlitzLock feedback will be handled separately):

- **`@RequestsOlderThanMinutes` → `@RequestsOlderThanSeconds`**: The example used a parameter name that doesn't exist in the proc. Fixed to `@RequestsOlderThanSeconds = 300`.
- **`@SPIDState` default**: Docs said "empty string for both" but the proc validates `NULL/S/R` and raises an error on empty string. Fixed to "NULL for both (default)".
- **`@ExecuteKills` safety claim**: Docs said a targeting filter is *required* with `@ExecuteKills = 'Y'`, but the proc doesn't enforce that — it kills all non-system sessions when no filters are specified. Updated wording to accurately describe the behavior as a warning rather than a false constraint.

## Test plan
- [ ] Verify README parameter names match `sp_kill.sql` parameter declarations
- [ ] Verify example code runs without error against the proc signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)