### PR TITLE
sp_ineachdb: support Azure SQL DB as sp_MSforeachdb drop-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,47 @@ For information about how this works, see [Tara Kizer's white paper on Log Shipp
 
 
 
+## sp_ineachdb: Run a Command in Each Database
+
+`sp_ineachdb` is a drop-in replacement for the undocumented `sp_MSforeachdb` with saner filtering and error handling. Pass a command string using `?` as a placeholder for the database name:
+
+```tsql
+EXEC sp_ineachdb @command = N'SELECT DB_NAME() AS db, COUNT(*) AS tables FROM [?].sys.tables;';
+```
+
+Useful parameters:
+
+* `@command` - the T-SQL to run. `?` (or whatever you set `@replace_character` to) gets replaced with the quoted database name.
+* `@database_list`, `@exclude_list` - comma-separated lists of databases to include or exclude. Bracket-quote names that contain special characters.
+* `@name_pattern`, `@exclude_pattern` - LIKE patterns applied to database names.
+* `@system_only`, `@user_only` - limit to system DBs (master/model/msdb/tempdb/distribution) or user DBs.
+* `@recovery_model_desc`, `@compatibility_level`, `@is_read_only`, `@is_auto_close_on`, `@is_auto_shrink_on`, `@is_broker_enabled`, `@is_query_store_on`, `@user_access`, `@state_desc` - filter by database property.
+* `@is_ag_writeable_copy = 1` - skip Availability Group secondaries.
+* `@print_dbname`, `@print_command`, `@print_command_only`, `@select_dbname` - diagnostics for debugging your command string without running it.
+
+### Azure SQL DB support
+
+Azure SQL DB forbids cross-database calls and 3-part object names, so "run in each database" collapses to "run in the current database" (Azure SQL DB sessions are bound to one user database anyway). `sp_ineachdb` detects Azure SQL DB via `SERVERPROPERTY('EngineEdition') = 5` and adapts automatically:
+
+* Seeds the database list with just the current database.
+* Executes `@command` via `EXEC sys.sp_executesql` instead of a 3-part dynamic call.
+* Rewrites common `sp_MSforeachdb`-style patterns in `@command` so they don't have to be changed:
+  * `USE [?];` and `USE ?;` (with or without brackets or semicolons) are stripped - you can't change database context in Azure SQL DB.
+  * `[?].schema.object` and `?.schema.object` are collapsed to `schema.object`, turning 3-part names into 2-part names.
+
+This means callers that already work with `sp_MSforeachdb` on box SQL (like `sp_Blitz` internals) can call `sp_ineachdb` on Azure SQL DB and Just Work.
+
+**Things to look out for on Azure SQL DB:**
+
+* **Placeholders inside string literals get rewritten too.** `PRINT 'See [?].sys.tables'` will have `[?].` stripped out - avoid putting the placeholder inside quoted strings. (This caveat also applies to box SQL, since `@command` text substitution happens everywhere.)
+* **Non-canonical whitespace isn't matched.** `USE  [?];` (double space) or `[?] . sys . tables` (spaces between name parts) won't be rewritten. Stick to the canonical `USE [?];` and `[?].sys.tables` forms.
+* **Managed Instance is not affected.** Azure SQL Managed Instance reports `EngineEdition = 8` and supports cross-database calls, so it uses the same code path as box SQL.
+* **Filter parameters still apply** - the current database is added to the list, then the usual `@name_pattern`, `@user_only`, property filters, etc. can still exclude it. If nothing matches, you get the normal `No databases to process.` message.
+
+[*Back to top*](#header1)
+
+
+
 ## Parameters Common to Many of the Stored Procedures
 
 * @Help = 1 - returns a result set or prints messages explaining the stored procedure's input and output. Make sure to check the Messages tab in SSMS to read it.

--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -105,7 +105,27 @@ BEGIN
           @cr     char(2) = CHAR(13) + CHAR(10),
 		  @SQLVersion	AS tinyint = (@@microsoftversion / 0x1000000) & 0xff,	     -- Stores the SQL Server Version Number(8(2000),9(2005),10(2008 & 2008R2),11(2012),12(2014),13(2016),14(2017),15(2019)
 		  @ServerName	AS sysname = CONVERT(sysname, SERVERPROPERTY('ServerName')), -- Stores the SQL Server Instance name.
-		  @NoSpaces nvarchar(20) = N'%[^' + CHAR(9) + CHAR(32) + CHAR(10) + CHAR(13) + N']%'; --Pattern for PATINDEX
+		  @NoSpaces nvarchar(20) = N'%[^' + CHAR(9) + CHAR(32) + CHAR(10) + CHAR(13) + N']%', --Pattern for PATINDEX
+		  @IsAzureSqlDb bit = CASE WHEN CONVERT(int, SERVERPROPERTY('EngineEdition')) = 5 THEN 1 ELSE 0 END;
+
+  /* Azure SQL DB forbids cross-database calls and 3-part names. Rewrite the
+     incoming @command so sp_MSforeachdb-style inputs work unchanged:
+       - strip USE [?]; / USE ?; variants (can't change database context)
+       - collapse [?].schema.object / ?.schema.object to schema.object
+     Force CI collation so USE/Use/use all match regardless of server collation. */
+  IF @IsAzureSqlDb = 1 AND @command IS NOT NULL
+  BEGIN
+    DECLARE @rc nvarchar(10) = @replace_character;
+
+    SET @command = REPLACE(@command COLLATE SQL_Latin1_General_CP1_CI_AS, N'USE [' + @rc + N'];', N'');
+    SET @command = REPLACE(@command COLLATE SQL_Latin1_General_CP1_CI_AS, N'USE [' + @rc + N']',  N'');
+    SET @command = REPLACE(@command COLLATE SQL_Latin1_General_CP1_CI_AS, N'USE '  + @rc + N';',  N'');
+    SET @command = REPLACE(@command COLLATE SQL_Latin1_General_CP1_CI_AS, N'USE '  + @rc,         N'');
+
+    /* Bracketed form first — otherwise '?.' would turn '[?].' into '[]'. */
+    SET @command = REPLACE(@command COLLATE SQL_Latin1_General_CP1_CI_AS, N'[' + @rc + N'].', N'');
+    SET @command = REPLACE(@command COLLATE SQL_Latin1_General_CP1_CI_AS, @rc + N'.',         N'');
+  END
 
 
   CREATE TABLE #ineachdb(id int, name nvarchar(512), is_distributor bit);
@@ -162,7 +182,16 @@ BEGIN
 3)If we find a [, we begin to accumulate the result until we reach closing ], (jumping over escaped ]]).
 4)Finally, tabs, line breaks and spaces are removed from unquoted names
 */
