### PR TITLE
sp_BlitzIndex: decode columnstore segment min/max for dates, GUIDs, strings

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -4097,11 +4097,20 @@ BEGIN
 									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id / 65536 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
 									+ '' to ''
 									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id / 65536 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
-								/* DATETIME: BIGINT = days * 2^32 + ticks (1/300 sec); days are since 1900-01-01. */
+								/* DATETIME: BIGINT = days * 2^32 + ticks (1/300 sec); days are since 1900-01-01.
+								   T-SQL integer division truncates toward zero, so for negative
+								   values (pre-1900 dates) with non-zero ticks we have to nudge
+								   toward negative infinity to get the right calendar day. */
 								WHEN c.system_type_id = 61 THEN
-									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id / 4294967296 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
+									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(CASE
+										WHEN seg.min_data_id < 0 AND seg.min_data_id % 4294967296 <> 0 THEN (seg.min_data_id / 4294967296) - 1
+										ELSE seg.min_data_id / 4294967296
+									END AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
 									+ '' to ''
-									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id / 4294967296 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
+									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(CASE
+										WHEN seg.max_data_id < 0 AND seg.max_data_id % 4294967296 <> 0 THEN (seg.max_data_id / 4294967296) - 1
+										ELSE seg.max_data_id / 4294967296
+									END AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
 								/* DATETIME2: BIGINT = days * 2^40 + ticks_100ns; days are since 0001-01-01. */
 								WHEN c.system_type_id = 42 THEN
 									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id / 1099511627776 AS INT), CONVERT(DATE, ''0001-01-01'')), 23)

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -4085,21 +4085,21 @@ BEGIN
 									+ '' to ''
 									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id AS INT), CONVERT(DATE, ''0001-01-01'')), 23)' +
 							CASE WHEN @HasDeepData = 1 THEN N'
-								/* UNIQUEIDENTIFIER: deep_data carries the raw 16-byte GUID on SQL 2022+ / Azure SQL DB. */
+								/* UNIQUEIDENTIFIER: deep_data is a 2-byte length prefix (0x10 0x00) followed by the 16-byte GUID. */
 								WHEN c.system_type_id = 36 AND seg.min_deep_data IS NOT NULL THEN
-									CONVERT(VARCHAR(36), TRY_CAST(seg.min_deep_data AS UNIQUEIDENTIFIER))
+									CONVERT(VARCHAR(36), TRY_CAST(SUBSTRING(seg.min_deep_data, 3, 16) AS UNIQUEIDENTIFIER))
 									+ '' to ''
-									+ CONVERT(VARCHAR(36), TRY_CAST(seg.max_deep_data AS UNIQUEIDENTIFIER))
-								/* CHAR / VARCHAR: deep_data is the actual sort-key bytes; truncate for display. */
+									+ CONVERT(VARCHAR(36), TRY_CAST(SUBSTRING(seg.max_deep_data, 3, 16) AS UNIQUEIDENTIFIER))
+								/* CHAR / VARCHAR: 2-byte little-endian length prefix, then the (possibly sort-key encoded) bytes; truncate for display. */
 								WHEN c.system_type_id IN (167, 175) AND seg.min_deep_data IS NOT NULL THEN
-									LEFT(TRY_CAST(seg.min_deep_data AS VARCHAR(900)), 30)
+									LEFT(TRY_CAST(SUBSTRING(seg.min_deep_data, 3, 898) AS VARCHAR(900)), 30)
 									+ '' to ''
-									+ LEFT(TRY_CAST(seg.max_deep_data AS VARCHAR(900)), 30)
-								/* NCHAR / NVARCHAR. */
+									+ LEFT(TRY_CAST(SUBSTRING(seg.max_deep_data, 3, 898) AS VARCHAR(900)), 30)
+								/* NCHAR / NVARCHAR: 2-byte length prefix, then UTF-16LE bytes. */
 								WHEN c.system_type_id IN (231, 239) AND seg.min_deep_data IS NOT NULL THEN
