### PR TITLE
sp_BlitzLock: replace -1 sentinel on @OutputDatabaseCheck with NULL

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -619,7 +619,7 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
         ) /*If database is invalid raiserror and set bitcheck*/
         BEGIN
             RAISERROR('Database Name (%s) for output of table is invalid please, Output to Table will not be performed', 0, 1, @OutputDatabaseName) WITH NOWAIT;
-            SET @OutputDatabaseCheck = -1; /* -1 invalid/false, 0 = good/true */
+            SET @OutputDatabaseCheck = NULL; /* bit can't hold -1; NULL = invalid, 0 = valid, default 1 = no output db requested. See issue #4000. */
         END;
         ELSE
         BEGIN


### PR DESCRIPTION
## Summary

Fixes #4000.

In `sp_BlitzLock`, when `@OutputDatabaseName` is supplied but the database doesn't exist, the proc does `SET @OutputDatabaseCheck = -1; /* -1 invalid/false, 0 = good/true */`. But `@OutputDatabaseCheck` is declared `bit`, which only stores `0`, `1`, or `NULL` — any nonzero integer is implicitly converted to `1`. So `-1` was silently being stored as `1`, the same as the default "no output database requested" value. The comment was lying about what was on disk.

PR #3801 fixed the declaration (`bit = -1` → `bit = 1`) but missed this inner `SET`.

This change swaps the sentinel to `NULL` so the proc actually has the tri-state it always intended:

| State                              | Stored value |
|------------------------------------|-------------:|
| No output DB requested (default)   |          `1` |
| Output DB requested, valid         |          `0` |
| Output DB requested, invalid       |       `NULL` |

## Why NULL is safe downstream

All three downstream checks (`IF @OutputDatabaseCheck = 0` at lines 4169, 4227, 4269) evaluate to UNKNOWN (→ false) when the value is `NULL`, which matches today's behavior (`1 = 0` is also false). The valid-DB path (`@OutputDatabaseCheck = 0`) is unaffected.

## Test plan

Verified on SQL Server 2025 lab box (also pre-verified bit semantics on Azure SQL DB):

- [x] **Bit semantics**: confirmed `bit = NULL` produces FALSE for both `@x = 0` and `@a = 1 OR @x = 0`, matching the prior silently-converted `1`
- [x] **Compile**: `CREATE OR ALTER` deployed cleanly
- [x] **Invalid output DB path**: `EXEC sp_BlitzLock @OutputDatabaseName = 'ThisDbDoesNotExist'` — emits the "invalid please" message, proceeds past line 622 without error, never enters the output-to-table block
- [x] **Valid output DB path (regression)**: `EXEC sp_BlitzLock @OutputDatabaseName = 'master', @OutputTableName = 'DeadLockTbl_FRKTest'` — `IF @OutputDatabaseCheck = 0` block fires, writes 412 rows to the target table, emits "Results to table" and "Findings to table" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)