### PR TITLE
sp_DatabaseRestore: harden against parameter SQL injection

### DIFF
--- a/Documentation/Development/Test sp_DatabaseRestore.sql
+++ b/Documentation/Development/Test sp_DatabaseRestore.sql
@@ -230,6 +230,35 @@ BEGIN TRY
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
 
+PRINT '--- 3.6 PASSES: @RunStoredProcAfterRestore with leading/trailing whitespace ---';
+PRINT '   (the proc trims and collapses whitespace around dots before PARSENAME so';
+PRINT '    pre-hardening callers using ''  MyProc  '' or ''dbo. MyProc'' still work)';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @RunStoredProcAfterRestore = '  MyProc  ',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 3.7 PASSES: @RunStoredProcAfterRestore with whitespace around the dot ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @RunStoredProcAfterRestore = 'dbo. MyProc',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 3.8 PASSES: bracketed identifiers with whitespace around the dot ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @RunStoredProcAfterRestore = '[dbo]. [My Proc]',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
 
 PRINT '====================================================';
 PRINT 'PART 4 - Logic-only verification (mimics what the proc does)';

--- a/Documentation/Development/Test sp_DatabaseRestore.sql
+++ b/Documentation/Development/Test sp_DatabaseRestore.sql
@@ -313,7 +313,20 @@ PRINT 'Input @StandbyUndoPath: ' + @StandbyPath;
 PRINT 'Generated STANDBY clause: STANDBY = ''' + REPLACE(@StandbyPath, N'''', N'''''') + REPLACE(@TestDb, N'''', N'''''') + 'Undo.ldf''';
 GO
 
-PRINT '--- 4.5 NEUTRAL: nested-EXEC RESTORE HEADERONLY needs four-quote escape ---';
+PRINT '--- 4.5 NEUTRAL: MOVE clause with apostrophe in @MoveDataDrive ---';
+PRINT '   The path-validation gate allows apostrophes (legal in Windows paths) so';
+PRINT '   they reach the @MoveOption builder, which embeds them in MOVE ''logical''';
+PRINT '   TO ''physical'' literals. The inline REPLACE doubles the apostrophe so';
+PRINT '   the literal still terminates correctly.';
+DECLARE @FilesTbl TABLE (LogicalName nvarchar(128), TargetPhysicalName nvarchar(260), PhysicalName nvarchar(260));
+INSERT @FilesTbl VALUES (N'TestData', N'C:\It''s\Data\Test.mdf', N'D:\old\Test.mdf');
+DECLARE @MoveOptOut nvarchar(max) = N'';
+SELECT @MoveOptOut = @MoveOptOut + N', MOVE ''' + REPLACE(LogicalName, N'''', N'''''') + N''' TO ''' + REPLACE(TargetPhysicalName, N'''', N'''''') + ''''
+FROM @FilesTbl;
+PRINT '@MoveOption fragment: ' + @MoveOptOut;
+GO
+
+PRINT '--- 4.6 NEUTRAL: nested-EXEC RESTORE HEADERONLY needs four-quote escape ---';
 PRINT '   The HEADERONLY/FILELISTONLY templates are EXEC(''RESTORE ... DISK=''''<path>'''''')';
 PRINT '   so the path crosses two SQL-parser layers. A single apostrophe in the';
 PRINT '   path needs to become four single quotes (REPLICATE(N'''''''', 4)) to';

--- a/Documentation/Development/Test sp_DatabaseRestore.sql
+++ b/Documentation/Development/Test sp_DatabaseRestore.sql
@@ -1,0 +1,307 @@
+/*
+sp_DatabaseRestore — SQL injection regression tests
+=====================================================
+
+These cases cover inputs that, prior to the hardening in PR #3980,
+could have been abused by a caller with EXECUTE permission on the
+proc to inject T-SQL or to inject shell commands via xp_cmdshell.
+
+Threat model: a caller who has EXECUTE on sp_DatabaseRestore but is
+not sysadmin should not be able to escalate to arbitrary T-SQL or
+shell command execution by passing crafted parameter values.
+
+How to run
+----------
+sp_DatabaseRestore + dbo.CommandExecute (Ola Hallengren's Maintenance
+Solution) must be installed in the current database. None of the C:\
+paths below need to actually exist — the validation gate fires (or
+doesn't) before xp_dirtree / xp_cmdshell are invoked, and the
+dynamic-RESTORE strings produced by @Debug = 1 are only PRINTed.
+
+Each test wraps the EXEC in BEGIN TRY / BEGIN CATCH so one failure
+doesn't stop the suite. The expected outcome is annotated above
+each test as either:
+   BLOCKED   — the validation gate must RAISERROR + RETURN
+   PASSES    — the validation gate must let the input through
+   NEUTRAL   — the input must be quoted/escaped so it cannot break
+               out of its surrounding SQL literal or identifier
+
+The "logic-only" cases at the bottom mimic the proc's PARSENAME +
+QUOTENAME / single-quote-doubling without needing a real backup
+folder, so the schema-resolution and identifier-quoting behaviour
+can still be exercised on a fresh test rig.
+
+Paths use C:\ so this works on any test rig without special storage.
+*/
+
+
+PRINT '====================================================';
+PRINT 'PART 1 - Path-shape validation gate';
+PRINT 'Each path-shaped parameter that contains a character with no';
+PRINT 'legitimate use in a Windows path (and high command-injection';
+PRINT 'risk) must be rejected before the proc reaches xp_cmdshell';
+PRINT 'or dynamic-SQL construction.';
+PRINT '====================================================';
+GO
+
+PRINT '--- 1.1 BLOCKED: ampersand in @BackupPathFull (cmd shell metachar) ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\& whoami &\',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.2 BLOCKED: semicolon + nested injection in @BackupPathFull ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\; xp_cmdshell ''calc''; --\',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.3 BLOCKED: pipe in @StandbyUndoPath ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @StandbyUndoPath = 'C:\Standby\| dir |\',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.4 BLOCKED: caret in @MoveDataDrive ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @MoveDataDrive = 'C:\Data^evil\',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.5 BLOCKED: < in @FileNamePrefix ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @FileNamePrefix = 'pref<x',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.6 BLOCKED: > in @MoveLogDrive ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @MoveLogDrive = 'C:\Logs>x\',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.7 BLOCKED: double-quote in @BackupPathDiff ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @BackupPathDiff = 'C:\Diff\"& whoami &"\',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.8 BLOCKED: NUL byte in @BackupPathLog ---';
+PRINT '   (the LIKE pattern uses COLLATE Latin1_General_BIN2 so NUL is detected;';
+PRINT '    under the default collation NUL is silently dropped from both sides)';
+DECLARE @PathWithNul nvarchar(260) = N'C:\Logs\' + NCHAR(0) + N'evil\';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @BackupPathLog = @PathWithNul,
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.9 BLOCKED: CR in @BackupPathFull ---';
+DECLARE @PathWithCR nvarchar(260) = N'C:\Backups\' + NCHAR(13) + N'evil\';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = @PathWithCR,
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 1.10 BLOCKED: LF in @MoveFilestreamDrive ---';
+DECLARE @PathWithLF nvarchar(260) = N'C:\FS\' + NCHAR(10) + N'evil\';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @MoveFilestreamDrive = @PathWithLF,
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+
+PRINT '====================================================';
+PRINT 'PART 2 - Identifier validation';
+PRINT '@RunStoredProcAfterRestore must be a 1- or 2-part name. The';
+PRINT 'proc rejects 3- and 4-part names so a caller cannot execute';
+PRINT 'cross-server / cross-database procs by smuggling extra dots.';
+PRINT '====================================================';
+GO
+
+PRINT '--- 2.1 BLOCKED: 3-part @RunStoredProcAfterRestore ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @RunStoredProcAfterRestore = 'targetdb.dbo.MyProc',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 2.2 BLOCKED: 4-part (linked-server) @RunStoredProcAfterRestore ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @RunStoredProcAfterRestore = 'attackerSrv.targetdb.dbo.MyProc',
+                                @Execute = 'N', @Debug = 1;
+    PRINT '*** REGRESSION: not blocked ***';
+END TRY BEGIN CATCH PRINT 'BLOCKED: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+
+PRINT '====================================================';
+PRINT 'PART 3 - Regression: legitimate inputs must still pass';
+PRINT 'These should pass the validation gate. They will fail later';
+PRINT 'with "(FULL) No rows were returned for that database in path"';
+PRINT 'because no real backups exist at C:\Backups\ — that is the';
+PRINT 'expected outcome and means the validation gate did not block.';
+PRINT '====================================================';
+GO
+
+PRINT '--- 3.1 PASSES: ordinary path ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 3.2 PASSES: path with apostrophe (legal but rare on Windows) ---';
+PRINT '   (validation gate must allow it; downstream sites must escape it)';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\It''s Friday\',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 3.3 PASSES: @Database with ampersand (database identifier, not a path) ---';
+PRINT '   (DB names can legally contain & ; etc.; @Database is intentionally NOT';
+PRINT '    in the path-shape gate — it gets single-quote-escaped at concat sites)';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'My&DB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 3.4 PASSES: 1-part @RunStoredProcAfterRestore ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @RunStoredProcAfterRestore = 'MyProc',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+PRINT '--- 3.5 PASSES: 2-part @RunStoredProcAfterRestore ---';
+BEGIN TRY
+    EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
+                                @BackupPathFull = 'C:\Backups\',
+                                @RunStoredProcAfterRestore = 'dbo.MyProc',
+                                @Execute = 'N', @Debug = 1;
+END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
+GO
+
+
+PRINT '====================================================';
+PRINT 'PART 4 - Logic-only verification (mimics what the proc does)';
+PRINT 'These do not call the proc; they reproduce the proc''s';
+PRINT 'PARSENAME + QUOTENAME / single-quote-doubling so you can see';
+PRINT 'on a fresh rig (without real backups) that injected payloads';
+PRINT 'are quoted into harmless identifiers / string literals.';
+PRINT '====================================================';
+GO
+
+PRINT '--- 4.1 NEUTRAL: @RunStoredProcAfterRestore with embedded ;DROP TABLE ---';
+PRINT '   Input is wrapped in a single bracketed identifier; SQL Server treats';
+PRINT '   the entire payload as one (non-existent) procedure name and the EXEC';
+PRINT '   simply fails to find it — no statement break, no DROP runs.';
+DECLARE @Input nvarchar(260) = N'dbo.MyProc; DROP TABLE foo; --';
+DECLARE @Schema sysname = NULLIF(PARSENAME(@Input, 2), N'');
+DECLARE @Proc   sysname = PARSENAME(@Input, 1);
+DECLARE @Db     nvarchar(128) = QUOTENAME('TargetDB');
+PRINT 'Input:  ' + @Input;
+PRINT 'Output: EXEC ' + @Db + N'.' + ISNULL(QUOTENAME(@Schema), N'') + N'.' + QUOTENAME(@Proc);
+GO
+
+PRINT '--- 4.2 NEUTRAL: @DatabaseOwner with bracket-injection ---';
+PRINT '   QUOTENAME doubles the inner ] so the entire string becomes one';
+PRINT '   bracketed identifier; the EXISTS check on syslogins fails to find';
+PRINT '   the login and the proc just PRINTs "not a valid Login".';
+DECLARE @Owner sysname = N'sa]; DROP TABLE foo; --';
+DECLARE @TargetDb nvarchar(128) = QUOTENAME('TargetDB');
+PRINT 'Input:  ' + @Owner;
+PRINT 'Output: ALTER AUTHORIZATION ON DATABASE::' + @TargetDb + N' TO ' + QUOTENAME(@Owner);
+GO
+
+PRINT '--- 4.3 NEUTRAL: 1-part proc name uses 3-part db..proc form ---';
+PRINT '   Without the second dot, [TargetDB].[MyProc] would be parsed as';
+PRINT '   schema=TargetDB.proc=MyProc in the *current* DB, not a proc in';
+PRINT '   the restored DB.';
+DECLARE @In nvarchar(260) = N'MyProc';
+DECLARE @S sysname = NULLIF(PARSENAME(@In, 2), N'');
+DECLARE @P sysname = PARSENAME(@In, 1);
+DECLARE @D nvarchar(128) = QUOTENAME('TargetDB');
+PRINT 'Input:  ' + @In;
+PRINT 'Output: EXEC ' + @D + N'.' + ISNULL(QUOTENAME(@S), N'') + N'.' + QUOTENAME(@P);
+GO
+
+PRINT '--- 4.4 NEUTRAL: @StandbyUndoPath with apostrophe gets quote-doubled in dynamic RESTORE ---';
+PRINT '   The path itself is preserved verbatim; what doubles is the apostrophe';
+PRINT '   inside the SQL string literal. After SQL parses the literal, the value';
+PRINT '   is a path containing one apostrophe, which is what the user supplied.';
+DECLARE @StandbyPath nvarchar(max) = N'C:\Standby\It''s\';
+DECLARE @TestDb nvarchar(128) = N'TestDB';
+PRINT 'Input @StandbyUndoPath: ' + @StandbyPath;
+PRINT 'Generated STANDBY clause: STANDBY = ''' + REPLACE(@StandbyPath, N'''', N'''''') + REPLACE(@TestDb, N'''', N'''''') + 'Undo.ldf''';
+GO
+
+PRINT '--- 4.5 NEUTRAL: nested-EXEC RESTORE HEADERONLY needs four-quote escape ---';
+PRINT '   The HEADERONLY/FILELISTONLY templates are EXEC(''RESTORE ... DISK=''''<path>'''''')';
+PRINT '   so the path crosses two SQL-parser layers. A single apostrophe in the';
+PRINT '   path needs to become four single quotes (REPLICATE(N'''''''', 4)) to';
+PRINT '   survive both layers and reappear as one apostrophe in the inner literal.';
+DECLARE @Tpl nvarchar(4000) = N'EXEC (''RESTORE HEADERONLY FROM DISK=''''{Path}'''''')';
+DECLARE @Path nvarchar(max) = N'C:\Backups\It''s\full.bak';
+DECLARE @Sql  nvarchar(max) = REPLACE(@Tpl, N'{Path}', REPLACE(@Path, N'''', REPLICATE(N'''', 4)));
+PRINT 'Input @Path:   ' + @Path;
+PRINT 'Outer @sql:    ' + @Sql;
+PRINT '(after the outer EXEC parses @sql, the inner RESTORE sees a literal';
+PRINT '''C:\Backups\It''s\full.bak'' — one apostrophe, exactly as supplied)';
+GO
+
+
+PRINT '====================================================';
+PRINT 'Done. Suite passed if every BLOCKED test produced "BLOCKED:"';
+PRINT 'and every PASSES test produced "EXPECTED LATE FAILURE: (FULL)';
+PRINT 'No rows were returned..." (or completed without raising).';
+PRINT '====================================================';
+GO

--- a/Documentation/Development/Test sp_DatabaseRestore.sql
+++ b/Documentation/Development/Test sp_DatabaseRestore.sql
@@ -37,10 +37,13 @@ Paths use C:\ so this works on any test rig without special storage.
 
 PRINT '====================================================';
 PRINT 'PART 1 - Path-shape validation gate';
-PRINT 'Each path-shaped parameter that contains a character with no';
-PRINT 'legitimate use in a Windows path (and high command-injection';
-PRINT 'risk) must be rejected before the proc reaches xp_cmdshell';
-PRINT 'or dynamic-SQL construction.';
+PRINT 'Each path-shaped parameter that contains a character we treat';
+PRINT 'as too risky to forward to cmd.exe / dynamic SQL must be';
+PRINT 'rejected before the proc reaches xp_cmdshell or dynamic-SQL';
+PRINT 'construction. (Note: characters like &, ;, ^ are technically';
+PRINT 'valid in Windows filenames; the restriction is a deliberate';
+PRINT 'security policy on top of OS path validity, not a claim that';
+PRINT 'they cannot legally appear in a Windows path.)';
 PRINT '====================================================';
 GO
 
@@ -179,9 +182,16 @@ GO
 PRINT '====================================================';
 PRINT 'PART 3 - Regression: legitimate inputs must still pass';
 PRINT 'These should pass the validation gate. They will fail later';
-PRINT 'with "(FULL) No rows were returned for that database in path"';
-PRINT 'because no real backups exist at C:\Backups\ — that is the';
-PRINT 'expected outcome and means the validation gate did not block.';
+PRINT 'with the proc''s "no rows / bad path" error because no real';
+PRINT 'backups exist at C:\Backups\ — that is the expected outcome';
+PRINT 'and means the validation gate did not block.';
+PRINT '';
+PRINT 'Each EXEC sets @SimpleFolderEnumeration = 1 to force the';
+PRINT 'xp_dirtree code path; otherwise the late-failure message';
+PRINT 'differs depending on whether xp_cmdshell is enabled on the';
+PRINT 'instance ("(FULL) No rows were returned..." vs "(FULL) No';
+PRINT 'rows or bad value for path..."), and we want a stable';
+PRINT 'expected outcome across test rigs.';
 PRINT '====================================================';
 GO
 
@@ -189,6 +199,7 @@ PRINT '--- 3.1 PASSES: ordinary path ---';
 BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
                                 @BackupPathFull = 'C:\Backups\',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
@@ -198,6 +209,7 @@ PRINT '   (validation gate must allow it; downstream sites must escape it)';
 BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
                                 @BackupPathFull = 'C:\Backups\It''s Friday\',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
@@ -208,6 +220,7 @@ PRINT '    in the path-shape gate — it gets single-quote-escaped at concat sit
 BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'My&DB',
                                 @BackupPathFull = 'C:\Backups\',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
@@ -217,6 +230,7 @@ BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
                                 @BackupPathFull = 'C:\Backups\',
                                 @RunStoredProcAfterRestore = 'MyProc',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
@@ -226,6 +240,7 @@ BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
                                 @BackupPathFull = 'C:\Backups\',
                                 @RunStoredProcAfterRestore = 'dbo.MyProc',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
@@ -237,6 +252,7 @@ BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
                                 @BackupPathFull = 'C:\Backups\',
                                 @RunStoredProcAfterRestore = '  MyProc  ',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
@@ -246,6 +262,7 @@ BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
                                 @BackupPathFull = 'C:\Backups\',
                                 @RunStoredProcAfterRestore = 'dbo. MyProc',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO
@@ -255,6 +272,7 @@ BEGIN TRY
     EXEC dbo.sp_DatabaseRestore @Database = 'AnyDB',
                                 @BackupPathFull = 'C:\Backups\',
                                 @RunStoredProcAfterRestore = '[dbo]. [My Proc]',
+                                @SimpleFolderEnumeration = 1,
                                 @Execute = 'N', @Debug = 1;
 END TRY BEGIN CATCH PRINT 'EXPECTED LATE FAILURE: ' + ERROR_MESSAGE(); END CATCH;
 GO

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -539,20 +539,21 @@ BEGIN
 END
 
 /* Reject path-shaped parameters that contain shell metacharacters or control chars.
-   Single quotes are deliberately allowed (legal in Windows paths) and are escaped at concat sites instead. */
-DECLARE @ForbiddenPathChars NVARCHAR(20) = N'"&|;^<>' + NCHAR(0) + NCHAR(10) + NCHAR(13);
-DECLARE @ForbiddenPathPattern NVARCHAR(40) = N'%[' + @ForbiddenPathChars + N']%';
+   Single quotes are deliberately allowed (legal in Windows paths) and are escaped at concat sites instead.
+   COLLATE Latin1_General_BIN2 is required so the LIKE '[...]' class catches NCHAR(0) — under default
+   collations the NUL byte is silently dropped from the pattern and compared values. */
+DECLARE @ForbiddenPathPattern NVARCHAR(40) = N'%["&|;^<>' + NCHAR(0) + NCHAR(10) + NCHAR(13) + N']%';
 DECLARE @InvalidPathParam sysname = NULL;
-IF @BackupPathFull            LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@BackupPathFull';
-IF @InvalidPathParam IS NULL AND @BackupPathDiff           LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@BackupPathDiff';
-IF @InvalidPathParam IS NULL AND @BackupPathLog            LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@BackupPathLog';
-IF @InvalidPathParam IS NULL AND @MoveDataDrive            LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveDataDrive';
-IF @InvalidPathParam IS NULL AND @MoveLogDrive             LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveLogDrive';
-IF @InvalidPathParam IS NULL AND @MoveFilestreamDrive      LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveFilestreamDrive';
-IF @InvalidPathParam IS NULL AND @MoveFullTextCatalogDrive LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveFullTextCatalogDrive';
-IF @InvalidPathParam IS NULL AND @StandbyUndoPath          LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@StandbyUndoPath';
-IF @InvalidPathParam IS NULL AND @FileNamePrefix           LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@FileNamePrefix';
-IF @InvalidPathParam IS NULL AND @Database                 LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@Database';
+IF @BackupPathFull            LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@BackupPathFull';
+IF @InvalidPathParam IS NULL AND @BackupPathDiff           LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@BackupPathDiff';
+IF @InvalidPathParam IS NULL AND @BackupPathLog            LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@BackupPathLog';
+IF @InvalidPathParam IS NULL AND @MoveDataDrive            LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@MoveDataDrive';
+IF @InvalidPathParam IS NULL AND @MoveLogDrive             LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@MoveLogDrive';
+IF @InvalidPathParam IS NULL AND @MoveFilestreamDrive      LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@MoveFilestreamDrive';
+IF @InvalidPathParam IS NULL AND @MoveFullTextCatalogDrive LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@MoveFullTextCatalogDrive';
+IF @InvalidPathParam IS NULL AND @StandbyUndoPath          LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@StandbyUndoPath';
+IF @InvalidPathParam IS NULL AND @FileNamePrefix           LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@FileNamePrefix';
+IF @InvalidPathParam IS NULL AND @Database                 LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@Database';
 IF @InvalidPathParam IS NOT NULL
 BEGIN
 	RAISERROR('Parameter %s contains a character that is not allowed in a file path. Forbidden: " & | ; ^ < > or control characters.', 16, 1, @InvalidPathParam) WITH NOWAIT;

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -541,7 +541,10 @@ END
 /* Reject path-shaped parameters that contain shell metacharacters or control chars.
    Single quotes are deliberately allowed (legal in Windows paths) and are escaped at concat sites instead.
    COLLATE Latin1_General_BIN2 is required so the LIKE '[...]' class catches NCHAR(0) — under default
-   collations the NUL byte is silently dropped from the pattern and compared values. */
+   collations the NUL byte is silently dropped from the pattern and compared values.
+   @Database is intentionally NOT in this list: it is primarily an identifier (database names can
+   legally contain '&', ';', etc.) and downstream usage either parameter-binds it (LIKE filters
+   against @FileList) or single-quote-escapes it before concatenating into a quoted SQL literal. */
 DECLARE @ForbiddenPathPattern NVARCHAR(40) = N'%["&|;^<>' + NCHAR(0) + NCHAR(10) + NCHAR(13) + N']%';
 DECLARE @InvalidPathParam sysname = NULL;
 IF @BackupPathFull            LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@BackupPathFull';
@@ -553,10 +556,9 @@ IF @InvalidPathParam IS NULL AND @MoveFilestreamDrive      LIKE @ForbiddenPathPa
 IF @InvalidPathParam IS NULL AND @MoveFullTextCatalogDrive LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@MoveFullTextCatalogDrive';
 IF @InvalidPathParam IS NULL AND @StandbyUndoPath          LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@StandbyUndoPath';
 IF @InvalidPathParam IS NULL AND @FileNamePrefix           LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@FileNamePrefix';
-IF @InvalidPathParam IS NULL AND @Database                 LIKE @ForbiddenPathPattern COLLATE Latin1_General_BIN2 SET @InvalidPathParam = N'@Database';
 IF @InvalidPathParam IS NOT NULL
 BEGIN
-	RAISERROR('Parameter %s contains a character that is not allowed in a file path. Forbidden: " & | ; ^ < > or control characters.', 16, 1, @InvalidPathParam) WITH NOWAIT;
+	RAISERROR('Parameter %s contains a forbidden character. Not allowed: " & | ; ^ < > or control characters.', 16, 1, @InvalidPathParam) WITH NOWAIT;
 	RETURN;
 END;
 
@@ -964,7 +966,7 @@ BEGIN
                              (SELECT CHAR( 10 ) + ',DISK=''' + REPLACE(BackupPath, '''', '''''') + REPLACE(BackupFile, '''', '''''') + ''''
 							  FROM #SplitFullBackups
 							  ORDER BY BackupFile
-							  FOR XML PATH ('')),
+							  FOR XML PATH (''), TYPE).value('.', 'nvarchar(max)'),
                              1,
                              2,
                              '') + N' WITH NORECOVERY, REPLACE' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
@@ -1156,7 +1158,7 @@ BEGIN
 											 (SELECT CHAR( 10 ) + ',DISK=''' + REPLACE(BackupPath, '''', '''''') + REPLACE(BackupFile, '''', '''''') + ''''
 											 FROM #SplitDiffBackups
 											 ORDER BY BackupFile
-											 FOR XML PATH ('')),
+											 FOR XML PATH (''), TYPE).value('.', 'nvarchar(max)'),
 									   1,
 									   2,
 									   '' ) + N' WITH NORECOVERY, REPLACE' +  @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
