### PR TITLE
sp_BlitzIndex: HAS_DBACCESS preflight to avoid hang on inaccessible DBs

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1216,6 +1216,13 @@ IF @AI > 0
 
 IF @GetAllDatabases = 1
     BEGIN
+        /* HAS_DBACCESS gates databases the current principal can actually query.
+           Without this filter, three-part-name queries against sys.dm_db_partition_stats
+           hang indefinitely under a SQL Server permission/recompile bug instead of
+           erroring with Msg 916. The TRY/CATCH preflight below catches the same case
+           for legacy non-sysadmin paths, but HAS_DBACCESS also covers Azure principals
+           (##MS_DatabaseConnector##, CONNECT ANY DATABASE) that report as
+           sysadmin-equivalent yet can still be denied CONNECT per database. */
         INSERT INTO #DatabaseList (DatabaseName)
         SELECT  DB_NAME(database_id)
         FROM    sys.databases
@@ -1226,6 +1233,7 @@ IF @GetAllDatabases = 1
         AND DB_NAME(database_id) NOT LIKE 'rdsadmin%'
 		AND LOWER(name) NOT IN('dbatools', 'dbadmin', 'dbmaintenance', 'gcloud_cloudsqladmin')
         AND is_distributor = 0
+        AND HAS_DBACCESS(DB_NAME(database_id)) = 1
 		OPTION    ( RECOMPILE );
 
         /*Check if sysadmin 
@@ -1325,10 +1333,23 @@ IF @GetAllDatabases = 1
     END;
 ELSE
     BEGIN
+        /* Preflight: if an explicit @DatabaseName was supplied but the current principal
+           has no access to it, fail loud rather than letting downstream queries hang.
+           sp_BlitzIndex queries sys.dm_db_partition_stats via three-part name, which
+           under a SQL Server permission/recompile bug spins at 100% CPU forever instead
+           of erroring with Msg 916. */
+        IF @DatabaseName IS NOT NULL AND @DatabaseName <> N''
+        AND DB_ID(@DatabaseName) IS NOT NULL
+        AND ISNULL(HAS_DBACCESS(@DatabaseName), 0) = 0
+            BEGIN
+                RAISERROR(N'The current login has no access to database %s. Run, against that database: CREATE USER [<login>] FOR LOGIN [<login>]; GRANT VIEW DATABASE STATE; GRANT VIEW DEFINITION;', 16, 1, @DatabaseName);
+                RETURN;
+            END;
+
         INSERT INTO #DatabaseList
                 ( DatabaseName )
-        SELECT CASE 
-		            WHEN @DatabaseName IS NULL OR @DatabaseName = N'' 
+        SELECT CASE
+		            WHEN @DatabaseName IS NULL OR @DatabaseName = N''
 		            THEN DB_NAME()
                     ELSE @DatabaseName END;
                END;

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -1342,7 +1342,8 @@ ELSE
         AND DB_ID(@DatabaseName) IS NOT NULL
         AND ISNULL(HAS_DBACCESS(@DatabaseName), 0) = 0
             BEGIN
-                RAISERROR(N'The current login has no access to database %s. Run, against that database: CREATE USER [<login>] FOR LOGIN [<login>]; GRANT VIEW DATABASE STATE; GRANT VIEW DEFINITION;', 16, 1, @DatabaseName);
+                DECLARE @CurrentLoginQuoted NVARCHAR(258) = QUOTENAME(SUSER_SNAME());
+                RAISERROR(N'The current login has no access to database %s. Run, against that database: CREATE USER %s FOR LOGIN %s; GRANT VIEW DATABASE STATE TO %s; GRANT VIEW DEFINITION TO %s;', 16, 1, @DatabaseName, @CurrentLoginQuoted, @CurrentLoginQuoted, @CurrentLoginQuoted, @CurrentLoginQuoted);
                 RETURN;
             END;
 


