### PR TITLE
sp_BlitzBackups: use @StartTime for CheckId 7 and 12

### DIFF
--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -975,18 +975,18 @@ RAISERROR('Rules analysis starting', 0, 1) WITH NOWAIT;
 								100 AS [Priority],
 								b.database_name AS [Database Name],
 								''No CHECKSUMS'' AS [Finding],
-								''The database '' + QUOTENAME(b.database_name) + '' has been backed up '' + CONVERT(VARCHAR(10), COUNT(*)) + '' times without CHECKSUMS in the past 30 days. CHECKSUMS can help alert you to corruption errors.'' AS [Warning]
+								''The database '' + QUOTENAME(b.database_name) + '' has been backed up '' + CONVERT(VARCHAR(10), COUNT(*)) + '' times without CHECKSUMS. CHECKSUMS can help alert you to corruption errors.'' AS [Warning]
 							FROM   ' + QUOTENAME(@MSDBName) + N'.dbo.backupset AS b
 							WHERE b.has_backup_checksums = 0
-							AND b.backup_finish_date >= DATEADD(DAY, -30, SYSDATETIME())
+							AND b.backup_finish_date >= @StartTime
 							GROUP BY b.database_name;' + @crlf;
 
 	IF @Debug = 1
 		PRINT @StringToExecute;
 
 		INSERT #Warnings ( CheckId, Priority, DatabaseName, Finding, Warning )
-		EXEC sys.sp_executesql @StringToExecute;
-	
+		EXEC sys.sp_executesql @StringToExecute, N'@StartTime DATETIME2', @StartTime;
+
 	/*Damaged is a Black Flag album. You don''t want your backups to be like a Black Flag album. */
 
 	SET @StringToExecute = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;' + @crlf;
@@ -1089,17 +1089,17 @@ IF @ProductVersionMajor >= 12
 		100 AS [Priority],
 		b.database_name AS [Database Name],
 		''Uncompressed backups'' AS [Finding],
-		''The database '' + QUOTENAME(b.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' uncompressed backups in the last 30 days. This is a free way to save time and space. And SPACETIME. If your version of SQL supports it.'' AS [Warning]
+		''The database '' + QUOTENAME(b.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' uncompressed backups. This is a free way to save time and space. And SPACETIME. If your version of SQL supports it.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS b
 	WHERE backup_size = compressed_backup_size AND type = ''D''
-	AND b.backup_finish_date >= DATEADD(DAY, -30, SYSDATETIME())
+	AND b.backup_finish_date >= @StartTime
 	GROUP BY b.database_name;' + @crlf;
 
 	IF @Debug = 1
 		PRINT @StringToExecute;
 
 		INSERT #Warnings ( CheckId, Priority, DatabaseName, Finding, Warning )
-		EXEC sys.sp_executesql @StringToExecute;
+		EXEC sys.sp_executesql @StringToExecute, N'@StartTime DATETIME2', @StartTime;
 
 	/*Looking for backups directed at the NUL device.*/
 	SET @StringToExecute =N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;' + @crlf;


### PR DESCRIPTION
## Summary

- CheckId 7 (No CHECKSUMS) and CheckId 12 (Uncompressed backups) were filtering on a hard-coded 30-day window via `DATEADD(DAY, -30, SYSDATETIME())`, ignoring the user's `@HoursBack` parameter.
- Replace both filters with `@StartTime` (already used elsewhere in this proc), pass `@StartTime` through `sp_executesql`, and drop the "in the last 30 days" / "in the past 30 days" wording from the warning text now that the window is dynamic.
- Same treatment as #3960 applied to CheckId 14 (Backup to NUL device). Trending block at line 797 (`DATEADD(YEAR, -1, @StartTime)`) is intentional and left alone — it backs the 13-column month pivot.

## Test plan

- [ ] `EXEC sp_BlitzBackups @HoursBack = 24, @Debug = 1;` — confirm CheckId 7/12 dynamic SQL prints `@StartTime` (no `DATEADD(DAY, -30, ...)`) and runs without "Must declare the scalar variable @StartTime".
- [ ] `EXEC sp_BlitzBackups @HoursBack = 168, @Debug = 1;` — same.
- [ ] `EXEC sp_BlitzBackups @HoursBack = 720, @Debug = 1;` — verify CheckId 7/12 row counts grow vs. `@HoursBack = 24`, proving the parameter is now honored.
- [ ] Confirm no result row for CheckId 7 or 12 contains the phrase "30 days".

🤖 Generated with [Claude Code](https://claude.com/claude-code)