@@ -1516,7 +1518,7 @@ WHERE BackupFile IS NOT NULL;
 									 FROM #SplitLogBackups
 									 WHERE DenseRank = @LogRestoreRanking
 									 ORDER BY BackupFile
-									 FOR XML PATH ('')),
+									 FOR XML PATH (''), TYPE).value('.', 'nvarchar(max)'),
 								1,
 								2,
 								'' ) + N' WITH ' + @LogRecoveryOption + NCHAR(13) + NCHAR(10);
@@ -1704,8 +1706,12 @@ BEGIN
 		RETURN;
 	END;
 	PRINT 'Attempting to run ' + @RunStoredProcAfterRestore
+	/* Always emit a 3-part name (db.schema.proc). For 1-part input the schema slot is left empty
+	   so the name resolves as db..proc — i.e., the default schema in the restored DB. Without the
+	   second dot, [db].[proc] is parsed as schema.object in the *current* DB. */
 	SET @sql = N'EXEC ' + @RestoreDatabaseName + N'.'
-	         + COALESCE(QUOTENAME(@RunStoredProcSchema) + N'.', N'')
+	         + ISNULL(QUOTENAME(@RunStoredProcSchema), N'')
+	         + N'.'
 	         + QUOTENAME(@RunStoredProcName);
 
 	IF @Debug = 1 OR @Execute = 'N'

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -562,6 +562,25 @@ BEGIN
 	RETURN;
 END;
 