### PR DESCRIPTION
Fixes #3981.

## Summary

When the executing principal has no user mapping in a target database, `sp_BlitzIndex`'s three-part-name queries against `sys.dm_db_partition_stats` hang at 100% CPU forever instead of returning `Msg 916`. This is a SQL Server engine bug: the compiled plan trips a permission check at execute time, the engine misclassifies that as "plan needs recompile," and loops. Reproduces on 2016 SP3 through 2025 CU4.

We can't fix the engine, so this PR preflights access and skips cleanly. The same fix pattern was applied to `sp_IndexCleanup` in DarlingData (https://github.com/erikdarlingdata/DarlingData/pull/778), which is where the issue was originally tracked: https://github.com/erikdarlingdata/PerformanceMonitor/issues/915.

## Changes

`sp_BlitzIndex.sql`:

- **`@GetAllDatabases = 1` path**: add `AND HAS_DBACCESS(DB_NAME(database_id)) = 1` to the `#DatabaseList` insert. This catches the Azure SQL DB case where principals like `##MS_DatabaseConnector##` / `CONNECT ANY DATABASE` report as sysadmin-equivalent (so they bypass the existing `IS_SRVROLEMEMBER('sysadmin') = 0`-gated TRY/CATCH preflight) but can still be denied `CONNECT` per database. The comment in the existing block already acknowledges this scenario.
- **Explicit `@DatabaseName` path**: preflight `HAS_DBACCESS(@DatabaseName)`. If 0/NULL, `RAISERROR` (severity 16) with a clear message telling the operator which `CREATE USER` / `GRANT` calls to run, then `RETURN`. Without this, the procedure runs to the analysis loop and hangs on the first `sys.dm_db_partition_stats` reference.

The existing TRY/CATCH preflight against `sys.indexes` is left in place as defense-in-depth — it works (because `sys.indexes` does fast-fail with `Msg 916`) and removing it would be churn unrelated to this fix.

No public parameter surface change. No unrelated rewrites.

## Manual repro

```sql
USE master;
CREATE LOGIN low_priv WITH PASSWORD = 'StrongP@ssw0rd!';
GRANT VIEW SERVER STATE TO low_priv;
CREATE USER low_priv FOR LOGIN low_priv;       -- in master, just so they can EXECUTE sp_BlitzIndex
GRANT EXECUTE ON dbo.sp_BlitzIndex TO low_priv;
-- intentionally no CREATE USER for low_priv in any other user database

-- as low_priv:
EXEC dbo.sp_BlitzIndex @DatabaseName = N'SomeUserDb';
-- before this PR: spins at 100% CPU forever (KILL the session to clear)
-- after this PR:  errors in <1 second with a GRANT hint

EXEC dbo.sp_BlitzIndex @GetAllDatabases = 1;
-- before this PR: hangs on the first inaccessible user DB
-- after this PR:  finishes cleanly; inaccessible DBs are silently skipped
```

The fix the user has to apply manually (per database) once they see the error is:

```sql
CREATE USER [low_priv] FOR LOGIN [low_priv];
GRANT VIEW DATABASE STATE TO [low_priv];
GRANT VIEW DEFINITION TO [low_priv];
```

## Test plan

- [x] Deploys cleanly on SQL Server 2022 (`CREATE OR ALTER` round-trips).
- [x] Happy path: `EXEC sp_BlitzIndex @DatabaseName = N'master'` as `sa` returns results normally.
- [x] Single-DB repro: low-priv login + `@DatabaseName = N'<inaccessible>'` errors in <1s with the new message instead of hanging.
- [x] Multi-DB repro: low-priv login + `@GetAllDatabases = 1, @BringThePain = 1` returns in ~1s with no hang; inaccessible DBs are excluded from `#DatabaseList`.
- [ ] Reviewer to confirm on a 2016/2017/2019 instance if available — `HAS_DBACCESS` exists on all of those.