### PR TITLE
sp_BlitzIndex: Made 'check_id 121: Optimized For Sequential Keys' report the index rather than just the table.

### DIFF
--- a/Documentation/sp_BlitzIndex_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzIndex_Checks_by_Priority.md
@@ -73,8 +73,8 @@ If you want to add a new check, start at 131.
 | 200      | Indexes Worth Reviewing | Heaps with Deletes                                              | https://www.brentozar.com/go/SelfLoathing                                                      | 49      |
 | 200      | High Workloads          | Scan-a-lots (index-usage-stats)                                 | https://www.brentozar.com/go/Workaholics                                                       | 80      |
 | 200      | High Workloads          | Top Recent Accesses (index-op-stats)                            | https://www.brentozar.com/go/Workaholics                                                       | 81      |
+| 200      | Specialized Indexes     | Optimized For Sequential Keys                                   | https://erikdarling.com/enabling-optimize-for-sequential-key/                                  | 121     |
 | 250      | Omitted Index Features  | Few Indexes Use Includes                                        | https://www.brentozar.com/go/IndexFeatures                                                     | 31      |
 | 250      | Omitted Index Features  | No Filtered Indexes or Indexed Views                            | https://www.brentozar.com/go/IndexFeatures                                                     | 32      |
 | 250      | Omitted Index Features  | No Indexes Use Includes                                         | https://www.brentozar.com/go/IndexFeatures                                                     | 30      |
 | 250      | Omitted Index Features  | Potential Filtered Index (Based on Column Name)                 | https://www.brentozar.com/go/IndexFeatures                                                     | 33      |
-| 250      | Specialized Indexes     | Optimized For Sequential Keys                                   | https://erikdarling.com/enabling-optimize-for-sequential-key/                                  | 121     |

--- a/Documentation/sp_BlitzIndex_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzIndex_Checks_by_Priority.md
@@ -77,4 +77,4 @@ If you want to add a new check, start at 131.
 | 250      | Omitted Index Features  | No Filtered Indexes or Indexed Views                            | https://www.brentozar.com/go/IndexFeatures                                                     | 32      |
 | 250      | Omitted Index Features  | No Indexes Use Includes                                         | https://www.brentozar.com/go/IndexFeatures                                                     | 30      |
 | 250      | Omitted Index Features  | Potential Filtered Index (Based on Column Name)                 | https://www.brentozar.com/go/IndexFeatures                                                     | 33      |
-| 250      | Specialized Indexes     | Optimized For Sequential Keys                                   |                                                                                                | 121     |
+| 250      | Specialized Indexes     | Optimized For Sequential Keys                                   | https://erikdarling.com/enabling-optimize-for-sequential-key/                                  | 121     |

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -6545,21 +6545,24 @@ BEGIN
 
 		RAISERROR(N'check_id 121: Optimized For Sequential Keys.', 0,1) WITH NOWAIT;
         INSERT    #BlitzIndexResults ( check_id, Priority, findings_group, finding, [database_name], URL, details, index_definition,
-                                               secret_columns, index_usage_summary, index_size_summary )
+                                               secret_columns, index_usage_summary, index_size_summary, more_info )
 
 				SELECT  121 AS check_id, 
 				200 AS Priority,
 				'Specialized Indexes' AS findings_group,
 				'Optimized For Sequential Keys',
 				i.database_name,
-				'' AS URL,
-				'The table ' + QUOTENAME(i.schema_name) + '.' + QUOTENAME(i.object_name) + ' is optimized for sequential keys.' AS details,
-				'' AS index_definition,
-				'N/A' AS secret_columns,
-				'N/A' AS index_usage_summary,
-				'N/A' AS index_size_summary
+				'https://erikdarling.com/enabling-optimize-for-sequential-key/' AS URL,
+				N'The index ' + i.db_schema_object_indexid + N' is optimized for sequential keys.' AS details,
+                ISNULL(i.key_column_names_with_sort_order,'N/A') AS index_definition,
+                ISNULL(i.secret_columns,'') AS secret_columns,
+                i.index_usage_summary AS index_usage_summary,
+                iss.index_size_summary AS index_size_summary,
+                i.more_info
 		FROM #IndexSanity AS i
+        JOIN #IndexSanitySize iss ON i.index_sanity_id=iss.index_sanity_id
 		WHERE i.optimize_for_sequential_key = 1
+        AND iss.total_reserved_MB >= CASE WHEN (@GetAllDatabases = 1 OR @Mode = 0) THEN @ThresholdMB ELSE iss.total_reserved_MB END
 		OPTION    ( RECOMPILE );
 
 


### PR DESCRIPTION
Closes #3987.

This was almost entirely a copy and paste job. The only thing I did that was even slightly unusual was populate the `more_info` column. I am not sure why we do not always do that. The `#IndexSanity` table makes it easy.

# Test Script

```sql
SELECT TOP (4) * INTO Foo FROM sys.messages; 
CREATE INDEX Foo_1 ON Foo (severity) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON);
CREATE INDEX Foo_2 ON Foo (is_event_logged) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF);
CREATE INDEX Foo_3 ON Foo (is_event_logged, severity) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON);
EXEC sp_BlitzIndex @Mode = 4, @IncludeInactiveIndexes = 1;
```

# Before and After

## Before

<img width="1295" height="424" alt="image" src="https://github.com/user-attachments/assets/660d2a32-6369-4812-95d9-e13e5fbd43de" />

## After

<img width="1388" height="415" alt="image" src="https://github.com/user-attachments/assets/28d1889d-137b-438e-9a36-71dc406c01d8" />

