### PR TITLE
sp_BlitzCache: speed up @SlowlySearchPlansFor by skipping the XML cast

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -2129,7 +2129,10 @@ IF @SlowlySearchPlansFor IS NOT NULL
     BEGIN
     RAISERROR(N'Setting string search for @SlowlySearchPlansFor, so remember, this is gonna be slow', 0, 1) WITH NOWAIT;
     SET @SlowlySearchPlansFor = REPLACE((REPLACE((REPLACE((REPLACE(@SlowlySearchPlansFor, N'[', N'_')), N']', N'_')), N'^', N'_')), N'''', N'''''');
-    SET @body_where += N'       AND CAST(qp.query_plan AS NVARCHAR(MAX)) LIKE N''%' + @SlowlySearchPlansFor + N'%'' ' + @nl;
+    /* Search against sys.dm_exec_text_query_plan, which returns NVARCHAR(MAX) directly
+       and skips the per-row XML-to-string cast that CAST(qp.query_plan AS NVARCHAR(MAX)) pays.
+       Issue #3936. */
+    SET @body_where += N'       AND tqp.query_plan LIKE N''%' + @SlowlySearchPlansFor + N'%'' ' + @nl;
     END
 
 
@@ -2182,6 +2185,13 @@ SET @body += N') AS qs
        CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
        CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
        CROSS APPLY sys.dm_exec_query_plan(qs.plan_handle) AS qp ' + @nl ;
+
+IF @SlowlySearchPlansFor IS NOT NULL
+    BEGIN
+    /* Only pay for the text plan when the user is actually searching strings.
+       Issue #3936. */
+    SET @body += N'     CROSS APPLY sys.dm_exec_text_query_plan(qs.plan_handle, 0, -1) AS tqp ' + @nl ;
+    END
 
 IF @VersionShowsAirQuoteActualPlans = 1
     BEGIN


### PR DESCRIPTION
## Summary

- Switches the `@SlowlySearchPlansFor` predicate from `CAST(qp.query_plan AS NVARCHAR(MAX)) LIKE ...` to `tqp.query_plan LIKE ...`, where `tqp` comes from `sys.dm_exec_text_query_plan(qs.plan_handle, 0, -1)`. That DMV returns the plan as `NVARCHAR(MAX)` directly, skipping the per-row XML-to-string cast that dominated the search cost.
- The extra `CROSS APPLY` is only added when `@SlowlySearchPlansFor` is set, so runs that don't use the parameter pay nothing.
- The existing `qp` (XML) apply stays in place because the rest of sp_BlitzCache still needs it for `.exist()` / `.value()` shredding and for `@NoobSaibot`.

Fixes #3936.

## Test plan

- [ ] Install the updated `sp_BlitzCache.sql` on a test instance.
- [ ] Run `EXEC sp_BlitzCache @SlowlySearchPlansFor = 'SomeIndexName';` and confirm it still returns the same rows as the previous version.
- [ ] Run `EXEC sp_BlitzCache @SlowlySearchPlansFor = 'SomeIndexName', @ExpertMode = 1;` and compare wall-clock duration against the previous version on a cache with a few thousand plans — should be noticeably faster.
- [ ] Run `EXEC sp_BlitzCache;` with no search parameter and confirm no behavior change (the extra `CROSS APPLY` should not appear in the generated SQL).
- [ ] Run `EXEC sp_BlitzCache @NoobSaibot = 1;` to confirm the XML `.exist()` path still works (it relies on the unchanged `qp` apply).
- [ ] Spot-check the generated SQL via `@Debug = 1` to confirm `tqp` only appears when the search parameter is supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)