-									LEFT(TRY_CAST(seg.min_deep_data AS NVARCHAR(450)), 30)
+									LEFT(TRY_CAST(SUBSTRING(seg.min_deep_data, 3, 898) AS NVARCHAR(450)), 30)
 									+ '' to ''
-									+ LEFT(TRY_CAST(seg.max_deep_data AS NVARCHAR(450)), 30)' ELSE N'' END +
+									+ LEFT(TRY_CAST(SUBSTRING(seg.max_deep_data, 3, 898) AS NVARCHAR(450)), 30)' ELSE N'' END +
 							N'
 								ELSE NULL
 							END,

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -3993,13 +3993,21 @@ BEGIN
         RAISERROR(N'Visualizing columnstore index contents.', 0,1) WITH NOWAIT;
 
         /*
-        SQL Server 2022+ / Azure SQL DB / MI added min_deep_data and max_deep_data
-        to sys.column_store_segments. When populated, they hold the actual bytes
-        of the segment min/max for strings, uniqueidentifiers, and datetimeoffset(>2).
-        Use them to render readable approximations of strings and GUIDs in the
-        visualizer instead of the dictionary IDs in min_data_id/max_data_id.
-        DATE is decoded directly from min_data_id (days since 0001-01-01) and
-        works on every supported version.
+        Decode the segment min/max into something readable for the visualizer
+        instead of the raw dictionary IDs in min_data_id / max_data_id.
+
+        DATE / DATETIME / DATETIME2 / SMALLDATETIME pack the value into the
+        BIGINT min_data_id and decode on every supported version:
+            DATE          : days since 0001-01-01
+            SMALLDATETIME : days * 65536 + minutes-since-midnight
+            DATETIME      : days * 2^32 + ticks (1/300 sec since midnight)
+            DATETIME2     : days * 2^40 + 100ns-ticks-since-midnight
+
+        SQL Server 2022+ / Azure SQL DB / MI added min_deep_data and
+        max_deep_data, which hold the actual bytes of the segment min/max
+        for strings, uniqueidentifiers, and datetimeoffset(scale>2). When
+        they are populated, decode them into GUIDs / strings / dates here.
+
         See https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3966
         */
         DECLARE @HasDeepData BIT = 0;
@@ -4079,17 +4087,47 @@ BEGIN
 						SELECT c.name AS column_name, p.partition_number, rg.row_group_id, rg.total_rows, rg.deleted_rows,
                             phys.state_desc, phys.trim_reason_desc, phys.transition_to_compressed_state_desc, phys.has_vertipaq_optimization,
 							details = COALESCE(CASE
-								/* DATE: min_data_id encodes days since 0001-01-01 on every supported version. */
+								/* DATE: min_data_id is days since 0001-01-01 on every supported version. */
 								WHEN c.system_type_id = 40 THEN
 									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id AS INT), CONVERT(DATE, ''0001-01-01'')), 23)
 									+ '' to ''
-									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id AS INT), CONVERT(DATE, ''0001-01-01'')), 23)' +
+									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id AS INT), CONVERT(DATE, ''0001-01-01'')), 23)
+								/* SMALLDATETIME: BIGINT = days * 65536 + minutes; days are since 1900-01-01. */
+								WHEN c.system_type_id = 58 THEN
+									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id / 65536 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
+									+ '' to ''
+									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id / 65536 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
+								/* DATETIME: BIGINT = days * 2^32 + ticks (1/300 sec); days are since 1900-01-01. */
+								WHEN c.system_type_id = 61 THEN
+									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id / 4294967296 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
+									+ '' to ''
+									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id / 4294967296 AS INT), CONVERT(DATE, ''1900-01-01'')), 23)
+								/* DATETIME2: BIGINT = days * 2^40 + ticks_100ns; days are since 0001-01-01. */
+								WHEN c.system_type_id = 42 THEN
+									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id / 1099511627776 AS INT), CONVERT(DATE, ''0001-01-01'')), 23)
+									+ '' to ''
+									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id / 1099511627776 AS INT), CONVERT(DATE, ''0001-01-01'')), 23)' +
 							CASE WHEN @HasDeepData = 1 THEN N'
 								/* UNIQUEIDENTIFIER: deep_data is a 2-byte length prefix (0x10 0x00) followed by the 16-byte GUID. */
 								WHEN c.system_type_id = 36 AND seg.min_deep_data IS NOT NULL THEN
 									CONVERT(VARCHAR(36), TRY_CAST(SUBSTRING(seg.min_deep_data, 3, 16) AS UNIQUEIDENTIFIER))
 									+ '' to ''
 									+ CONVERT(VARCHAR(36), TRY_CAST(SUBSTRING(seg.max_deep_data, 3, 16) AS UNIQUEIDENTIFIER))
