### PR TITLE
sp_Blitz: add Azure SQL Database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Commonly used parameters:
 * @CheckServerInfo = 1 - includes additional rows at priority 250 with server configuration details like service accounts. 
 * @IgnorePrioritiesAbove = 50 - if you want a daily bulletin of the most important warnings, set @IgnorePrioritiesAbove = 50 to only get the urgent stuff.
 
+**Azure SQL DB support:** sp_Blitz runs on Azure SQL Database (`SERVERPROPERTY('EngineEdition') = 5`) and skips ~40 checks that rely on things Azure SQL DB does not expose: backup history in msdb, SQL Agent jobs and alerts, `xp_*` extended procs (drive space, error log, registry reads), `sys.master_files`, `sp_validatelogins`, cross-database DBCC commands, linked servers, and database mirroring / AGs. When sp_Blitz detects Azure SQL DB, a CheckID 223 "Some Checks Skipped" informational row is returned so you know coverage is reduced. Email output via `@EmailRecipients` (Database Mail is unavailable) and remote output via `@OutputServerName` (no linked servers) are also not supported on Azure SQL DB - sp_Blitz prints a not-supported message and continues instead of erroring. Managed Instance (`EngineEdition = 8`) and Amazon RDS are unaffected and continue to use their existing code paths.
+
 Advanced tips:
 
 * [How to install, run, and centralize the data from sp_Blitz using PowerShell](https://garrybargsley.com/2020/07/14/sp_blitz-for-all-servers/)

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -190,7 +190,7 @@ BEGIN
 			,@TraceFileIssue bit
 			-- Flag for Windows OS to help with Linux support
 			,@IsWindowsOperatingSystem BIT
-			-- Flag for Azure SQL Database (EngineEdition 5) to skip checks that do not apply
+			-- Flag for Azure SQL Database (EngineEdition 5) - used to skip incompatible checks and guard email / linked-server output paths
 			,@IsAzureSQLDB BIT
 			,@DaysUptime NUMERIC(23,2)
             /* For First Responder Kit consistency check:*/
@@ -930,12 +930,14 @@ BEGIN
 		/* If the server is Azure SQL Database, skip checks that it doesn't allow */
 		IF @IsAzureSQLDB = 1
 			BEGIN
-						/* Backup / restore history - msdb does not exist on Azure SQL DB */
+						/* Backup / restore history and corruption tracking - msdb does not exist on Azure SQL DB */
 						INSERT INTO #SkipChecks (CheckID) VALUES (1);   /* Full backups */
 						INSERT INTO #SkipChecks (CheckID) VALUES (2);   /* Log backups */
 						INSERT INTO #SkipChecks (CheckID) VALUES (4);   /* Full backup of user DB */
 						INSERT INTO #SkipChecks (CheckID) VALUES (5);   /* Log backup of user DB */
 						INSERT INTO #SkipChecks (CheckID) VALUES (18);  /* Backup to same drive */
+						INSERT INTO #SkipChecks (CheckID) VALUES (90);  /* Database Corruption Detected - reads msdb.dbo.suspect_pages */
+						INSERT INTO #SkipChecks (CheckID) VALUES (93);  /* Backup to same drive as data - joins msdb backup history with sys.master_files */
 						INSERT INTO #SkipChecks (CheckID) VALUES (177); /* Disabled Internal Monitoring Features - requires dm_server_registry access */
 						INSERT INTO #SkipChecks (CheckID) VALUES (186); /* MSDB Backup History Purged Too Frequently */
 
@@ -966,9 +968,12 @@ BEGIN
 						INSERT INTO #SkipChecks (CheckID) VALUES (97);   /* Unusual SQL Server Edition */
 						INSERT INTO #SkipChecks (CheckID) VALUES (2301); /* sp_validatelogins */
 
-						/* File layout / tempdb - cannot read tempdb or system DBs cross-DB from a user DB */
+						/* File layout / tempdb - cannot read tempdb or system DBs cross-DB from a user DB, and sys.master_files is unavailable */
 						INSERT INTO #SkipChecks (CheckID) VALUES (21);  /* Database encrypted - always true on Azure SQL DB */
 						INSERT INTO #SkipChecks (CheckID) VALUES (24);  /* System DB on C drive */
+						INSERT INTO #SkipChecks (CheckID) VALUES (25);  /* TempDB on C Drive - reads sys.master_files */
+						INSERT INTO #SkipChecks (CheckID) VALUES (26);  /* User Databases on C Drive - reads sys.master_files */
+						INSERT INTO #SkipChecks (CheckID) VALUES (36);  /* Slow Storage Reads - joins sys.dm_io_virtual_file_stats with sys.master_files */
 						INSERT INTO #SkipChecks (CheckID) VALUES (40);  /* TempDB only one data file */
 						INSERT INTO #SkipChecks (CheckID) VALUES (41);  /* TempDB file size/growth mismatch */
 						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'master');  /* Max file size set */

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -928,7 +928,7 @@ BEGIN
             END; /* Azure Managed Instance skipped checks */
 
 		/* If the server is Azure SQL Database, skip checks that it doesn't allow */
