### PR TITLE
sp_BlitzIndex: report optimize_for_sequential_key in table mode 

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -3255,6 +3255,7 @@ BEGIN
             s.last_user_update,
             s.create_date,
             s.modify_date,
+            s.optimize_for_sequential_key,
 			sz.page_latch_wait_count,
 			CONVERT(VARCHAR(10), (sz.page_latch_wait_in_ms / 1000) / 86400) + ':' + CONVERT(VARCHAR(20), DATEADD(s, (sz.page_latch_wait_in_ms / 1000), 0), 108) AS page_latch_wait_time,
 			sz.page_io_latch_wait_count,
@@ -3287,7 +3288,7 @@ BEGIN
                 N'SQL Server First Responder Kit' ,   
                 N'http://FirstResponderKit.org' ,
                 N'From Your Community Volunteers',
-                NULL,@DaysUptimeInsertValue,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,
+                NULL,@DaysUptimeInsertValue,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,
                 0 AS display_order
     )
     SELECT 
@@ -3309,9 +3310,10 @@ BEGIN
             create_date AS [Created],
             modify_date AS [Last Modified],
 			page_latch_wait_count AS [Page Latch Wait Count],
-			page_latch_wait_time as [Page Latch Wait Time (D:H:M:S)],
+			page_latch_wait_time AS [Page Latch Wait Time (D:H:M:S)],
+            optimize_for_sequential_key AS [Optimized For Sequential Key?],
 			page_io_latch_wait_count AS [Page IO Latch Wait Count],								
-			page_io_latch_wait_time as [Page IO Latch Wait Time (D:H:M:S)],
+			page_io_latch_wait_time AS [Page IO Latch Wait Time (D:H:M:S)],
             create_tsql AS [Create TSQL],
             drop_tsql AS [Drop TSQL]
     FROM table_mode_cte


### PR DESCRIPTION
Closes #3989. This was effortless. The only thing worth anyone checking is if this works on pre-2019 versions. I see no reason why it should not.

# Test Script

```sql
SELECT TOP (4) * INTO Foo FROM sys.messages; 
CREATE INDEX Foo_1 ON Foo (severity) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON);
CREATE INDEX Foo_2 ON Foo (is_event_logged) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF);
CREATE INDEX Foo_3 ON Foo (is_event_logged, severity) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON);
EXEC dbo.sp_BlitzIndex @DatabaseName='master', @SchemaName='dbo', @TableName='Foo';
```

# Before and After

There are so many columns that it's hard to get a good screenshot :sob: 

## Before

<img width="1414" height="1888" alt="out" src="https://github.com/user-attachments/assets/9b038f84-a5d8-47de-b68e-3e2a20a3020c" />


## After

<img width="1485" height="1951" alt="out" src="https://github.com/user-attachments/assets/0609e844-ddad-4458-b9d9-4fddc36c97e4" />