+								/* DATETIMEOFFSET: deep_data is [2-byte length][time bytes][3-byte date][2-byte offset].
+								   Time width depends on scale: 3 bytes for scale 0-2, 4 bytes for 3-4, 5 bytes for 5-7.
+								   Date is 3 little-endian bytes of days since 0001-01-01. */
+								WHEN c.system_type_id = 43 AND seg.min_deep_data IS NOT NULL THEN
+									CONVERT(VARCHAR(10), DATEADD(DAY,
+										CAST(SUBSTRING(seg.min_deep_data, 3 + (CASE WHEN c.scale <= 2 THEN 3 WHEN c.scale <= 4 THEN 4 ELSE 5 END), 1) AS INT)
+										+ 256 * CAST(SUBSTRING(seg.min_deep_data, 4 + (CASE WHEN c.scale <= 2 THEN 3 WHEN c.scale <= 4 THEN 4 ELSE 5 END), 1) AS INT)
+										+ 65536 * CAST(SUBSTRING(seg.min_deep_data, 5 + (CASE WHEN c.scale <= 2 THEN 3 WHEN c.scale <= 4 THEN 4 ELSE 5 END), 1) AS INT),
+										CONVERT(DATE, ''0001-01-01'')), 23)
+									+ '' to ''
+									+ CONVERT(VARCHAR(10), DATEADD(DAY,
+										CAST(SUBSTRING(seg.max_deep_data, 3 + (CASE WHEN c.scale <= 2 THEN 3 WHEN c.scale <= 4 THEN 4 ELSE 5 END), 1) AS INT)
+										+ 256 * CAST(SUBSTRING(seg.max_deep_data, 4 + (CASE WHEN c.scale <= 2 THEN 3 WHEN c.scale <= 4 THEN 4 ELSE 5 END), 1) AS INT)
+										+ 65536 * CAST(SUBSTRING(seg.max_deep_data, 5 + (CASE WHEN c.scale <= 2 THEN 3 WHEN c.scale <= 4 THEN 4 ELSE 5 END), 1) AS INT),
+										CONVERT(DATE, ''0001-01-01'')), 23)
 								/* CHAR / VARCHAR: 2-byte little-endian length prefix, then the (possibly sort-key encoded) bytes; truncate for display. */
 								WHEN c.system_type_id IN (167, 175) AND seg.min_deep_data IS NOT NULL THEN
 									LEFT(TRY_CAST(SUBSTRING(seg.min_deep_data, 3, 898) AS VARCHAR(900)), 30)

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -3992,6 +3992,22 @@ BEGIN
     BEGIN
         RAISERROR(N'Visualizing columnstore index contents.', 0,1) WITH NOWAIT;
 
+        /*
+        SQL Server 2022+ / Azure SQL DB / MI added min_deep_data and max_deep_data
+        to sys.column_store_segments. When populated, they hold the actual bytes
+        of the segment min/max for strings, uniqueidentifiers, and datetimeoffset(>2).
+        Use them to render readable approximations of strings and GUIDs in the
+        visualizer instead of the dictionary IDs in min_data_id/max_data_id.
+        DATE is decoded directly from min_data_id (days since 0001-01-01) and
+        works on every supported version.
+        See https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3966
+        */
+        DECLARE @HasDeepData BIT = 0;
+        IF EXISTS (SELECT 1 FROM sys.all_columns
+                   WHERE object_id = OBJECT_ID('sys.column_store_segments')
+                     AND name = 'min_deep_data')
+            SET @HasDeepData = 1;
+
 		SET @dsql = N'USE ' + QUOTENAME(@DatabaseName) + N'; 
 			IF EXISTS(SELECT * FROM ' + QUOTENAME(@DatabaseName) + N'.sys.column_store_row_groups WHERE object_id = @ObjectID)
 				BEGIN