-		IF SERVERPROPERTY('EngineEdition') = 5
+		IF @IsAzureSQLDB = 1
 			BEGIN
 						/* Backup / restore history - msdb does not exist on Azure SQL DB */
 						INSERT INTO #SkipChecks (CheckID) VALUES (1);   /* Full backups */
@@ -9933,7 +9933,7 @@ IF NOT EXISTS ( SELECT  1
 								DROP TABLE IF EXISTS #MasterFiles;
 								CREATE TABLE #MasterFiles (database_id INT, file_id INT, type_desc NVARCHAR(50), name NVARCHAR(255), physical_name NVARCHAR(255), size BIGINT);
 								/* Azure SQL Database doesn't have sys.master_files, so we have to build our own. */
-								IF (CONVERT(INT, SERVERPROPERTY('EngineEdition')) = 5
+								IF (@IsAzureSQLDB = 1
 									 AND (OBJECT_ID('sys.master_files') IS NULL))
 									SET @StringToExecute = 'INSERT INTO #MasterFiles (database_id, file_id, type_desc, name, physical_name, size) SELECT DB_ID(), file_id, type_desc, name, physical_name, size FROM sys.database_files;';
 								ELSE

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -190,6 +190,8 @@ BEGIN
 			,@TraceFileIssue bit
 			-- Flag for Windows OS to help with Linux support
 			,@IsWindowsOperatingSystem BIT
+			-- Flag for Azure SQL Database (EngineEdition 5) to skip checks that do not apply
+			,@IsAzureSQLDB BIT
 			,@DaysUptime NUMERIC(23,2)
             /* For First Responder Kit consistency check:*/
             ,@spBlitzFullName                VARCHAR(1024)
@@ -746,6 +748,9 @@ BEGIN
 				SELECT @IsWindowsOperatingSystem = 1 ;
 			END;
 
+		-- Flag for Azure SQL Database - used to guard email and linked server output paths
+		SELECT @IsAzureSQLDB = CASE WHEN CONVERT(INT, SERVERPROPERTY('EngineEdition')) = 5 THEN 1 ELSE 0 END;
+
 
 			IF NOT EXISTS ( SELECT  1
 							FROM    #SkipChecks
@@ -921,6 +926,90 @@ BEGIN
 					            'https://docs.microsoft.com/en-us/azure/sql-database/sql-database-managed-instance-index' AS URL ,
 					            'Managed Instance detected, so we skipped some checks that are not currently possible, relevant, or practical there.' AS Details;
             END; /* Azure Managed Instance skipped checks */
+
+		/* If the server is Azure SQL Database, skip checks that it doesn't allow */
+		IF SERVERPROPERTY('EngineEdition') = 5
+			BEGIN
+						/* Backup / restore history - msdb does not exist on Azure SQL DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (1);   /* Full backups */
+						INSERT INTO #SkipChecks (CheckID) VALUES (2);   /* Log backups */
+						INSERT INTO #SkipChecks (CheckID) VALUES (4);   /* Full backup of user DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (5);   /* Log backup of user DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (18);  /* Backup to same drive */
+						INSERT INTO #SkipChecks (CheckID) VALUES (177); /* Disabled Internal Monitoring Features - requires dm_server_registry access */
+						INSERT INTO #SkipChecks (CheckID) VALUES (186); /* MSDB Backup History Purged Too Frequently */
+
+						/* SQL Agent - no Agent on Azure SQL DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (6);   /* Jobs Owned By Users */
+						INSERT INTO #SkipChecks (CheckID) VALUES (30);  /* Alerts not configured */
+						INSERT INTO #SkipChecks (CheckID) VALUES (31);  /* No enabled operators */
+						INSERT INTO #SkipChecks (CheckID) VALUES (57);  /* Agent Job Runs at Startup */
+						INSERT INTO #SkipChecks (CheckID) VALUES (59);  /* Alerts Configured without Follow Up */
+						INSERT INTO #SkipChecks (CheckID) VALUES (61);  /* Agent alerts for severity 19-25 */
+						INSERT INTO #SkipChecks (CheckID) VALUES (73);  /* No Failsafe Operator Configured */
+						INSERT INTO #SkipChecks (CheckID) VALUES (79);  /* Shrink Database Job */
+						INSERT INTO #SkipChecks (CheckID) VALUES (94);  /* Job failure without operator notification */
+						INSERT INTO #SkipChecks (CheckID) VALUES (96);  /* Agent alerts for corruption */
+						INSERT INTO #SkipChecks (CheckID) VALUES (98);  /* Disabled alerts */
+						INSERT INTO #SkipChecks (CheckID) VALUES (123); /* Agent Jobs Starting Simultaneously */
+						INSERT INTO #SkipChecks (CheckID) VALUES (180); /* Maintenance plans */
+						INSERT INTO #SkipChecks (CheckID) VALUES (181); /* Repetitive maintenance tasks */
+						INSERT INTO #SkipChecks (CheckID) VALUES (219); /* Alerts without event descriptions */
+
+						/* Cross-DB / system-DB access not permitted on Azure SQL DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (29);   /* Tables in model database */
+						INSERT INTO #SkipChecks (CheckID) VALUES (55);   /* Database owner <> sa - queries master.sys */
+						INSERT INTO #SkipChecks (CheckID) VALUES (68);   /* Last good DBCC CHECKDB - DBCC DBINFO cross-DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (69);   /* High VLF count - DBCC LOGINFO cross-DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (71);   /* sysadmin in master.sys.syslogins */
+						INSERT INTO #SkipChecks (CheckID) VALUES (74);   /* Trace flags - DBCC TRACESTATUS */
+						INSERT INTO #SkipChecks (CheckID) VALUES (97);   /* Unusual SQL Server Edition */
+						INSERT INTO #SkipChecks (CheckID) VALUES (2301); /* sp_validatelogins */
+
+						/* File layout / tempdb - cannot read tempdb or system DBs cross-DB from a user DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (21);  /* Database encrypted - always true on Azure SQL DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (24);  /* System DB on C drive */
+						INSERT INTO #SkipChecks (CheckID) VALUES (40);  /* TempDB only one data file */
+						INSERT INTO #SkipChecks (CheckID) VALUES (41);  /* TempDB file size/growth mismatch */
+						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'master');  /* Max file size set */
+						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'model');   /* Max file size set */
+						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'msdb');    /* Max file size set */
+						INSERT INTO #SkipChecks (CheckID, DatabaseName) VALUES (80, 'tempdb');  /* Max file size set */
+						INSERT INTO #SkipChecks (CheckID) VALUES (172); /* TempDB files on C drive */
+
+						/* Server / OS / services - not addressable on Azure SQL DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (50);  /* Max Server Memory - not user-configurable */
+						INSERT INTO #SkipChecks (CheckID) VALUES (92);  /* Drive space - xp_fixeddrives */
+						INSERT INTO #SkipChecks (CheckID) VALUES (100); /* Remote DAC */
+						INSERT INTO #SkipChecks (CheckID) VALUES (192); /* IFI - not applicable */
+						INSERT INTO #SkipChecks (CheckID) VALUES (193); /* xp_readerrorlog for IFI */
+						INSERT INTO #SkipChecks (CheckID) VALUES (199); /* Default trace */
+						INSERT INTO #SkipChecks (CheckID) VALUES (211); /* Power plan - xp_regread */
+						INSERT INTO #SkipChecks (CheckID) VALUES (212); /* Additional instances - xp_regread */
+						INSERT INTO #SkipChecks (CheckID) VALUES (224); /* SSRS/SSAS/SSIS Installed */
+						INSERT INTO #SkipChecks (CheckID) VALUES (258); /* SQL Server service running as LocalSystem */
+						INSERT INTO #SkipChecks (CheckID) VALUES (259); /* Agent service running as LocalSystem */
+						INSERT INTO #SkipChecks (CheckID) VALUES (260); /* SQL Server service account in Administrators */
+						INSERT INTO #SkipChecks (CheckID) VALUES (261); /* Agent service account in Administrators */
+
+						/* Replication / mirroring / AGs - not applicable on Azure SQL DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (227); /* Database Mirroring */
+
+			            INSERT  INTO #BlitzResults
+			            ( CheckID ,
+				            Priority ,
+				            FindingsGroup ,
+				            Finding ,
+				            URL ,
+				            Details
+			            )
+			            SELECT 223 AS CheckID ,
+					            0 AS Priority ,
+					            'Informational' AS FindingsGroup ,
+					            'Some Checks Skipped' AS Finding ,
+					            'https://learn.microsoft.com/en-us/azure/azure-sql/database/' AS URL ,
+					            'Azure SQL Database detected, so we skipped some checks that are not currently possible, relevant, or practical there.' AS Details;
+            END; /* Azure SQL Database skipped checks */
 
 		/*
 		That's the end of the SkipChecks stuff.
@@ -9844,7 +9933,7 @@ IF NOT EXISTS ( SELECT  1
 								DROP TABLE IF EXISTS #MasterFiles;
 								CREATE TABLE #MasterFiles (database_id INT, file_id INT, type_desc NVARCHAR(50), name NVARCHAR(255), physical_name NVARCHAR(255), size BIGINT);
 								/* Azure SQL Database doesn't have sys.master_files, so we have to build our own. */
