### PR TITLE
Install-Azure.sql: include sp_Blitz and sp_ineachdb

### DIFF
--- a/Documentation/Development/Build Installation Scripts.ps1
+++ b/Documentation/Development/Build Installation Scripts.ps1
@@ -138,9 +138,17 @@ $InstallAllPath   = Join-Path $RepoRoot "Install-All-Scripts.sql"
 $InstallAzurePath = Join-Path $RepoRoot "Install-Azure.sql"
 
 # ── Install-Azure.sql ────────────────────────────────────────────────────────
-# All sp_Blitz*.sql except sp_Blitz.sql, sp_BlitzBackups.sql, sp_DatabaseRestore.sql, sp_BlitzFirst.sql
-$azureContent = Get-ChildItem -Path $RepoRoot -Filter "sp_Blitz*.sql" |
-    Where-Object { $_.Name -ne "sp_Blitz.sql" -and $_.Name -notlike "*BlitzBackups*" -and $_.Name -notlike "*DatabaseRestore*" -and $_.Name -notlike "*BlitzFirst*" } |
+# sp_ineachdb.sql must come first because sp_Blitz calls it at runtime.
+# All sp_Blitz*.sql except sp_BlitzBackups.sql, sp_DatabaseRestore.sql, sp_BlitzFirst.sql.
+# sp_BlitzBackups and sp_DatabaseRestore depend on xp_cmdshell / msdb backup history.
+# sp_BlitzFirst is appended last (same as Install-All-Scripts.sql).
+$IneachdbPath = Join-Path $RepoRoot "sp_ineachdb.sql"
+$azureContent = @()
+if (Test-Path $IneachdbPath) {
+    $azureContent += Get-Content -Path $IneachdbPath -Raw -Encoding UTF8
+}
+$azureContent += Get-ChildItem -Path $RepoRoot -Filter "sp_Blitz*.sql" |
+    Where-Object { $_.Name -notlike "*BlitzBackups*" -and $_.Name -notlike "*DatabaseRestore*" -and $_.Name -notlike "*BlitzFirst*" } |
     ForEach-Object { Get-Content $_.FullName -Raw -Encoding UTF8 }
 
 if (Test-Path $BlitzFirstPath) {


### PR DESCRIPTION
Closes #3953

## Summary

- The build script (`Documentation/Development/Build Installation Scripts.ps1`) explicitly excluded `sp_Blitz.sql` from `Install-Azure.sql`, dating from when sp_Blitz didn't run on Azure SQL DB. Now that #3951 added Azure support, drop the exclusion.
- Also prepend `sp_ineachdb.sql` to the Azure bundle — `sp_Blitz` calls it at runtime for per-database checks, and it already has built-in Azure SQL DB support (#3943). The existing `sp_Blitz*.sql` glob missed it because of the naming.
- `sp_BlitzBackups` and `sp_DatabaseRestore` remain excluded (they depend on `xp_cmdshell` / msdb backup history).

## Test plan

- [ ] Run the build script: `& "Documentation\Development\Build Installation Scripts.ps1"` — verify it completes and the generated `Install-Azure.sql` includes `sp_ineachdb`, `sp_Blitz`, and the existing procs (sp_BlitzAnalysis, sp_BlitzCache, sp_BlitzIndex, sp_BlitzLock, sp_BlitzQueryStore, sp_BlitzWho, sp_BlitzFirst).
- [ ] Verify `Install-Azure.sql` does NOT include `sp_BlitzBackups` or `sp_DatabaseRestore`.
- [ ] Run `Install-Azure.sql` on an Azure SQL Database user DB — all procs install without error.
- [ ] `EXEC dbo.sp_Blitz;` on Azure SQL DB after installing via `Install-Azure.sql` — completes without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)