+/* Validate @RunStoredProcAfterRestore shape up-front so an invalid input fails fast instead
+   of after a successful restore. The actual EXEC build happens later (after the restore);
+   here we only check that the value is a 1- or 2-part name and stash the whitespace-normalized
+   form for later reuse. See the EXEC build site for the QUOTENAME logic. */
+DECLARE @RunStoredProcNormalized nvarchar(260) = NULL;
+IF @RunStoredProcAfterRestore IS NOT NULL AND LEN(LTRIM(@RunStoredProcAfterRestore)) > 0
+BEGIN
+	SET @RunStoredProcNormalized = LTRIM(RTRIM(@RunStoredProcAfterRestore));
+	WHILE CHARINDEX(N' .', @RunStoredProcNormalized) > 0 SET @RunStoredProcNormalized = REPLACE(@RunStoredProcNormalized, N' .', N'.');
+	WHILE CHARINDEX(N'. ', @RunStoredProcNormalized) > 0 SET @RunStoredProcNormalized = REPLACE(@RunStoredProcNormalized, N'. ', N'.');
+	IF PARSENAME(@RunStoredProcNormalized, 1) IS NULL
+	   OR PARSENAME(@RunStoredProcNormalized, 3) IS NOT NULL
+	   OR PARSENAME(@RunStoredProcNormalized, 4) IS NOT NULL
+	BEGIN
+		RAISERROR('@RunStoredProcAfterRestore must be a procedure name or schema.procedure (1- or 2-part name).', 16, 1) WITH NOWAIT;
+		RETURN;
+	END;
+END;
+
 --File Extension cleanup
 IF @FileExtensionDiff LIKE '%.%'
 BEGIN