-WITH C
+IF @IsAzureSqlDb = 1
+BEGIN
+  /* Azure SQL DB: the session is bound to one user database. Seed with it and
+     let the downstream filter DELETEs decide whether it survives. */
+  INSERT #ineachdb(id, name, is_distributor)
+  SELECT DB_ID(), DB_NAME(), 0;
+END
+ELSE
+BEGIN
+;WITH C
 AS (SELECT V.SrcList
          , CAST('' AS nvarchar(MAX)) AS Name
          , V.DBList
@@ -213,6 +242,7 @@ WHERE (   EXISTS (SELECT NULL FROM F WHERE F.name = d.name AND F.SrcList = 'In')
           OR @database_list IS NULL)
       AND NOT EXISTS (SELECT NULL FROM F WHERE F.name = d.name AND F.SrcList = 'Out')
 OPTION (MAXRECURSION 0);
+END
 ;
   -- next, let's delete any that *don't* match various criteria passed in
   DELETE dbs FROM #ineachdb AS dbs
@@ -356,8 +386,16 @@ OPTION (MAXRECURSION 0);
 
       IF COALESCE(@print_command_only,0) = 0
       BEGIN
-        SET @exec = @dbq + @sx;
-        EXEC @exec @cmd;
+        IF @IsAzureSqlDb = 1
+        BEGIN
+          /* Azure SQL DB: no 3-part names allowed; just run in current DB. */
+          EXEC sys.sp_executesql @cmd;
+        END
+        ELSE
+        BEGIN
+          SET @exec = @dbq + @sx;
+          EXEC @exec @cmd;
+        END
       END
     END TRY
 


### PR DESCRIPTION
Fixes #3943

## Summary

- Detect Azure SQL DB via `SERVERPROPERTY('EngineEdition') = 5` and branch around the two things Azure forbids: 3-part names and `USE` statements.
- On Azure: seed `#ineachdb` with only the current database, execute `@cmd` with plain `EXEC sys.sp_executesql @cmd` (no 3-part dynamic call), and rewrite `@command` to strip `USE [?];` variants and collapse `[?].schema.object` / `?.schema.object` to 2-part names.
- Box SQL, Managed Instance (EngineEdition 8), Synapse, and SQL Edge keep the existing code path byte-for-byte — all changes are gated on `@IsAzureSqlDb = 1`.

This lets callers of `sp_MSforeachdb` (sp_Blitz et al.) swap in `sp_ineachdb` on Azure SQL DB without rewriting their `USE [?]; SELECT ... FROM [?].sys.xxx` command strings.

## Known limitations (documented in the issue)

- String literals containing the placeholder get rewritten too (latent issue with the existing `REPLACE(@command, @replace_character, ...)`).
- Non-canonical whitespace like `USE  [?];` or `[?] . sys . tables` won't match the `REPLACE` patterns. Rare in practice.

## Out of scope

- Updating sp_Blitz et al. to call `sp_ineachdb` on Azure — separate follow-up.

## Test plan

- [ ] Box SQL: run existing `sp_ineachdb` test calls — behavior unchanged across user/system DBs, filters, AG edge cases.
- [ ] Box SQL: confirm `@print_command_only = 1` still prints the 3-part `[db].sys.sp_executesql` form.
- [ ] Azure SQL DB: `EXEC sp_ineachdb @command = N'USE [?]; SELECT DB_NAME() AS db, COUNT(*) AS tables FROM [?].sys.tables;'` returns one row for the current DB with correct values.
- [ ] Azure SQL DB: `EXEC sp_ineachdb @command = N'SELECT ? AS placeholder;'` returns `[current_db]`.
- [ ] Azure SQL DB: `EXEC sp_ineachdb @command = N'SELECT 1;', @print_command_only = 1` prints the command without crashing.
- [ ] Azure SQL DB: confirm filter parameters (`@name_pattern`, `@user_only`, etc.) still correctly include/exclude the current DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)