-								IF ((SERVERPROPERTY('Edition')) = 'SQL Azure' 
+								IF (CONVERT(INT, SERVERPROPERTY('EngineEdition')) = 5
 									 AND (OBJECT_ID('sys.master_files') IS NULL))
 									SET @StringToExecute = 'INSERT INTO #MasterFiles (database_id, file_id, type_desc, name, physical_name, size) SELECT DB_ID(), file_id, type_desc, name, physical_name, size FROM sys.database_files;';
 								ELSE
@@ -10134,44 +10223,53 @@ IF NOT EXISTS ( SELECT  1
 						
 				IF @EmailRecipients IS NOT NULL
 					BEGIN
-					
-					IF @Debug IN (1, 2) RAISERROR('Sending an email.', 0, 1) WITH NOWAIT;
-					
-					/* Database mail won't work off a local temp table. I'm not happy about this hacky workaround either. */
-					IF (OBJECT_ID('tempdb..##BlitzResults', 'U') IS NOT NULL) DROP TABLE ##BlitzResults;
-					SELECT * INTO ##BlitzResults FROM #BlitzResults;
-					SET @query_result_separator = char(9);
-					SET @StringToExecute = 'SET NOCOUNT ON;SELECT [Priority] , [FindingsGroup] , [Finding] , [DatabaseName] , [URL] ,  [Details] , CheckID FROM ##BlitzResults ORDER BY Priority , FindingsGroup , Finding , DatabaseName , Details; SET NOCOUNT OFF;';
-					SET @EmailSubject = 'sp_Blitz Results for ' + @@SERVERNAME;
-					SET @EmailBody = 'sp_Blitz ' + CAST(CONVERT(DATETIME, @VersionDate, 102) AS VARCHAR(100)) + '. http://FirstResponderKit.org';
-					IF @EmailProfile IS NULL
-						EXEC msdb.dbo.sp_send_dbmail
-							@recipients = @EmailRecipients,
-							@subject = @EmailSubject,
-							@body = @EmailBody,
-							@query_attachment_filename = 'sp_Blitz-Results.csv',
-							@attach_query_result_as_file = 1,
-							@query_result_header = 1,
-							@query_result_width = 32767,
-							@append_query_error = 1,
-							@query_result_no_padding = 1,
-							@query_result_separator = @query_result_separator,
-							@query = @StringToExecute;
+
+					IF @IsAzureSQLDB = 1
+						BEGIN
+							IF @Debug IN (1, 2) RAISERROR('Skipping email - Database Mail is not available on Azure SQL Database.', 0, 1) WITH NOWAIT;
+							PRINT 'Email output is not supported on Azure SQL Database (Database Mail / msdb.dbo.sp_send_dbmail is unavailable). Skipping email send.';
+						END;
 					ELSE
-						EXEC msdb.dbo.sp_send_dbmail
-							@profile_name = @EmailProfile,
-							@recipients = @EmailRecipients,
-							@subject = @EmailSubject,
-							@body = @EmailBody,
-							@query_attachment_filename = 'sp_Blitz-Results.csv',
-							@attach_query_result_as_file = 1,
-							@query_result_header = 1,
-							@query_result_width = 32767,
-							@append_query_error = 1,
-							@query_result_no_padding = 1,
-							@query_result_separator = @query_result_separator,
-							@query = @StringToExecute;
-					IF (OBJECT_ID('tempdb..##BlitzResults', 'U') IS NOT NULL) DROP TABLE ##BlitzResults;
+						BEGIN
+
+						IF @Debug IN (1, 2) RAISERROR('Sending an email.', 0, 1) WITH NOWAIT;
+
+						/* Database mail won't work off a local temp table. I'm not happy about this hacky workaround either. */
+						IF (OBJECT_ID('tempdb..##BlitzResults', 'U') IS NOT NULL) DROP TABLE ##BlitzResults;
+						SELECT * INTO ##BlitzResults FROM #BlitzResults;
+						SET @query_result_separator = char(9);
+						SET @StringToExecute = 'SET NOCOUNT ON;SELECT [Priority] , [FindingsGroup] , [Finding] , [DatabaseName] , [URL] ,  [Details] , CheckID FROM ##BlitzResults ORDER BY Priority , FindingsGroup , Finding , DatabaseName , Details; SET NOCOUNT OFF;';
+						SET @EmailSubject = 'sp_Blitz Results for ' + @@SERVERNAME;
+						SET @EmailBody = 'sp_Blitz ' + CAST(CONVERT(DATETIME, @VersionDate, 102) AS VARCHAR(100)) + '. http://FirstResponderKit.org';
+						IF @EmailProfile IS NULL
+							EXEC msdb.dbo.sp_send_dbmail
+								@recipients = @EmailRecipients,
+								@subject = @EmailSubject,
+								@body = @EmailBody,
+								@query_attachment_filename = 'sp_Blitz-Results.csv',
+								@attach_query_result_as_file = 1,
+								@query_result_header = 1,
+								@query_result_width = 32767,
+								@append_query_error = 1,
+								@query_result_no_padding = 1,
+								@query_result_separator = @query_result_separator,
+								@query = @StringToExecute;
+						ELSE
+							EXEC msdb.dbo.sp_send_dbmail
+								@profile_name = @EmailProfile,
+								@recipients = @EmailRecipients,
+								@subject = @EmailSubject,
+								@body = @EmailBody,
+								@query_attachment_filename = 'sp_Blitz-Results.csv',
+								@attach_query_result_as_file = 1,
+								@query_result_header = 1,
+								@query_result_width = 32767,
+								@append_query_error = 1,
+								@query_result_no_padding = 1,
+								@query_result_separator = @query_result_separator,
+								@query = @StringToExecute;
+						IF (OBJECT_ID('tempdb..##BlitzResults', 'U') IS NOT NULL) DROP TABLE ##BlitzResults;
+						END;
 				END;
 
 				/* Checks if @OutputServerName is populated with a valid linked server, and that the database name specified is valid */
@@ -10180,11 +10278,18 @@ IF NOT EXISTS ( SELECT  1
 				DECLARE @LinkedServerDBCheck NVARCHAR(2000);
 				DECLARE @ValidLinkedServerDB INT;
 				DECLARE @tmpdbchk table (cnt int);
-				IF @OutputServerName IS NOT NULL
+				IF @OutputServerName IS NOT NULL AND @IsAzureSQLDB = 1
 					BEGIN
-						
+						IF @Debug IN (1, 2) RAISERROR('Skipping linked server output - not supported on Azure SQL Database.', 0, 1) WITH NOWAIT;
+						PRINT 'Linked server output (@OutputServerName) is not supported on Azure SQL Database. Skipping remote output.';
+						SET @ValidOutputServer = 0;
+						SET @ValidOutputLocation = 0;
+					END;
+				ELSE IF @OutputServerName IS NOT NULL
+					BEGIN
+
 						IF @Debug IN (1, 2) RAISERROR('Outputting to a remote server.', 0, 1) WITH NOWAIT;
-						
+
 						IF EXISTS (SELECT server_id FROM sys.servers WHERE QUOTENAME([name]) = @OutputServerName)
 							BEGIN
 								SET @LinkedServerDBCheck = 'SELECT 1 WHERE EXISTS (SELECT * FROM '+@OutputServerName+'.master.sys.databases WHERE QUOTENAME([name]) = '''+@OutputDatabaseName+''')';

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -997,8 +997,11 @@ BEGIN
 						INSERT INTO #SkipChecks (CheckID) VALUES (260); /* SQL Server service account in Administrators */
 						INSERT INTO #SkipChecks (CheckID) VALUES (261); /* Agent service account in Administrators */
 
-						/* Replication / mirroring / AGs - not applicable on Azure SQL DB */
+						/* Replication / mirroring / AGs / clustering - not applicable on Azure SQL DB */
+						INSERT INTO #SkipChecks (CheckID) VALUES (53);  /* Cluster Node - sys.dm_hadr_* DMVs unavailable */
 						INSERT INTO #SkipChecks (CheckID) VALUES (227); /* Database Mirroring */
+						INSERT INTO #SkipChecks (CheckID) VALUES (234); /* SQL Server Update May Fail - queries master.sys.master_files */
+						INSERT INTO #SkipChecks (CheckID) VALUES (268); /* AG Replica Falling Behind - sys.availability_* DMVs unavailable */
 
 			            INSERT  INTO #BlitzResults
 			            ( CheckID ,


### PR DESCRIPTION
Closes #3952

## Summary

- Azure SQL Database (EngineEdition = 5) is allowed past the version gate in sp_Blitz today, but has no dedicated skip block, so ~40 checks that rely on msdb, SQL Agent, `xp_*`, `sys.master_files`, `sp_validatelogins`, linked servers, or cross-database metadata throw errors.
- This PR follows the existing Managed Instance skip pattern (sp_Blitz.sql:879) and adds an Azure SQL DB equivalent: detect the edition into an `@IsAzureSQLDB` flag, add incompatible CheckIDs to `#SkipChecks`, and emit the CheckID 223 "some checks skipped" informational row.
- Also fixes CheckID 232 (Data Size) to detect Azure SQL DB via `EngineEdition = 5` instead of the legacy `Edition = 'SQL Azure'` string, and guards `msdb.dbo.sp_send_dbmail` email output and `@OutputServerName` linked-server output on Azure SQL DB so they print a not-supported message instead of throwing.
- Scope is deliberately limited to skip + drop-in DMV swaps. Backup history, Agent, config, and `xp_*` checks remain skipped rather than rewritten. No changes to MI, RDS, Express, or on-prem code paths.

### CheckIDs skipped on Azure SQL DB

- **Backup / restore history** (msdb unavailable): 1, 2, 4, 5, 18, 177, 186
- **SQL Agent** (no Agent on Azure SQL DB): 6, 30, 31, 57, 59, 61, 73, 79, 94, 96, 98, 123, 180, 181, 219
- **Cross-DB / system-DB access**: 29, 55, 68, 69, 71, 74, 97, 2301
- **File layout / tempdb**: 21, 24, 40, 41, 80 (system DBs), 172
- **Server / OS / services**: 50, 92, 100, 192, 193, 199, 211, 212, 224, 258, 259, 260, 261
- **Replication / mirroring**: 227

## Test plan

- [ ] Run modified `sp_Blitz` on an on-prem SQL Server 2016+; row counts match a pre-change run and CheckID 223 does not fire from the new Azure branch.
- [ ] Run with `@Debug = 1` on on-prem; no new errors in debug output.
- [ ] Install into an Azure SQL Database user DB: `EXEC dbo.sp_Blitz;` completes without error.
- [ ] CheckID 223 appears once with the Azure SQL Database message on Azure.
- [ ] CheckID 232 (Data Size) returns a row with a reasonable GB figure for the current DB on Azure.
- [ ] `EXEC dbo.sp_Blitz @EmailRecipients = 'test@example.com';` on Azure — completes without error, PRINT output mentions email not supported.
- [ ] `EXEC dbo.sp_Blitz @OutputServerName = '[SomeLinkedServer]', @OutputDatabaseName = 'x', @OutputSchemaName = 'dbo', @OutputTableName = 'y';` on Azure — does not throw, PRINT output mentions linked server not supported.
- [ ] Run Managed Instance regression (if available) to confirm MI behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)