@@ -1696,22 +1715,10 @@ END;'
 
 IF @RunStoredProcAfterRestore IS NOT NULL AND LEN(LTRIM(@RunStoredProcAfterRestore)) > 0
 BEGIN
-	/* Normalize whitespace before PARSENAME: trim outer space and collapse any whitespace
-	   that surrounds the dots, so 'dbo. MyProc' or '  MyProc ' parse the same as 'dbo.MyProc'.
-	   The original raw-concat behavior accepted these because T-SQL's parser ignores
-	   whitespace around dots in EXEC statements; preserving that for backward compat. */
-	DECLARE @NormalizedRunStoredProc nvarchar(260) = LTRIM(RTRIM(@RunStoredProcAfterRestore));
-	WHILE CHARINDEX(N' .', @NormalizedRunStoredProc) > 0 SET @NormalizedRunStoredProc = REPLACE(@NormalizedRunStoredProc, N' .', N'.');
-	WHILE CHARINDEX(N'. ', @NormalizedRunStoredProc) > 0 SET @NormalizedRunStoredProc = REPLACE(@NormalizedRunStoredProc, N'. ', N'.');
-	DECLARE @RunStoredProcSchema sysname = NULLIF(PARSENAME(@NormalizedRunStoredProc, 2), N'');
-	DECLARE @RunStoredProcName   sysname = PARSENAME(@NormalizedRunStoredProc, 1);
-	IF @RunStoredProcName IS NULL
-	   OR PARSENAME(@NormalizedRunStoredProc, 3) IS NOT NULL
-	   OR PARSENAME(@NormalizedRunStoredProc, 4) IS NOT NULL
-	BEGIN
-		RAISERROR('@RunStoredProcAfterRestore must be a procedure name or schema.procedure (1- or 2-part name).', 16, 1) WITH NOWAIT;
-		RETURN;
-	END;
+	/* Shape and whitespace already validated near the top of the proc; @RunStoredProcNormalized
+	   holds the trimmed/dot-normalized form. Re-PARSENAME here just to extract the parts. */
+	DECLARE @RunStoredProcSchema sysname = NULLIF(PARSENAME(@RunStoredProcNormalized, 2), N'');
+	DECLARE @RunStoredProcName   sysname = PARSENAME(@RunStoredProcNormalized, 1);
 	PRINT 'Attempting to run ' + @RunStoredProcAfterRestore
 	/* Always emit a 3-part name (db.schema.proc). For 1-part input the schema slot is left empty
 	   ([db]..[proc]) so SQL Server applies its own schema-resolution rules in the target DB.

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -538,6 +538,27 @@ BEGIN
 	END
 END
 
+/* Reject path-shaped parameters that contain shell metacharacters or control chars.
+   Single quotes are deliberately allowed (legal in Windows paths) and are escaped at concat sites instead. */
+DECLARE @ForbiddenPathChars NVARCHAR(20) = N'"&|;^<>' + NCHAR(0) + NCHAR(10) + NCHAR(13);
+DECLARE @ForbiddenPathPattern NVARCHAR(40) = N'%[' + @ForbiddenPathChars + N']%';
+DECLARE @InvalidPathParam sysname = NULL;
+IF @BackupPathFull            LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@BackupPathFull';
+IF @InvalidPathParam IS NULL AND @BackupPathDiff           LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@BackupPathDiff';
+IF @InvalidPathParam IS NULL AND @BackupPathLog            LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@BackupPathLog';
+IF @InvalidPathParam IS NULL AND @MoveDataDrive            LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveDataDrive';
+IF @InvalidPathParam IS NULL AND @MoveLogDrive             LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveLogDrive';
+IF @InvalidPathParam IS NULL AND @MoveFilestreamDrive      LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveFilestreamDrive';
+IF @InvalidPathParam IS NULL AND @MoveFullTextCatalogDrive LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@MoveFullTextCatalogDrive';
+IF @InvalidPathParam IS NULL AND @StandbyUndoPath          LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@StandbyUndoPath';
+IF @InvalidPathParam IS NULL AND @FileNamePrefix           LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@FileNamePrefix';
+IF @InvalidPathParam IS NULL AND @Database                 LIKE @ForbiddenPathPattern SET @InvalidPathParam = N'@Database';
+IF @InvalidPathParam IS NOT NULL
+BEGIN
+	RAISERROR('Parameter %s contains a character that is not allowed in a file path. Forbidden: " & | ; ^ < > or control characters.', 16, 1, @InvalidPathParam) WITH NOWAIT;
+	RETURN;
+END;
+
 --File Extension cleanup
 IF @FileExtensionDiff LIKE '%.%'
 BEGIN
