### PR TITLE
Add CheckID 276: AG Not Fully Configured

### DIFF
--- a/Documentation/sp_Blitz_Checks_by_Priority.md
+++ b/Documentation/sp_Blitz_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, URL, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 275.
-If you want to add a new one, start at 276.
+CURRENT HIGH CHECKID: 276.
+If you want to add a new one, start at 277.
 
 | Priority | FindingsGroup | Finding | URL | CheckID |
 |----------|-----------------------------|---------------------------------------------------------|------------------------------------------------------------------------|----------|
@@ -300,6 +300,7 @@ If you want to add a new one, start at 276.
 | 240 | Wait Stats | No Significant Waits Detected | https://www.BrentOzar.com/go/waits | 153 |
 | 240 | Wait Stats | Top Wait Stats | https://www.BrentOzar.com/go/waits | 152 |
 | 240 | Wait Stats | Wait Stats Have Been Cleared | https://www.BrentOzar.com/go/waits | 185 |
+| 250 | Informational | AG Not Fully Configured | https://www.BrentOzar.com/go/ag | 276 |
 | 250 | Informational | SQL Server Agent is running under an NT Service account | https://www.BrentOzar.com/go/setup | 170 |
 | 250 | Informational | SQL Server is running under an NT Service account | https://www.BrentOzar.com/go/setup | 169 |
 | 250 | Server Info | Agent is Currently Offline |  | 167 |

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -10036,6 +10036,34 @@ IF NOT EXISTS ( SELECT  1
 
 
 
+					/* Check if AG is enabled at server level but no databases are in an AG */
+					IF NOT EXISTS ( SELECT  1
+									FROM    #SkipChecks
+									WHERE   DatabaseName IS NULL AND CheckID = 276 )
+						BEGIN
+							IF SERVERPROPERTY('IsHadrEnabled') = 1
+								AND NOT EXISTS ( SELECT 1 FROM sys.databases WHERE replica_id IS NOT NULL )
+								BEGIN
+
+									IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 276) WITH NOWAIT;
+
+									INSERT  INTO #BlitzResults
+											( CheckID ,
+											  Priority ,
+											  FindingsGroup ,
+											  Finding ,
+											  URL ,
+											  Details
+											)
+									SELECT  276 AS CheckID ,
+											250 AS Priority ,
+											'Informational' AS FindingsGroup ,
+											'AG Not Fully Configured' AS Finding ,
+											'https://www.BrentOzar.com/go/ag' AS URL ,
+											'Availability Groups is turned on at the server level, but no databases are in an Availability Group.' AS Details;
+								END;
+						END;
+
 					END; /* IF @CheckServerInfo = 1 */
 			END; /* IF ( ( SERVERPROPERTY('ServerName') NOT IN ( SELECT ServerName */
 


### PR DESCRIPTION
Closes #3830

## Summary
- Adds CheckID 276 to `sp_Blitz.sql`: fires at priority 250 (Informational) when `SERVERPROPERTY('IsHadrEnabled') = 1` but no databases have a `replica_id` set in `sys.databases` — meaning AG is enabled at the server level but no databases are actually in an AG
- Only runs when `@CheckServerInfo = 1`, consistent with other informational checks
- Supports the standard `#SkipChecks` mechanism
- Adds the check to `Documentation/sp_Blitz_Checks_by_Priority.md` and bumps the current high CheckID to 276

## Test plan
- [ ] Run `EXEC dbo.sp_Blitz @CheckServerInfo = 1;` on a server with HADR enabled but no AG databases — should see the new finding
- [ ] Run on a server with no HADR enabled — finding should not appear
- [ ] Run on a server with HADR enabled and databases in an AG — finding should not appear
- [ ] Confirm finding is suppressible via `#SkipChecks` with `CheckID = 276`

🤖 Generated with [Claude Code](https://claude.com/claude-code)