### PR TITLE
sp_BlitzBackups: priority changes and doc for #3963

### DIFF
--- a/Documentation/sp_BlitzBackups_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzBackups_Checks_by_Priority.md
@@ -4,7 +4,7 @@ This table lists all checks ordered by priority.
 
 Before adding a new check, make sure to add a Github issue for it first, and have a group discussion about its priority, and description.
 
-If you want to change anything about a check - the priority, finding,, or ID - open a Github issue first. The relevant scripts have to be updated too.
+If you want to change anything about a check - the priority, finding, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
 CURRENT HIGH CHECKID: 14.
 If you want to add a new one, start at 15.

--- a/Documentation/sp_BlitzBackups_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzBackups_Checks_by_Priority.md
@@ -1,0 +1,28 @@
+# sp_BlitzBackups Checks by Priority
+
+This table lists all checks ordered by priority.
+
+Before adding a new check, make sure to add a Github issue for it first, and have a group discussion about its priority, and description.
+
+If you want to change anything about a check - the priority, finding,, or ID - open a Github issue first. The relevant scripts have to be updated too.
+
+CURRENT HIGH CHECKID: 14.
+If you want to add a new one, start at 15.
+
+| Priority | Finding                                | CheckID |
+| -------: | :------------------------------------- | ------: |
+|       10 | Recovery model switched                |      11 |
+|       10 | Backup to NUL device without COPY_ONLY |      14 |
+|       10 | Damaged backups                        |       8 |
+|       20 | No CHECKSUMS                           |       7 |
+|       20 | Backup to NUL device                   |      14 |
+|       50 | Single user mode backups               |       6 |
+|       50 | Big Diffs/Logs                         |      13 |
+|       80 | Uncompressed backups                   |      12 |
+|      100 | Non-Agent backups taken                |       1 |
+|      100 | Compatibility level changing           |       2 |
+|      100 | Password backups                       |       3 |
+|      100 | Encrypted backups                      |       9 |
+|      100 | Bulk logged backups                    |      10 |
+|      150 | Read only state backups                |       5 |
+|      200 | Snapshot backups                       |       4 |

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -912,7 +912,7 @@ RAISERROR('Rules analysis starting', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'SELECT 
 								4 AS CheckId,
-								100 AS [Priority],
+								200 AS [Priority],
 								b.database_name AS [Database Name],
 								''Snapshot backups'' AS [Finding],
 								''The database '' + QUOTENAME(b.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' snapshot backups. This message is purely informational.'' AS [Warning]
@@ -932,7 +932,7 @@ RAISERROR('Rules analysis starting', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'SELECT 
 								5 AS CheckId,
-								100 AS [Priority],
+								150 AS [Priority],
 								b.database_name AS [Database Name],
 								''Read only state backups'' AS [Finding],
 								''The database '' + QUOTENAME(b.database_name) + '' has been backed up '' + CONVERT(VARCHAR(10), COUNT(*)) + '' times while in a read-only state. This can be normal if it''''s a secondary, but a bit odd otherwise.'' AS [Warning]
@@ -952,7 +952,7 @@ RAISERROR('Rules analysis starting', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'SELECT 
 								6 AS CheckId,
-								100 AS [Priority],
+								50 AS [Priority],
 								b.database_name AS [Database Name],
 								''Single user mode backups'' AS [Finding],
 								''The database '' + QUOTENAME(b.database_name) + '' has been backed up '' + CONVERT(VARCHAR(10), COUNT(*)) + '' times while in single-user mode. This is really weird! Make sure your backup process doesn''''t include a mode change anywhere.'' AS [Warning]
@@ -972,7 +972,7 @@ RAISERROR('Rules analysis starting', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'SELECT 
 								7 AS CheckId,
-								100 AS [Priority],
+								20 AS [Priority],
 								b.database_name AS [Database Name],
 								''No CHECKSUMS'' AS [Finding],
 								''The database '' + QUOTENAME(b.database_name) + '' has been backed up '' + CONVERT(VARCHAR(10), COUNT(*)) + '' times without CHECKSUMS. CHECKSUMS can help alert you to corruption errors.'' AS [Warning]
@@ -993,7 +993,7 @@ RAISERROR('Rules analysis starting', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'SELECT 
 								8 AS CheckId,
-								100 AS [Priority],
+								10 AS [Priority],
 								b.database_name AS [Database Name],
 								''Damaged backups'' AS [Finding],
 								''The database '' + QUOTENAME(b.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' damaged backups taken without stopping to throw an error. This is done by specifying CONTINUE_AFTER_ERROR in your BACKUP commands.'' AS [Warning]
@@ -1065,10 +1065,10 @@ IF @ProductVersionMajor >= 12
 
 	SET @StringToExecute += N'SELECT 
 		11 AS CheckId,
-		100 AS [Priority],
+		10 AS [Priority],
 		b.database_name AS [Database Name],
 		''Recovery model switched'' AS [Finding],
-		''The database '' + QUOTENAME(b.database_name) + '' has changed recovery models from between FULL and SIMPLE '' + CONVERT(VARCHAR(10), COUNT(DISTINCT b.recovery_model)) + '' times. This breaks the log chain and is generally a bad idea.'' AS [Warning]
+		''The database '' + QUOTENAME(b.database_name) + '' has changed recovery models between FULL and SIMPLE '' + CONVERT(VARCHAR(10), COUNT(DISTINCT b.recovery_model)) + '' times. This breaks the log chain and is generally a bad idea.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS b
 	WHERE b.recovery_model <> ''BULK-LOGGED''
 	GROUP BY b.database_name
@@ -1086,7 +1086,7 @@ IF @ProductVersionMajor >= 12
 
 	SET @StringToExecute += N'SELECT 
 		12 AS CheckId,
-		100 AS [Priority],
+		80 AS [Priority],
 		b.database_name AS [Database Name],
 		''Uncompressed backups'' AS [Finding],
 		''The database '' + QUOTENAME(b.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' uncompressed backups. This is a free way to save time and space. And SPACETIME. If your version of SQL supports it.'' AS [Warning]
@@ -1106,7 +1106,7 @@ IF @ProductVersionMajor >= 12
 
 	SET @StringToExecute += N'SELECT 
 		14 AS CheckId,
-		100 AS [Priority],
+		20 AS [Priority],
 		bs.database_name AS [Database Name],
 		''Backup to NUL device'' AS [Finding],
 		''The database '' + QUOTENAME(bs.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to the NUL device, the latest one being on ''+
@@ -1119,7 +1119,7 @@ IF @ProductVersionMajor >= 12
 	GROUP BY bs.database_name' + @crlf;
 	SET @StringToExecute += N'UNION ALL' + @crlf + N'SELECT
 		14 AS CheckId,
-		100 AS [Priority],
+		10 AS [Priority],
 		bs.database_name AS [Database Name],
 		''Backup to NUL device without COPY_ONLY'' AS [Finding],
 		''The database '' + QUOTENAME(bs.database_name) + '' is not in SIMPLE recovery model and has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to the NUL device, the latest one being on ''+
@@ -1142,7 +1142,7 @@ RAISERROR('Rules analysis starting on temp tables', 0, 1) WITH NOWAIT;
 		INSERT #Warnings ( CheckId, Priority, DatabaseName, Finding, Warning )
 		SELECT
 			13 AS CheckId,
-			100 AS Priority,
+			50 AS Priority,
 			r.DatabaseName as [DatabaseName],
 			'Big Diffs' AS [Finding],
 			'On average, Differential backups for this database are >=40% of the size of the average Full backup.' AS [Warning]
@@ -1152,7 +1152,7 @@ RAISERROR('Rules analysis starting on temp tables', 0, 1) WITH NOWAIT;
 		INSERT #Warnings ( CheckId, Priority, DatabaseName, Finding, Warning )
 		SELECT
 			13 AS CheckId,
-			100 AS Priority,
+			50 AS Priority,
 			r.DatabaseName as [DatabaseName],
 			'Big Logs' AS [Finding],
 			'On average, Log backups for this database are >=20% of the size of the average Full backup.' AS [Warning]


### PR DESCRIPTION
Closes #3963 

**Priority 10 — Fix immediately**
- **Damaged backups** (8): Backups taken with `CONTINUE_AFTER_ERROR` may not be restorable at all.
- **Recovery model switched** (11): Breaks the log chain. Point-in-time recovery is compromised right now.
- **Backup to NUL without COPY_ONLY** (14): Backups don't exist *and* the backup chain is broken.

**Priority 20 — Fix soon**
- **No CHECKSUMS** (7): You won't know about corruption until restore time (silent risk).
- **Backup to NUL** (14): Backups don't exist, but at least the chain isn't broken (COPY_ONLY or SIMPLE recovery).

**Priority 50 — Worth investigating**
- **Single user mode backups** (6): Operationally dangerous but not an immediate data loss risk.
- **Big Diffs/Logs** (13): Signals a backup strategy that may not meet RTO. Worth reviewing, not an emergency.

**Priority 80 — Best practice gap**
- **Uncompressed backups** (12): Wastes time and space but data is still safe and recoverable.

**Priority 100 — Informational/investigate**
- Non-Agent backups, compatibility level changes, password backups, encrypted backups, bulk logged backups. All worth knowing about and investigating, but none directly threaten recoverability right now.

**Priority 150/200 — Noise**
- **Read-only state backups** (5): Explicitly called out as potentially normal (AG secondaries).
- **Snapshot backups** (4): The code comment literally says "purely informational."