@@ -4062,7 +4078,34 @@ BEGIN
 					FROM (
 						SELECT c.name AS column_name, p.partition_number, rg.row_group_id, rg.total_rows, rg.deleted_rows,
                             phys.state_desc, phys.trim_reason_desc, phys.transition_to_compressed_state_desc, phys.has_vertipaq_optimization,
-							details = CAST(seg.min_data_id AS VARCHAR(20)) + '' to '' + CAST(seg.max_data_id AS VARCHAR(20)) + '', '' + CAST(CAST(((COALESCE(d.on_disk_size,0) + COALESCE(seg.on_disk_size,0)) / 1024.0 / 1024) AS DECIMAL(18,0)) AS VARCHAR(20)) + '' MB''' 
+							details = COALESCE(CASE
+								/* DATE: min_data_id encodes days since 0001-01-01 on every supported version. */
+								WHEN c.system_type_id = 40 THEN
+									CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.min_data_id AS INT), CONVERT(DATE, ''0001-01-01'')), 23)
+									+ '' to ''
+									+ CONVERT(VARCHAR(10), DATEADD(DAY, CAST(seg.max_data_id AS INT), CONVERT(DATE, ''0001-01-01'')), 23)' +
+							CASE WHEN @HasDeepData = 1 THEN N'
+								/* UNIQUEIDENTIFIER: deep_data carries the raw 16-byte GUID on SQL 2022+ / Azure SQL DB. */
+								WHEN c.system_type_id = 36 AND seg.min_deep_data IS NOT NULL THEN
+									CONVERT(VARCHAR(36), TRY_CAST(seg.min_deep_data AS UNIQUEIDENTIFIER))
+									+ '' to ''
+									+ CONVERT(VARCHAR(36), TRY_CAST(seg.max_deep_data AS UNIQUEIDENTIFIER))
+								/* CHAR / VARCHAR: deep_data is the actual sort-key bytes; truncate for display. */
+								WHEN c.system_type_id IN (167, 175) AND seg.min_deep_data IS NOT NULL THEN
+									LEFT(TRY_CAST(seg.min_deep_data AS VARCHAR(900)), 30)
+									+ '' to ''
+									+ LEFT(TRY_CAST(seg.max_deep_data AS VARCHAR(900)), 30)
+								/* NCHAR / NVARCHAR. */
+								WHEN c.system_type_id IN (231, 239) AND seg.min_deep_data IS NOT NULL THEN
+									LEFT(TRY_CAST(seg.min_deep_data AS NVARCHAR(450)), 30)
+									+ '' to ''
+									+ LEFT(TRY_CAST(seg.max_deep_data AS NVARCHAR(450)), 30)' ELSE N'' END +
+							N'
+								ELSE NULL
+							END,
+							/* Fall back to raw min/max_data_id for numeric types and anything we could not decode. */
+							CAST(seg.min_data_id AS VARCHAR(20)) + '' to '' + CAST(seg.max_data_id AS VARCHAR(20)))
+							+ '', '' + CAST(CAST(((COALESCE(d.on_disk_size,0) + COALESCE(seg.on_disk_size,0)) / 1024.0 / 1024) AS DECIMAL(18,0)) AS VARCHAR(20)) + '' MB'''
 							+ CASE WHEN @ShowPartitionRanges = 1 THEN N',
 							CASE
 								WHEN pp.system_type_id IN (40, 41, 42, 43, 58, 61) THEN 126


### PR DESCRIPTION
Closes #3966.

## Summary
The columnstore segment visualizer used to print raw `min_data_id`/`max_data_id` for every column, which are dictionary indices for non-numeric types and therefore meaningless when teaching segment elimination. Wrap the `details =` expression in a `CASE` so we render readable values:

- **DATE** &rarr; `YYYY-MM-DD` via `DATEADD` on `min_data_id` (days since `0001-01-01`).
- **SMALLDATETIME** &rarr; `YYYY-MM-DD` via `min_data_id / 65536` (days since `1900-01-01`).
- **DATETIME** &rarr; `YYYY-MM-DD` via `min_data_id / 2^32` (days since `1900-01-01`), with a floor-style adjustment so pre-1900 dates with non-zero ticks land on the right calendar day.
- **DATETIME2** &rarr; `YYYY-MM-DD` via `min_data_id / 2^40` (days since `0001-01-01`).
- **DATETIMEOFFSET** &rarr; `YYYY-MM-DD` parsed out of `min_deep_data` / `max_deep_data` (3 little-endian bytes of days since `0001-01-01`, offset by the column's `scale`-dependent time-byte width). Requires SQL 2022+ / Azure SQL DB / MI with the index rebuilt; else falls back to raw.
- **UNIQUEIDENTIFIER** &rarr; the GUID from `min_deep_data` / `max_deep_data` (skipping the 2-byte length prefix).
- **CHAR / VARCHAR / NCHAR / NVARCHAR** &rarr; the actual contents from `min_deep_data` / `max_deep_data`, truncated to 30 characters so they still fit the visualizer cells.
- Anything we can't decode (numerics, segments where `min_deep_data` is `NULL` because the index hasn't been rebuilt since the upgrade, etc.) falls back to the existing raw `min_data_id` / `max_data_id` display.

## Implementation notes
- Encodings for `min_data_id` were derived empirically against Azure SQL DB by writing CCIs with one known value at a time and decoding the BIGINT.
- The deep_data branches are gated by a runtime `sys.all_columns` check so the dynamic SQL never references columns that don't exist on older builds.
- Every conversion uses `TRY_CAST`, so a single odd row can't break the whole visualization.
- `min_deep_data` / `max_deep_data` are stored as a 2-byte little-endian byte-length prefix followed by the value bytes. Strip the prefix with `SUBSTRING(deep_data, 3, ...)` before casting (without that, GUIDs were shifted by `0x0010` and strings rendered with two leading garbage characters).
- For NVARCHAR specifically, the bytes after the prefix are the collation-aware sort key, not the literal string. ASCII characters round-trip cleanly; non-ASCII characters may be remapped (e.g. `'9'` &rarr; `'٩'` under `SQL_Latin1_General_CP1_CI_AS`). Still readable for teaching.

## Out of scope (intentional)
- `BINARY` / `VARBINARY` columns are not decoded; raw values stay.
- `TIME` columns are not decoded.

## Test plan
- [x] Live test on Azure SQL DB against a probe CCI with `id INT`, `order_date DATE`, `created_at DATETIME2(3)`, `customer_id UNIQUEIDENTIFIER`, `first_name VARCHAR(50)`, `description NVARCHAR(200)`, `amount DECIMAL(10,2)`. Confirmed every type renders as expected.
- [x] Live test against a probe CCI with `dt DATETIME`, `dt2 DATETIME2(3)`, `sdt SMALLDATETIME`, `dto DATETIMEOFFSET(3)`, `d DATE` covering 2010-01-01 through 2019-12-29 - all five render as `2010-01-01 to 2019-12-29` (DATETIMEOFFSET as `2010-01-01 to 2019-12-30` because the max value crosses midnight UTC).
- [x] Live test of pre-1900 DATETIME edge case (`1899-12-31 12:00:00`, `min_data_id = -4282007296`) to confirm the floor-division fix renders `1899-12-31` instead of `1900-01-01`.
- [ ] Run on a SQL 2022 / Azure SQL DB CCI that has *not* been rebuilt since the upgrade - confirm strings/GUIDs/datetimeoffset fall back to raw `min_data_id` / `max_data_id` instead of erroring.
- [ ] Run with `@ShowPartitionRanges = 1` on a partitioned columnstore - confirm the partition-range columns still render correctly alongside the new details format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)