### PR TITLE
sp_BlitzCache: fix empty <ai_prompt /> on parent procedure rows

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5325,7 +5325,38 @@ XML Execution Plan:
 Thank you.'
     FROM ##BlitzCacheProcs p
     WHERE p.SPID = @@SPID
-    AND NOT (p.QueryType LIKE 'Procedure or Function:%'     /* This and the below exists query makes sure that we don't get advice for parent procs, only their statements, if the statements are in our result set. */
+    /* Generate a prompt for every row, including parent procedures whose
+       statements are also in the result set. When @AI = 1 we still avoid
+       calling the API on those parents (see the cursor below), but @AI = 2
+       users get a full prompt on every row so they can paste it elsewhere. */
+    OPTION (RECOMPILE);
+
+    /* If both query text and query plan are null, override with a simple message - no metrics or system prompt needed */
+    UPDATE ##BlitzCacheProcs
+    SET ai_prompt = N'Prompt not generated because we can''t find the query text or query plan.'
+    WHERE SPID = @@SPID
+    AND QueryText IS NULL
+    AND QueryPlan IS NULL
+    OPTION (RECOMPILE);
+
+    IF @Debug = 2
+        SELECT 'After setting up ai_prompt, before calling AI' AS ai_stage, SqlHandle, QueryHash, PlanHandle, QueryPlan, ai_prompt, ai_advice, ai_raw_response
+            FROM ##BlitzCacheProcs
+            WHERE SPID = @@SPID;
+        
+    IF @AI = 1
+    BEGIN
+        RAISERROR('Calling AI endpoint for query plan analysis - starting loop', 0, 1) WITH NOWAIT;
+
+        /* Parent procedures whose statements are also in the result set are
+           skipped by the AI cursor below (each statement is analyzed
+           individually). Stamp a clear ai_advice on those parent rows so the
+           column shows an explanation instead of being blank in the output. */
+        UPDATE p
+        SET p.ai_advice = N'AI advice not generated for this parent procedure because its individual statements are being analyzed separately. See the AI Advice on each Statement (parent ...) row.'
+        FROM ##BlitzCacheProcs p
+        WHERE p.SPID = @@SPID
+        AND p.QueryType LIKE 'Procedure or Function:%'
         AND EXISTS
         (
             SELECT 1
@@ -5350,25 +5381,7 @@ Thank you.'
                           - (LEN('Statement (parent ') + 1)
                     )))
         )
-    )
-    OPTION (RECOMPILE);
-
-    /* If both query text and query plan are null, override with a simple message - no metrics or system prompt needed */
-    UPDATE ##BlitzCacheProcs
-    SET ai_prompt = N'Prompt not generated because we can''t find the query text or query plan.'
-    WHERE SPID = @@SPID
-    AND QueryText IS NULL
-    AND QueryPlan IS NULL
-    OPTION (RECOMPILE);
-
-    IF @Debug = 2
-        SELECT 'After setting up ai_prompt, before calling AI' AS ai_stage, SqlHandle, QueryHash, PlanHandle, QueryPlan, ai_prompt, ai_advice, ai_raw_response
-            FROM ##BlitzCacheProcs
-            WHERE SPID = @@SPID;
-        
-    IF @AI = 1
-    BEGIN
-        RAISERROR('Calling AI endpoint for query plan analysis - starting loop', 0, 1) WITH NOWAIT;
+        OPTION (RECOMPILE);
 
         DECLARE @CurrentSqlHandle VARBINARY(64);
         DECLARE @CurrentQueryHash BINARY(8);
@@ -5378,13 +5391,40 @@ Thank you.'
         DECLARE @AIResponseJSON NVARCHAR(MAX);
         DECLARE @AIReturnValue INT;
         DECLARE @AIErrorMessage NVARCHAR(4000);
-        
+
         DECLARE ai_cursor CURSOR LOCAL FAST_FORWARD FOR
