### PR TITLE
Fix typos in comments and messages

### DIFF
--- a/sp_BlitzAnalysis.sql
+++ b/sp_BlitzAnalysis.sql
@@ -50,7 +50,7 @@ BEGIN
 	PRINT 'EXEC sp_BlitzAnalysis 
 @StartDate = NULL,		/* Specify a datetime or NULL will get an hour ago */
 @EndDate = NULL,		/* Specify a datetime or NULL will get an hour of data since @StartDate */
-@OutputDatabaseName = N''DBA'',		/* Specify the database name where where we can find your logged blitz data */
+@OutputDatabaseName = N''DBA'',		/* Specify the database name where we can find your logged blitz data */
 @OutputSchemaName = N''dbo'',		/* Specify the schema */
 @OutputTableNameBlitzFirst = N''BlitzFirst'',		/* Table name where you are storing sp_BlitzFirst output, Set to NULL to ignore */ 
 @OutputTableNameFileStats = N''BlitzFirst_FileStats'',		/* Table name where you are storing sp_BlitzFirst filestats output, Set to NULL to ignore */ 
@@ -174,7 +174,7 @@ BEGIN
 	/* Default to an hour of data or SYSDATETIMEOFFSET() if now is earlier than the hour added to @StartDate */
 	IF(DATEADD(HOUR,1,@StartDate) < SYSDATETIMEOFFSET())
 	BEGIN 
-		RAISERROR('@EndDate was NULL - Setting to return 1 hour of information, if you want more then set @EndDate aswell',0,0) WITH NOWAIT;
+		RAISERROR('@EndDate was NULL - Setting to return 1 hour of information, if you want more then set @EndDate as well',0,0) WITH NOWAIT;
 		SET @EndDate = DATEADD(HOUR,1,@StartDate);
 	END
 	ELSE 
@@ -493,7 +493,7 @@ END
 /* Blitz cache data */
 RAISERROR('Sortorder for BlitzCache data: %s',0,0,@BlitzCacheSortorder) WITH NOWAIT;
 
-/* Set intial CTE */
+/* Set initial CTE */
 SET @Sql = N'WITH CheckDates AS (
 SELECT DISTINCT CheckDate 
 FROM '

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5468,7 +5468,7 @@ Thank you.'
                     SET @AIAdviceText = N'No response received from AI service.';
                 END;
 
-                /* Store the response in the the ai_advice column */
+                /* Store the response in the ai_advice column */
                 UPDATE ##BlitzCacheProcs
                 SET ai_advice = @AIAdviceText, ai_raw_response = @AIResponseJSON, ai_payload = @AIPayload
                 WHERE SPID = @@SPID

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -90,7 +90,7 @@ BEGIN
 
         @OutputSchemaName: Specify a schema name to output information to a specific Schema
 
-        @OutputTableName: Specify table name to to output information to a specific table
+        @OutputTableName: Specify table name to output information to a specific table
 
         /*Point at a table containing deadlock XML*/
         @TargetDatabaseName: The database that contains the table with deadlock report XML

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -448,7 +448,7 @@ BEGIN
 END;
 IF (SELECT RIGHT(@MoveLogDrive, 1)) <> '/' AND CHARINDEX('/', @MoveLogDrive) > 0 --Has to end in a '/'
 BEGIN
-	IF @Execute = 'Y' OR @Debug = 1 RAISERROR('Fixing@MoveLogDrive to add a "/"', 0, 1) WITH NOWAIT;
+	IF @Execute = 'Y' OR @Debug = 1 RAISERROR('Fixing @MoveLogDrive to add a "/"', 0, 1) WITH NOWAIT;
 	SET @MoveLogDrive += N'/';
 END;
 ELSE IF (SELECT RIGHT(@MoveLogDrive, 1)) <> '\' --Has to end in a '\'
@@ -839,7 +839,7 @@ BEGIN
 					ELSE IF @Debug = 1
 					BEGIN
 						IF DATABASEPROPERTYEX(@UnquotedRestoreDatabaseName,'STATUS') IS NULL PRINT 'Unable to retrieve STATUS from "' + @UnquotedRestoreDatabaseName + '" database. Skipping setting database to SINGLE_USER';
-						ELSE IF DATABASEPROPERTYEX(@UnquotedRestoreDatabaseName,'STATUS') = 'RESTORING' PRINT @UnquotedRestoreDatabaseName + ' database STATUS is RESTORING. Skiping setting database to SINGLE_USER';
+						ELSE IF DATABASEPROPERTYEX(@UnquotedRestoreDatabaseName,'STATUS') = 'RESTORING' PRINT @UnquotedRestoreDatabaseName + ' database STATUS is RESTORING. Skipping setting database to SINGLE_USER';
 			        END
 		        END
             END
@@ -894,7 +894,7 @@ BEGIN
 					ELSE IF @Debug = 1
 					BEGIN
 						IF DATABASEPROPERTYEX(@UnquotedRestoreDatabaseName,'STATUS') IS NULL PRINT 'Unable to retrieve STATUS from "' + @UnquotedRestoreDatabaseName + '" database. Skipping setting database OFFLINE';
-						ELSE IF DATABASEPROPERTYEX(@UnquotedRestoreDatabaseName,'STATUS') = 'RESTORING' PRINT @UnquotedRestoreDatabaseName + ' database STATUS is RESTORING. Skiping setting database OFFLINE';
+						ELSE IF DATABASEPROPERTYEX(@UnquotedRestoreDatabaseName,'STATUS') = 'RESTORING' PRINT @UnquotedRestoreDatabaseName + ' database STATUS is RESTORING. Skipping setting database OFFLINE';
 			        END
 		        END
 			END;
@@ -1600,12 +1600,12 @@ IF @DatabaseOwner IS NOT NULL
 				END
 				ELSE
 				BEGIN
-					PRINT 'Current user''s login is NOT a member of the sysadmin role. Database TRUSTWORHY bit has not been enabled.';
+					PRINT 'Current user''s login is NOT a member of the sysadmin role. Database TRUSTWORTHY bit has not been enabled.';
 				END
 			END
 			ELSE
 			BEGIN
-				PRINT @RestoreDatabaseName + ' is still in Recovery, so we are unable to enable the TRUSTWORHY bit.';
+				PRINT @RestoreDatabaseName + ' is still in Recovery, so we are unable to enable the TRUSTWORTHY bit.';
 			END
 		END;
 


### PR DESCRIPTION
Fixes [#3967](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3967) — thanks to @sepe81 for spotting these.

## Changes

- **sp_BlitzAnalysis.sql**: "where where" → "where", "aswell" → "as well", "intial" → "initial"
- **sp_BlitzCache.sql**: "the the" → "the"
- **sp_BlitzLock.sql**: "to to" → "to"
- **sp_DatabaseRestore.sql**: "TRUSTWORHY" → "TRUSTWORTHY" (×2), "Skiping" → "Skipping" (×2), "Fixing@MoveLogDrive" → "Fixing @MoveLogDrive"

Comments and user-facing messages only — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)