@@ -625,7 +646,7 @@ BEGIN
 		END
 		ELSE
 		BEGIN
-			SET @cmd = N'DIR /b "' + @CurrentBackupPathFull + N'"';
+			SET @cmd = N'DIR /b "' + REPLACE(@CurrentBackupPathFull, N'''', N'''''') + N'"';
 			IF @Debug = 1
 			BEGIN
 				IF @cmd IS NULL PRINT '@cmd is NULL for @CurrentBackupPathFull';
@@ -762,7 +783,7 @@ BEGIN
     SET @FileListParamSQL += N')' + NCHAR(13) + NCHAR(10);
     SET @FileListParamSQL += N'EXEC (''RESTORE FILELISTONLY FROM DISK=''''{Path}'''''')';
 
-    SET @sql = REPLACE(@FileListParamSQL, N'{Path}', @CurrentBackupPathFull + @LastFullBackup);
+    SET @sql = REPLACE(@FileListParamSQL, N'{Path}', REPLACE(@CurrentBackupPathFull + @LastFullBackup, N'''', REPLICATE(N'''', 4)));
 
     IF @Debug = 1
     BEGIN
@@ -778,7 +799,7 @@ BEGIN
     END
 
     --get the backup completed data so we can apply tlogs from that point forwards
-    SET @sql = REPLACE(@HeadersSQL, N'{Path}', @CurrentBackupPathFull + @LastFullBackup);
+    SET @sql = REPLACE(@HeadersSQL, N'{Path}', REPLACE(@CurrentBackupPathFull + @LastFullBackup, N'''', REPLICATE(N'''', 4)));
 
     IF @Debug = 1
     BEGIN
@@ -939,7 +960,7 @@ BEGIN
 
 			SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM '
                        + STUFF(
-                             (SELECT CHAR( 10 ) + ',DISK=''' + BackupPath + BackupFile + ''''
+                             (SELECT CHAR( 10 ) + ',DISK=''' + REPLACE(BackupPath, '''', '''''') + REPLACE(BackupFile, '''', '''''') + ''''
 							  FROM #SplitFullBackups
 							  ORDER BY BackupFile
 							  FOR XML PATH ('')),
@@ -949,7 +970,7 @@ BEGIN
         END;
 	    ELSE
 		BEGIN
-			SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @CurrentBackupPathFull + @LastFullBackup + N''' WITH NORECOVERY, REPLACE' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
+			SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + REPLACE(@CurrentBackupPathFull, N'''', N'''''') + REPLACE(@LastFullBackup, N'''', N'''''') + N''' WITH NORECOVERY, REPLACE' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
 		END
 	    IF (@StandbyMode = 1)
 	    BEGIN
@@ -959,11 +980,11 @@ BEGIN
 			END
 	        ELSE IF (SELECT COUNT(*) FROM #SplitFullBackups) > 0
 			BEGIN
-				SET @sql = @sql + ', STANDBY = ''' + @StandbyUndoPath + @Database + 'Undo.ldf''' + NCHAR(13) + NCHAR(10);
+				SET @sql = @sql + ', STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''' + NCHAR(13) + NCHAR(10);
 			END
 			ELSE
 	        BEGIN
-		        SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @CurrentBackupPathFull + @LastFullBackup + N''' WITH  REPLACE' + @BackupParameters + @MoveOption + N' , STANDBY = ''' + @StandbyUndoPath + @Database + 'Undo.ldf''' + NCHAR(13) + NCHAR(10);
+		        SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + REPLACE(@CurrentBackupPathFull, N'''', N'''''') + REPLACE(@LastFullBackup, N'''', N'''''') + N''' WITH  REPLACE' + @BackupParameters + @MoveOption + N' , STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''' + NCHAR(13) + NCHAR(10);
 	        END
         END;
 		IF @Debug = 1 OR @Execute = 'N'
@@ -1050,7 +1071,7 @@ BEGIN
 		END
 		ELSE
 		BEGIN
-			SET @cmd = N'DIR /b "' + @CurrentBackupPathDiff + N'"';
+			SET @cmd = N'DIR /b "' + REPLACE(@CurrentBackupPathDiff, N'''', N'''''') + N'"';
 			IF @Debug = 1
 			BEGIN
 				IF @cmd IS NULL PRINT '@cmd is NULL for @CurrentBackupPathDiff';
@@ -1131,7 +1152,7 @@ BEGIN
 			IF @Debug = 1 RAISERROR ('Split backups found', 0, 1) WITH NOWAIT;
 			SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM '
 									   + STUFF(
-											 (SELECT CHAR( 10 ) + ',DISK=''' + BackupPath + BackupFile + ''''
+											 (SELECT CHAR( 10 ) + ',DISK=''' + REPLACE(BackupPath, '''', '''''') + REPLACE(BackupFile, '''', '''''') + ''''
 											 FROM #SplitDiffBackups
 											 ORDER BY BackupFile
 											 FOR XML PATH ('')),
@@ -1140,7 +1161,7 @@ BEGIN
 									   '' ) + N' WITH NORECOVERY, REPLACE' +  @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
 		END;
 		ELSE
-			SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @CurrentBackupPathDiff + @LastDiffBackup + N''' WITH NORECOVERY' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
+			SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + REPLACE(@CurrentBackupPathDiff, N'''', N'''''') + REPLACE(@LastDiffBackup, N'''', N'''''') + N''' WITH NORECOVERY' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
 
 	    IF (@StandbyMode = 1)
 		BEGIN
@@ -1149,9 +1170,9 @@ BEGIN
 				    IF @Execute = 'Y' OR @Debug = 1 RAISERROR('The file path of the undo file for standby mode was not specified. The database will not be restored in standby mode.', 0, 1) WITH NOWAIT;
 			    END
 		    ELSE IF (SELECT COUNT(*) FROM #SplitDiffBackups) > 0
-				SET @sql = @sql + ', STANDBY = ''' + @StandbyUndoPath + @Database + 'Undo.ldf''' + NCHAR(13) + NCHAR(10);
+				SET @sql = @sql + ', STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''' + NCHAR(13) + NCHAR(10);
 			ELSE
-			    SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + @BackupPathDiff + @LastDiffBackup + N''' WITH STANDBY = ''' + @StandbyUndoPath + @Database + 'Undo.ldf''' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
+			    SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + REPLACE(@BackupPathDiff, N'''', N'''''') + REPLACE(@LastDiffBackup, N'''', N'''''') + N''' WITH STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
 	    END;
 		IF @Debug = 1 OR @Execute = 'N'
 		BEGIN
@@ -1162,7 +1183,7 @@ BEGIN
 			EXECUTE @sql = [dbo].[CommandExecute] @DatabaseContext=N'master', @Command = @sql, @CommandType = 'RESTORE DATABASE', @Mode = 1, @DatabaseName = @UnquotedRestoreDatabaseName, @LogToTable = 'Y', @Execute = 'Y';
 
 		--get the backup completed data so we can apply tlogs from that point forwards
-		SET @sql = REPLACE(@HeadersSQL, N'{Path}', @CurrentBackupPathDiff + @LastDiffBackup);
+		SET @sql = REPLACE(@HeadersSQL, N'{Path}', REPLACE(@CurrentBackupPathDiff + @LastDiffBackup, N'''', REPLICATE(N'''', 4)));
 
 		IF @Debug = 1
 		BEGIN
@@ -1235,7 +1256,7 @@ BEGIN
 		END
 		ELSE
 		BEGIN
-			SET @cmd = N'DIR /b "' + @CurrentBackupPathLog + N'"';
+			SET @cmd = N'DIR /b "' + REPLACE(@CurrentBackupPathLog, N'''', N'''''') + N'"';
 			IF @Debug = 1
 			BEGIN
 				IF @cmd IS NULL PRINT '@cmd is NULL for @CurrentBackupPathLog';
@@ -1365,7 +1386,7 @@ IF (@StandbyMode = 1)
 				IF @Execute = 'Y' OR @Debug = 1 RAISERROR('The file path of the undo file for standby mode was not specified. Logs will not be restored in standby mode.', 0, 1) WITH NOWAIT;
 			END;
 		ELSE
-			SET @LogRecoveryOption = N'STANDBY = ''' + @StandbyUndoPath + @Database + 'Undo.ldf''';
+			SET @LogRecoveryOption = N'STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''';
 	END;
 
 IF (@LogRecoveryOption = N'')
@@ -1450,7 +1471,7 @@ WHERE BackupFile IS NOT NULL;
 			IF @i = 1
 
 			BEGIN
-		    SET @sql = REPLACE(@HeadersSQL, N'{Path}', @CurrentBackupPathLog + @BackupFile);
+		    SET @sql = REPLACE(@HeadersSQL, N'{Path}', REPLACE(@CurrentBackupPathLog + @BackupFile, N'''', REPLICATE(N'''', 4)));
 
 				IF @Debug = 1
 				BEGIN
@@ -1490,7 +1511,7 @@ WHERE BackupFile IS NOT NULL;
 					IF @Debug = 1 RAISERROR ('Split backups found', 0, 1) WITH NOWAIT;
 					SET @sql = N'RESTORE LOG ' + @RestoreDatabaseName + N' FROM '
 							   + STUFF(
-									(SELECT CHAR( 10 ) + ',DISK=''' + BackupPath + BackupFile + ''''
+									(SELECT CHAR( 10 ) + ',DISK=''' + REPLACE(BackupPath, '''', '''''') + REPLACE(BackupFile, '''', '''''') + ''''
 									 FROM #SplitLogBackups
 									 WHERE DenseRank = @LogRestoreRanking
 									 ORDER BY BackupFile
@@ -1500,7 +1521,7 @@ WHERE BackupFile IS NOT NULL;
 								'' ) + N' WITH ' + @LogRecoveryOption + NCHAR(13) + NCHAR(10);
 				END;
 				ELSE
-				SET @sql = N'RESTORE LOG ' + @RestoreDatabaseName + N' FROM DISK = ''' + @CurrentBackupPathLog + @BackupFile + N''' WITH ' + @LogRecoveryOption + NCHAR(13) + NCHAR(10);
+				SET @sql = N'RESTORE LOG ' + @RestoreDatabaseName + N' FROM DISK = ''' + REPLACE(@CurrentBackupPathLog, N'''', N'''''') + REPLACE(@BackupFile, N'''', N'''''') + N''' WITH ' + @LogRecoveryOption + NCHAR(13) + NCHAR(10);
 
 					IF @Debug = 1 OR @Execute = 'N'
 					BEGIN
@@ -1582,7 +1603,7 @@ IF @DatabaseOwner IS NOT NULL
 		BEGIN
 			IF EXISTS (SELECT * FROM master.dbo.syslogins WHERE syslogins.loginname = @DatabaseOwner)
 			BEGIN
-				SET @sql = N'ALTER AUTHORIZATION ON DATABASE::' + @RestoreDatabaseName + ' TO [' + @DatabaseOwner + ']';
+				SET @sql = N'ALTER AUTHORIZATION ON DATABASE::' + @RestoreDatabaseName + N' TO ' + QUOTENAME(@DatabaseOwner);
 
 					IF @Debug = 1 OR @Execute = 'N'
 					BEGIN
@@ -1672,8 +1693,19 @@ END;'
 
 IF @RunStoredProcAfterRestore IS NOT NULL AND LEN(LTRIM(@RunStoredProcAfterRestore)) > 0
 BEGIN
+	DECLARE @RunStoredProcSchema sysname = NULLIF(PARSENAME(@RunStoredProcAfterRestore, 2), N'');
+	DECLARE @RunStoredProcName   sysname = PARSENAME(@RunStoredProcAfterRestore, 1);
+	IF @RunStoredProcName IS NULL
+	   OR PARSENAME(@RunStoredProcAfterRestore, 3) IS NOT NULL
+	   OR PARSENAME(@RunStoredProcAfterRestore, 4) IS NOT NULL
+	BEGIN
+		RAISERROR('@RunStoredProcAfterRestore must be a procedure name or schema.procedure (1- or 2-part name).', 16, 1) WITH NOWAIT;
+		RETURN;
+	END;
 	PRINT 'Attempting to run ' + @RunStoredProcAfterRestore
-	SET @sql = N'EXEC ' + @RestoreDatabaseName + '.' + @RunStoredProcAfterRestore
+	SET @sql = N'EXEC ' + @RestoreDatabaseName + N'.'
+	         + COALESCE(QUOTENAME(@RunStoredProcSchema) + N'.', N'')
+	         + QUOTENAME(@RunStoredProcName);
 
 	IF @Debug = 1 OR @Execute = 'N'
 	BEGIN

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -1175,7 +1175,7 @@ BEGIN
 		    ELSE IF (SELECT COUNT(*) FROM #SplitDiffBackups) > 0
 				SET @sql = @sql + ', STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''' + NCHAR(13) + NCHAR(10);
 			ELSE
-			    SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + REPLACE(@BackupPathDiff, N'''', N'''''') + REPLACE(@LastDiffBackup, N'''', N'''''') + N''' WITH STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
+			    SET @sql = N'RESTORE DATABASE ' + @RestoreDatabaseName + N' FROM DISK = ''' + REPLACE(@CurrentBackupPathDiff, N'''', N'''''') + REPLACE(@LastDiffBackup, N'''', N'''''') + N''' WITH STANDBY = ''' + REPLACE(@StandbyUndoPath, N'''', N'''''') + REPLACE(@Database, N'''', N'''''') + 'Undo.ldf''' + @BackupParameters + @MoveOption + NCHAR(13) + NCHAR(10);
 	    END;
 		IF @Debug = 1 OR @Execute = 'N'
 		BEGIN
@@ -1696,11 +1696,18 @@ END;'
 
 IF @RunStoredProcAfterRestore IS NOT NULL AND LEN(LTRIM(@RunStoredProcAfterRestore)) > 0
 BEGIN
-	DECLARE @RunStoredProcSchema sysname = NULLIF(PARSENAME(@RunStoredProcAfterRestore, 2), N'');
-	DECLARE @RunStoredProcName   sysname = PARSENAME(@RunStoredProcAfterRestore, 1);
+	/* Normalize whitespace before PARSENAME: trim outer space and collapse any whitespace
+	   that surrounds the dots, so 'dbo. MyProc' or '  MyProc ' parse the same as 'dbo.MyProc'.
+	   The original raw-concat behavior accepted these because T-SQL's parser ignores
+	   whitespace around dots in EXEC statements; preserving that for backward compat. */
+	DECLARE @NormalizedRunStoredProc nvarchar(260) = LTRIM(RTRIM(@RunStoredProcAfterRestore));
+	WHILE CHARINDEX(N' .', @NormalizedRunStoredProc) > 0 SET @NormalizedRunStoredProc = REPLACE(@NormalizedRunStoredProc, N' .', N'.');
+	WHILE CHARINDEX(N'. ', @NormalizedRunStoredProc) > 0 SET @NormalizedRunStoredProc = REPLACE(@NormalizedRunStoredProc, N'. ', N'.');
+	DECLARE @RunStoredProcSchema sysname = NULLIF(PARSENAME(@NormalizedRunStoredProc, 2), N'');
+	DECLARE @RunStoredProcName   sysname = PARSENAME(@NormalizedRunStoredProc, 1);
 	IF @RunStoredProcName IS NULL
-	   OR PARSENAME(@RunStoredProcAfterRestore, 3) IS NOT NULL
-	   OR PARSENAME(@RunStoredProcAfterRestore, 4) IS NOT NULL
+	   OR PARSENAME(@NormalizedRunStoredProc, 3) IS NOT NULL
+	   OR PARSENAME(@NormalizedRunStoredProc, 4) IS NOT NULL
 	BEGIN
 		RAISERROR('@RunStoredProcAfterRestore must be a procedure name or schema.procedure (1- or 2-part name).', 16, 1) WITH NOWAIT;
 		RETURN;

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -875,7 +875,14 @@ BEGIN
                     PhysicalName,
                     LogicalName
 		    FROM #FileListParameters)
-	    SELECT @MoveOption = @MoveOption + N', MOVE ''' + Files.LogicalName + N''' TO ''' + Files.TargetPhysicalName + ''''
+	    /* Both LogicalName and TargetPhysicalName get embedded inside SQL string literals
+	       below. TargetPhysicalName is built from caller parameters (@MoveDataDrive,
+	       @MoveLogDrive, @MoveFilestreamDrive, @MoveFullTextCatalogDrive, @FileNamePrefix)
+	       which the path-validation gate allows to contain apostrophes — so an apostrophe
+	       in any of those params would otherwise close the literal. Double the quotes
+	       inline. (LogicalName is filesystem-sourced and out of scope per threat model;
+	       escaping it too is defense-in-depth at zero cost.) */
+	    SELECT @MoveOption = @MoveOption + N', MOVE ''' + REPLACE(Files.LogicalName, N'''', N'''''') + N''' TO ''' + REPLACE(Files.TargetPhysicalName, N'''', N'''''') + ''''
 	    FROM Files
         WHERE Files.TargetPhysicalName <> Files.PhysicalName;
 

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -649,7 +649,7 @@ BEGIN
 		END
 		ELSE
 		BEGIN
-			SET @cmd = N'DIR /b "' + REPLACE(@CurrentBackupPathFull, N'''', N'''''') + N'"';
+			SET @cmd = N'DIR /b "' + @CurrentBackupPathFull + N'"';
 			IF @Debug = 1
 			BEGIN
 				IF @cmd IS NULL PRINT '@cmd is NULL for @CurrentBackupPathFull';
@@ -1074,7 +1074,7 @@ BEGIN
 		END
 		ELSE
 		BEGIN
-			SET @cmd = N'DIR /b "' + REPLACE(@CurrentBackupPathDiff, N'''', N'''''') + N'"';
+			SET @cmd = N'DIR /b "' + @CurrentBackupPathDiff + N'"';
 			IF @Debug = 1
 			BEGIN
 				IF @cmd IS NULL PRINT '@cmd is NULL for @CurrentBackupPathDiff';
@@ -1259,7 +1259,7 @@ BEGIN
 		END
 		ELSE
 		BEGIN
-			SET @cmd = N'DIR /b "' + REPLACE(@CurrentBackupPathLog, N'''', N'''''') + N'"';
+			SET @cmd = N'DIR /b "' + @CurrentBackupPathLog + N'"';
 			IF @Debug = 1
 			BEGIN
 				IF @cmd IS NULL PRINT '@cmd is NULL for @CurrentBackupPathLog';
@@ -1707,8 +1707,8 @@ BEGIN
 	END;
 	PRINT 'Attempting to run ' + @RunStoredProcAfterRestore
 	/* Always emit a 3-part name (db.schema.proc). For 1-part input the schema slot is left empty
-	   so the name resolves as db..proc — i.e., the default schema in the restored DB. Without the
-	   second dot, [db].[proc] is parsed as schema.object in the *current* DB. */
+	   ([db]..[proc]) so SQL Server applies its own schema-resolution rules in the target DB.
+	   Without the second dot, [db].[proc] is parsed as schema.object in the *current* DB. */
 	SET @sql = N'EXEC ' + @RestoreDatabaseName + N'.'
 	         + ISNULL(QUOTENAME(@RunStoredProcSchema), N'')
 	         + N'.'


### PR DESCRIPTION
## Summary

Hardens `sp_DatabaseRestore` against parameter-based SQL injection. Threat model: a caller with `EXECUTE` on the proc but **not** sysadmin should not be able to escalate to arbitrary T-SQL or shell command execution by passing crafted parameter values.

- **Validation gate** for path-shaped parameters. Rejects `"`, `&`, `|`, `;`, `^`, `<`, `>`, NUL, CR, LF — characters with no legitimate use in Windows paths but high command-injection risk. Single quotes are allowed (legal but rare in real paths) and escaped at concat sites instead. Applied to `@BackupPathFull/Diff/Log`, `@MoveDataDrive/LogDrive/FilestreamDrive/FullTextCatalogDrive`, `@StandbyUndoPath`, `@FileNamePrefix`. (`@Database` is **not** in this list — it's a database identifier, not a path; `&`/`;` are legal in DB names. It's protected via single-quote escaping at the few sites it gets concatenated into a quoted SQL literal.) The LIKE pattern uses `COLLATE Latin1_General_BIN2` so the `[…]` class catches NCHAR(0) — under the default collation NUL is silently dropped from both pattern and value.
- **`QUOTENAME(@DatabaseOwner)`** in the `ALTER AUTHORIZATION` build (was `'[' + @DatabaseOwner + ']'`, which a `]` in the value would escape).
- **`PARSENAME` + `QUOTENAME` for `@RunStoredProcAfterRestore`** before the `EXEC` build. Rejects 3- or 4-part names; quotes both the schema and proc parts. Always emits a 3-part name — for 1-part input the schema slot is left empty (`[db]..[proc]`) so SQL Server's own schema resolution kicks in; without the second dot, `[db].[proc]` parses as schema.object in the *current* DB. Closes the highest-severity site — previously the value was concatenated raw and passed straight to `sp_executesql @sql`.
- **Single-quote escape at every dynamic-RESTORE concat site** that wraps a caller-supplied path or `@Database` in `'...'`. Includes single-file `RESTORE DATABASE/LOG FROM DISK = '...'`, `STANDBY = '...'`, and the per-row split-backup `DISK=` entries built via `FOR XML PATH`. Note: this is **not** applied to the `xp_cmdshell DIR /b "..."` command-string build — cmd.exe doesn't interpret `''` as an escape, so doubling there would corrupt legitimate paths with an apostrophe; the value is just passed as-is to xp_cmdshell and never crosses a SQL parser again.
- **`, TYPE).value('.', 'nvarchar(max)')`** on the three `FOR XML PATH` split-backup builders so legitimate filenames containing `&`/`<`/`>` don't get XML-entity-encoded into the generated `RESTORE DISK=` paths.
- **Doubled-twice escape (`REPLICATE(N'''', 4)`) for `{Path}` substitution** in the `RESTORE HEADERONLY` / `RESTORE FILELISTONLY` templates, where the path lives inside a nested `EXEC` literal (two parser layers).

Out of scope (deliberate): filenames sourced from the filesystem (xp_dirtree / xp_cmdshell output) and `RESTORE FILELISTONLY` output flowing back into MOVE clauses. An attacker who can write into the backup folder is already trusted in this model. (The XML-PATH split-backup sites do escape `BackupFile` alongside `BackupPath` for code-shape consistency, but that's a side effect, not the intended fix.)

## Test plan

Verified end-to-end against SQL Server 2025 RTM-CU4. All eleven injection probes plus regression cases pass:

- [x] Deploy + verify the proc compiles cleanly.
- [x] Regression — legitimate paths still work: `C:\Backups\`, `\\server\share\`, and a path containing a single quote (`C:\Backups\It's Friday\`). The xp_cmdshell `DIR /b` command preserves the apostrophe correctly (single quote, not doubled).
- [x] `@DatabaseOwner = 'sa'` and `@RunStoredProcAfterRestore = 'dbo.MyProc'` (and `'MyProc'`) — both accepted; the generated `ALTER AUTHORIZATION` and `EXEC` strings (visible with `@Debug = 1, @Execute = 'N'`) show `[sa]` and `[Test].[dbo].[MyProc]` / `[Test]..[MyProc]` respectively.
- [x] `@Database = 'My&DB'` — passes validation (database identifier, not a path).
- [x] Injection attempts blocked or neutralized:
  - `@BackupPathFull = 'C:\Backups\"& whoami &"'` — validation gate rejects with RAISERROR + RETURN.
  - `@BackupPathFull = 'C:\Backups\; xp_cmdshell ''calc''; --'` — same, blocked by `;` rejection.
  - `@MoveDataDrive` containing NCHAR(0) — caught by the BIN2-collated LIKE.
  - `@DatabaseOwner = 'sa]; DROP TABLE foo; --'` — `QUOTENAME` produces a single bracketed identifier; the `EXISTS` check in `master.dbo.syslogins` fails to find that login and the proc falls through to the "not a valid Login" PRINT path with no injected statement executed.
  - `@RunStoredProcAfterRestore = 'dbo.MyProc; DROP TABLE foo; --'` — `PARSENAME(..., 1)` returns `MyProc; DROP TABLE foo; --`, gets wrapped in brackets; the `EXEC` fails to find a procedure with that bracketed name.
  - `@RunStoredProcAfterRestore = 'srv.db.dbo.MyProc'` — rejected with the new RAISERROR (4-part name not allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)