-        SELECT DISTINCT SqlHandle, QueryHash, PlanHandle, ai_prompt, COALESCE(QueryType, N'') + N' - ' + LEFT(COALESCE(QueryText, N'(no text)'), 100)
-        FROM ##BlitzCacheProcs
-        WHERE SPID = @@SPID
-        AND ai_prompt IS NOT NULL
-        AND (QueryPlan IS NOT NULL OR QueryText IS NOT NULL);
+        SELECT DISTINCT p.SqlHandle, p.QueryHash, p.PlanHandle, p.ai_prompt, COALESCE(p.QueryType, N'') + N' - ' + LEFT(COALESCE(p.QueryText, N'(no text)'), 100)
+        FROM ##BlitzCacheProcs AS p
+        WHERE p.SPID = @@SPID
+        AND p.ai_prompt IS NOT NULL
+        AND (p.QueryPlan IS NOT NULL OR p.QueryText IS NOT NULL)
+        /* Skip parent procs whose statements are in the result set — those
+           statements are analyzed individually, so the parent would be a
+           redundant API call. */
+        AND NOT (p.QueryType LIKE 'Procedure or Function:%'
+            AND EXISTS
+            (
+                SELECT 1
+                FROM ##BlitzCacheProcs AS S
+                WHERE
+                    S.SPID         = p.SPID
+                    AND S.DatabaseName = p.DatabaseName
+                    AND S.PlanHandle   = p.PlanHandle
+                    AND S.QueryType LIKE 'Statement (parent %'
+                    AND
+                        LTRIM(RTRIM(SUBSTRING(
+                            p.QueryType,
+                            CHARINDEX(':', p.QueryType) + 1,
+                            8000
+                        ))) =
+                        LTRIM(RTRIM(SUBSTRING(
+                            S.QueryType,
+                            LEN('Statement (parent ') + 1,
+                            CHARINDEX(')', S.QueryType, LEN('Statement (parent ') + 1)
+                              - (LEN('Statement (parent ') + 1)
+                        )))
+            )
+        );
         
         OPEN ai_cursor;
         

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5348,13 +5348,22 @@ Thank you.'
     BEGIN
         RAISERROR('Calling AI endpoint for query plan analysis - starting loop', 0, 1) WITH NOWAIT;
 
-        /* Parent procedures whose statements are also in the result set are
-           skipped by the AI cursor below (each statement is analyzed
-           individually). Stamp a clear ai_advice on those parent rows so the
-           column shows an explanation instead of being blank in the output. */
-        UPDATE p
-        SET p.ai_advice = N'AI advice not generated for this parent procedure because its individual statements are being analyzed separately. See the AI Advice on each Statement (parent ...) row.'
-        FROM ##BlitzCacheProcs p
+        /* Identify parent procedure rows whose statements are also in the
+           result set. The same set is consumed twice below — once to stamp a
+           clear ai_advice on those parent rows so the column isn't blank in
+           the output, and again to filter the AI cursor so we don't pay for a
+           redundant API call (each statement is analyzed individually).
+           Materializing it once keeps the (PlanHandle, QueryType-name) match
+           logic in one place. */
+        CREATE TABLE #parents_with_kids
+        (
+            PlanHandle VARBINARY(64) NOT NULL,
+            QueryType  NVARCHAR(258) NOT NULL
+        );
+
+        INSERT INTO #parents_with_kids (PlanHandle, QueryType)
+        SELECT DISTINCT p.PlanHandle, p.QueryType
+        FROM ##BlitzCacheProcs AS p
         WHERE p.SPID = @@SPID
         AND p.QueryType LIKE 'Procedure or Function:%'
         AND EXISTS
@@ -5383,6 +5392,18 @@ Thank you.'
         )
         OPTION (RECOMPILE);
 
+        CREATE NONCLUSTERED INDEX IX_parents_with_kids
+            ON #parents_with_kids (PlanHandle, QueryType);
+
+        UPDATE p
+        SET p.ai_advice = N'AI advice not generated for this parent procedure because its individual statements are being analyzed separately. See the AI Advice on each Statement (parent ...) row.'
+        FROM ##BlitzCacheProcs AS p
+        INNER JOIN #parents_with_kids AS pwk
+            ON pwk.PlanHandle = p.PlanHandle
+           AND pwk.QueryType  = p.QueryType
+        WHERE p.SPID = @@SPID
+        OPTION (RECOMPILE);
+
         DECLARE @CurrentSqlHandle VARBINARY(64);
         DECLARE @CurrentQueryHash BINARY(8);
         DECLARE @CurrentPlanHandle VARBINARY(64);
@@ -5401,29 +5422,12 @@ Thank you.'
         /* Skip parent procs whose statements are in the result set — those
            statements are analyzed individually, so the parent would be a
            redundant API call. */
