### PR TITLE
sp_BlitzCache: roll up missing indexes to proc/function/trigger row

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -4762,31 +4762,45 @@ IF EXISTS ( SELECT 1/0
 
 		/* Roll up missing indexes from statement rows (QueryHash IS NOT NULL)
 		   to the parent proc/function/trigger row (QueryHash IS NULL).
-		   Aggregate from #missing_index_pretty by SqlHandle so the rollup
-		   ends up in a single <MissingIndexes><![CDATA[ ... ]]></MissingIndexes>
-		   wrapper (well-formed XML for the XML column). See issue #3993. */
+		   Key by PlanHandle so each cached plan's parent row gets only its
+		   own statements' recommendations (a proc with multiple cached plans
+		   produces one parent row per PlanHandle, and each plan's statements
+		   share that PlanHandle). The rollup is wrapped in a single
+		   <MissingIndexes><![CDATA[ ... ]]></MissingIndexes> envelope so it
+		   stays well-formed for the XML column. See issue #3993. */
 		RAISERROR(N'Rolling up missing indexes to parent proc/function/trigger row', 0, 1) WITH NOWAIT;
 		WITH proc_missing AS (
-		SELECT mip.SqlHandle,
+		SELECT DISTINCT
+		       stmt.PlanHandle,
 			   N'<MissingIndexes><![CDATA['
 			   + CHAR(10) + CHAR(13)
 			   + STUFF((   SELECT CHAR(10) + CHAR(13) + ISNULL(mip2.details, '') AS details
 						   FROM   #missing_index_pretty AS mip2
-						   WHERE  mip2.SqlHandle = mip.SqlHandle
+						   JOIN   ##BlitzCacheProcs AS s2
+								  ON  s2.SqlHandle = mip2.SqlHandle
+								  AND s2.QueryHash = mip2.QueryHash
+								  AND s2.ExecutionCount = mip2.executions
+								  AND s2.SPID = @@SPID
+						   WHERE  s2.PlanHandle = stmt.PlanHandle
 						   GROUP BY mip2.details
 						   ORDER BY MAX(mip2.impact) DESC
 						   FOR XML PATH(N''), TYPE ).value(N'.[1]', N'NVARCHAR(MAX)'), 1, 2, N'')
 			   + CHAR(10) + CHAR(13)
 			   + N']]></MissingIndexes>'
 			   AS full_details
-		FROM #missing_index_pretty AS mip
-		GROUP BY mip.SqlHandle
+		FROM ##BlitzCacheProcs AS stmt
+		JOIN #missing_index_pretty AS mip
+		  ON  mip.SqlHandle = stmt.SqlHandle
+		  AND mip.QueryHash = stmt.QueryHash
+		  AND mip.executions = stmt.ExecutionCount
+		WHERE stmt.SPID = @@SPID
+		  AND stmt.QueryHash IS NOT NULL
 						)
 		UPDATE bbcp
 			SET bbcp.missing_indexes = pm.full_details
 		FROM ##BlitzCacheProcs AS bbcp
 		JOIN proc_missing AS pm
-		ON pm.SqlHandle = bbcp.SqlHandle
+		ON pm.PlanHandle = bbcp.PlanHandle
 		WHERE bbcp.QueryHash IS NULL
 		AND bbcp.SPID = @@SPID
 		OPTION (RECOMPILE);

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -4760,6 +4760,37 @@ IF EXISTS ( SELECT 1/0
 		AND SPID = @@SPID
 		OPTION (RECOMPILE);
 
+		/* Roll up missing indexes from statement rows (QueryHash IS NOT NULL)
+		   to the parent proc/function/trigger row (QueryHash IS NULL).
+		   Aggregate from #missing_index_pretty by SqlHandle so the rollup
+		   ends up in a single <MissingIndexes><![CDATA[ ... ]]></MissingIndexes>
+		   wrapper (well-formed XML for the XML column). See issue #3993. */
+		RAISERROR(N'Rolling up missing indexes to parent proc/function/trigger row', 0, 1) WITH NOWAIT;
+		WITH proc_missing AS (
+		SELECT mip.SqlHandle,
+			   N'<MissingIndexes><![CDATA['
+			   + CHAR(10) + CHAR(13)
+			   + STUFF((   SELECT CHAR(10) + CHAR(13) + ISNULL(mip2.details, '') AS details
+						   FROM   #missing_index_pretty AS mip2
+						   WHERE  mip2.SqlHandle = mip.SqlHandle
+						   GROUP BY mip2.details
+						   ORDER BY MAX(mip2.impact) DESC
+						   FOR XML PATH(N''), TYPE ).value(N'.[1]', N'NVARCHAR(MAX)'), 1, 2, N'')
+			   + CHAR(10) + CHAR(13)
+			   + N']]></MissingIndexes>'
+			   AS full_details
+		FROM #missing_index_pretty AS mip
+		GROUP BY mip.SqlHandle
+						)
+		UPDATE bbcp
+			SET bbcp.missing_indexes = pm.full_details
+		FROM ##BlitzCacheProcs AS bbcp
+		JOIN proc_missing AS pm
+		ON pm.SqlHandle = bbcp.SqlHandle
+		WHERE bbcp.QueryHash IS NULL
+		AND bbcp.SPID = @@SPID
+		OPTION (RECOMPILE);
+
 	END;
 
 	RAISERROR(N'Filling in missing index blanks', 0, 1) WITH NOWAIT;


### PR DESCRIPTION
Fixes #3993.

The parent row in `##BlitzCacheProcs` (QueryType `Procedure or Function:` / `Trigger:`) is inserted with `QueryHash = NULL`, so the existing missing-indexes `UPDATE` — which joins on `QueryHash` — never touches it. The Missing Indexes column on that row always fell through to the `<?NoNeedToClickMe -- N/A --?>` fill-in even when its child statements had recommendations.

This PR adds a second `UPDATE` that aggregates from `#missing_index_pretty` by `SqlHandle` alone and writes the result onto the parent row. Aggregating at the `#missing_index_pretty` layer (rather than concatenating each statement's already-wrapped XML) keeps the rollup inside a single `<MissingIndexes><![CDATA[ … ]]></MissingIndexes>` envelope, which is well-formed XML for the XML-typed column. The inner `GROUP BY mip2.details` dedupes overlapping recommendations across statements, and `ORDER BY MAX(mip2.impact) DESC` preserves the existing impact ordering.

If no statement contributed to `#missing_index_pretty` for a given proc, the join is a no-op and the existing fill-in-blanks step still writes the N/A placeholder, so procs with no missing-index recommendations are unaffected.

**Testing**

Reproduced the bug from the issue against `usp_Q6627` on `StackOverflow` (SQL Server 2025 RTM-CU4-GDR), then re-ran with the fix:

- Before: proc row's Missing Indexes = `<?NoNeedToClickMe -- N/A --?>`; statement row's Missing Indexes = `<MissingIndexes> … CREATE NONCLUSTERED INDEX ix_LastEditorUserId_PostTypeId_Includes … </MissingIndexes>`.
- After: both rows show the full `<MissingIndexes>` block with both recommended indexes (`ix_LastEditorUserId_PostTypeId_Includes`, `ix_LastEditorUserId_Includes`), highest-impact first.

Also tested against a proc with no missing-index recommendations — both rows correctly fall through to the `<?NoNeedToClickMe -- N/A --?>` placeholder, confirming the no-rollup path is unaffected.