-        AND NOT (p.QueryType LIKE 'Procedure or Function:%'
-            AND EXISTS
-            (
-                SELECT 1
-                FROM ##BlitzCacheProcs AS S
-                WHERE
-                    S.SPID         = p.SPID
-                    AND S.DatabaseName = p.DatabaseName
-                    AND S.PlanHandle   = p.PlanHandle
-                    AND S.QueryType LIKE 'Statement (parent %'
-                    AND
-                        LTRIM(RTRIM(SUBSTRING(
-                            p.QueryType,
-                            CHARINDEX(':', p.QueryType) + 1,
-                            8000
-                        ))) =
-                        LTRIM(RTRIM(SUBSTRING(
-                            S.QueryType,
-                            LEN('Statement (parent ') + 1,
-                            CHARINDEX(')', S.QueryType, LEN('Statement (parent ') + 1)
-                              - (LEN('Statement (parent ') + 1)
-                        )))
-            )
+        AND NOT EXISTS
+        (
+            SELECT 1
+            FROM #parents_with_kids AS pwk
+            WHERE pwk.PlanHandle = p.PlanHandle
+              AND pwk.QueryType  = p.QueryType
         );
         
         OPEN ai_cursor;


### PR DESCRIPTION
Fixes #3995.

## Summary

When `sp_BlitzCache` runs with `@AI = 1` or `@AI = 2`, some rows render the **AI Prompt** column as a self-closing, empty XML element (`<ai_prompt />`). The affected rows are `Procedure or Function:` parent rows whose corresponding `Statement (parent ...)` rows are also in the result set. Full diagnosis is in #3995.

## What changed

Two concerns were conflated under `ai_prompt IS NULL`:

| Concern | Where it applies | Where it was enforced before | Where it is enforced now |
|---|---|---|---|
| Generate a usable prompt for display | `@AI = 1` and `@AI = 2` | Skipped on parent-with-kids rows in the metrics `UPDATE` | Always applied — every row gets a prompt |
| Avoid redundant API call for the same optimization | `@AI = 1` only | Implicit (parent rows had NULL `ai_prompt`, so the cursor skipped them) | Explicit `NOT EXISTS` predicate on the cursor's `WHERE` |

Three edits in `sp_BlitzCache.sql`:

1. **Metrics `UPDATE` (around line 5258)** — removed the parent-with-kids exclusion. Every row in `##BlitzCacheProcs` now gets an `ai_prompt`.
2. **AI cursor `WHERE` (around line 5395)** — added the parent-with-kids `NOT EXISTS` clause. The cursor still skips parents whose statements are also in the result set, so no redundant API calls.
3. **New `UPDATE` inside `IF @AI = 1` (around line 5351)** — stamps `ai_advice` on the skipped parents with: *"AI advice not generated for this parent procedure because its individual statements are being analyzed separately. See the AI Advice on each Statement (parent ...) row."* — so the column shows an explanation instead of being blank.

`@AI = 2` users now see a full prompt on every row — including parent procedures, which is legitimately useful when the user wants the model to reason about a procedure as a whole rather than statement-by-statement. `@AI = 1` users continue to pay for AI calls only on the statement rows, not on their parent procs.

## Test results

Run against my local plan cache (no plan cache reset) before and after the fix:

| Test | Before | After |
|---|---|---|
| `@AI = 2`: rows with NULL `ai_prompt` | 7 of 59 | **0 of 59** |
| `@AI = 2`: parent-with-kids rows with a full prompt | 0 of 7 | **7 of 7** (15K-50K chars each) |
| Rendered output: empty `<ai_prompt />` elements | several | **0** |
| `@AI = 1`: parent-with-kids rows that triggered an API call | 7 of 7 | **0 of 7** |
| `@AI = 1`: parent-with-kids rows with the stub `ai_advice` | 0 of 7 | **7 of 7** |
| `@AI = 1`: non-parent rows processed by the cursor | 32 | **32** (unchanged) |

## Test plan

- [ ] Install `sp_BlitzCache.sql` from this branch on a server whose plan cache contains stored procedures with multiple statements.
- [ ] `EXEC dbo.sp_BlitzCache @AI = 2, @Top = 50;` — verify the **AI Prompt** column has content on every row, including `Procedure or Function:` rows whose statements are also present.
- [ ] Inspect the same result in SSMS — verify no row renders as `<ai_prompt />`.
- [ ] If you have AI credentials configured, run `EXEC dbo.sp_BlitzCache @AI = 1, @Top = 50;` and verify:
  - Parent-with-statements rows show the new stub message in **AI Advice** rather than a real AI response.
  - Non-parent rows still receive real AI advice as before.
  - The total number of API calls equals the number of non-parent rows (no extra calls on parents).