### PR TITLE
sp_BlitzCache: minimize query plan XML sent to AI (#3862)

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5324,10 +5324,16 @@ BEGIN
         CPUms    BIGINT,
         Elapms   BIGINT
     );
-    /* Showplan wraps child RelOps in a single intermediary element (Hash, NestedLoops,
-       Filter, Sort, etc.), so `RelOp/ * /RelOp` returns the immediate children. We
-       build this map explicitly because SQL Server XQuery does not support the
-       ancestor:: axis. */
+    /* SQL Server XQuery does not support the ancestor:: axis, so we build the
+       parent-child RelOp map in two steps: first capture every ancestor-descendant
+       pair via descendant:: (handles arbitrarily-deep nesting like scalar subquery
+       RelOps under ComputeScalar/DefinedValues/ScalarOperator), then derive the
+       immediate parents by eliminating pairs that have an intermediate RelOp. */
+    DECLARE @plan_anc_desc TABLE (
+        AncestorId   INT,
+        DescendantId INT,
+        PRIMARY KEY (AncestorId, DescendantId)
+    );
     DECLARE @plan_parent_child TABLE (
         ParentNodeId INT,
         ChildNodeId  INT
@@ -5361,6 +5367,7 @@ BEGIN
     BEGIN
         BEGIN TRY
             DELETE FROM @plan_op_thread;
+            DELETE FROM @plan_anc_desc;
             DELETE FROM @plan_parent_child;
             DELETE FROM @plan_op_recalc;
 
@@ -5435,12 +5442,24 @@ BEGIN
                 CROSS APPLY ro.nodes('p:RunTimeInformation/p:RunTimeCountersPerThread') AS c(ctr);
 
                 ;WITH XMLNAMESPACES('http://schemas.microsoft.com/sqlserver/2004/07/showplan' AS p)
-                INSERT INTO @plan_parent_child (ParentNodeId, ChildNodeId)
+                INSERT INTO @plan_anc_desc (AncestorId, DescendantId)
                 SELECT
-                    parent_ro.value('@NodeId', 'int'),
-                    child_ro.value('@NodeId', 'int')
-                FROM @cur_plan.nodes('//p:RelOp') AS p_(parent_ro)
-                CROSS APPLY parent_ro.nodes('*/p:RelOp') AS c(child_ro);
+                    a_ro.value('@NodeId', 'int'),
+                    d_ro.value('@NodeId', 'int')
+                FROM @cur_plan.nodes('//p:RelOp') AS p_(a_ro)
+                CROSS APPLY a_ro.nodes('.//p:RelOp') AS c(d_ro);
+
+                /* Immediate parent = ancestor pair with no intermediate RelOp. */
+                INSERT INTO @plan_parent_child (ParentNodeId, ChildNodeId)
+                SELECT ad.AncestorId, ad.DescendantId
+                FROM @plan_anc_desc ad
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM @plan_anc_desc ad2
+                    JOIN @plan_anc_desc ad3 ON ad3.AncestorId = ad2.DescendantId
+                    WHERE ad2.AncestorId = ad.AncestorId
+                      AND ad3.DescendantId = ad.DescendantId
+                );
 
                 ;WITH child_sum AS (
                     SELECT pc.ParentNodeId, t.ThreadId,

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -240,11 +240,12 @@ CREATE TABLE ##BlitzCacheProcs (
         Warnings VARCHAR(MAX),
     	Pattern NVARCHAR(20),
         ai_prompt NVARCHAR(MAX),
+        ai_query_plan NVARCHAR(MAX),
         ai_advice NVARCHAR(MAX),
         ai_payload NVARCHAR(MAX),
         ai_raw_response NVARCHAR(MAX)
     );
-GO 
+GO
 
 ALTER PROCEDURE dbo.sp_BlitzCache
     @Help BIT = 0,
@@ -2887,6 +2888,7 @@ BEGIN
         Warnings VARCHAR(MAX),
 		Pattern NVARCHAR(20),
         ai_prompt NVARCHAR(MAX),
+        ai_query_plan NVARCHAR(MAX),
         ai_advice NVARCHAR(MAX),
         ai_payload NVARCHAR(MAX),
         ai_raw_response NVARCHAR(MAX)
@@ -2895,6 +2897,9 @@ END;
 ELSE
 BEGIN
   RAISERROR(N'Cleaning up old plans for your SPID', 0, 1) WITH NOWAIT;
+  /* Schema-drift guard: older versions did not have ai_query_plan; add it on the fly so @Reanalyze runs do not fail. */
+  IF COL_LENGTH('tempdb..##BlitzCacheProcs','ai_query_plan') IS NULL
+      ALTER TABLE ##BlitzCacheProcs ADD ai_query_plan NVARCHAR(MAX) NULL;
   DELETE ##BlitzCacheProcs
     WHERE SPID = @@SPID
 	OPTION (RECOMPILE) ;
@@ -5300,6 +5305,225 @@ BEGIN
       AND LEN(c.Constitution) > 0;
 
 
+    /* Minimize the query plan XML before adding it to the AI prompt.
+       Goals: less token spend, less LLM distraction. Implements GitHub issue #3862.
+       - Strip cost-percentage attributes (the issue's main ask) and other noise.
+       - Collapse per-thread row-mode timings into per-operator net values
+         (Forrest McDaniel's approach: per-thread sum minus immediate-child sum).
+       - Minify whitespace in the final text.
+       On any failure we leave ai_query_plan NULL; the prompt build below falls
+       back to CAST(QueryPlan AS NVARCHAR(MAX)). */
+    RAISERROR(N'Minimizing query plan XML for AI prompt', 0, 1) WITH NOWAIT;
+
+    DECLARE @plan_op_thread TABLE (
+        NodeId   INT,
+        Mode     VARCHAR(10),
+        ThreadId INT,
+        Rows_    BIGINT,
+        Scans    BIGINT,
+        CPUms    BIGINT,
+        Elapms   BIGINT
+    );
+    /* Showplan wraps child RelOps in a single intermediary element (Hash, NestedLoops,
+       Filter, Sort, etc.), so `RelOp/ * /RelOp` returns the immediate children. We
+       build this map explicitly because SQL Server XQuery does not support the
+       ancestor:: axis. */
+    DECLARE @plan_parent_child TABLE (
+        ParentNodeId INT,
+        ChildNodeId  INT
+    );
+    DECLARE @plan_op_recalc TABLE (
+        NodeId    INT,
+        SumCPUms  BIGINT,
+        MaxElapms BIGINT,
+        SumRows   BIGINT,
+        MaxScans  BIGINT
+    );
+
+    DECLARE @cur_sql VARBINARY(64),
+            @cur_hash BINARY(8),
+            @cur_plan XML,
+            @cur_plan_text NVARCHAR(MAX),
+            @cur_has_actuals BIT,
+            @cur_relop_count INT,
+            @nid INT, @cpu BIGINT, @elap BIGINT, @rows BIGINT, @scans BIGINT;
+
+    DECLARE ai_plan_min_cursor CURSOR LOCAL FAST_FORWARD FOR
+        SELECT SqlHandle, QueryHash, QueryPlan
+        FROM ##BlitzCacheProcs
+        WHERE SPID = @@SPID
+          AND QueryPlan IS NOT NULL;
+
+    OPEN ai_plan_min_cursor;
+    FETCH NEXT FROM ai_plan_min_cursor INTO @cur_sql, @cur_hash, @cur_plan;
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        BEGIN TRY
+            DELETE FROM @plan_op_thread;
+            DELETE FROM @plan_parent_child;
+            DELETE FROM @plan_op_recalc;
+
+            /* Does this plan have actuals? If not, estimated attributes are the
+               only signal we have; do not strip estimates that lack an actual
+               equivalent. */
+            SET @cur_has_actuals = CASE WHEN @cur_plan.exist(N'
+                declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
+                //p:RunTimeInformation
+            ') = 1 THEN 1 ELSE 0 END;
+
+            /* 2a. Always-delete attributes: cost-percentage distractors per the issue, plus noise. */
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedTotalSubtreeCost'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementSubTreeCost'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateCPU'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateIO'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@AvgRowSize'); END TRY BEGIN CATCH END CATCH;
+
+            /* Compile/hardware chatter — already surfaced in the metrics block. */
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileTime'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileCPU'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileMemory'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CachedPlanSize'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@MaxCompileMemory'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedAvailableDegreeOfParallelism'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedAvailableMemoryGrant'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedPagesCached'); END TRY BEGIN CATCH END CATCH;
+
+            /* Statement metadata of low AI value. */
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementOptmEarlyAbortReason'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementOptmLevel'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@RetrievedFromCache'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@SecurityPolicyApplied'); END TRY BEGIN CATCH END CATCH;
+
+            /* Estimate attributes superseded by actuals — only strip when actuals exist. */
+            IF @cur_has_actuals = 1
+            BEGIN
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateRebinds'); END TRY BEGIN CATCH END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateRewinds'); END TRY BEGIN CATCH END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedRowsRead'); END TRY BEGIN CATCH END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedRowsForAllExecs'); END TRY BEGIN CATCH END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@TableCardinality'); END TRY BEGIN CATCH END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedExecutionMode'); END TRY BEGIN CATCH END CATCH;
+            END;
+
+            /* 2b. Element deletion. */
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:OptimizerHardwareDependentProperties'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:OptimizerStatsUsage'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:TraceFlags'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:WaitStats'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:ParameterList[not(p:ColumnReference)]'); END TRY BEGIN CATCH END CATCH;
+
+            /* 2c. Row-mode operator timing recalc (per-thread cumulative -> per-operator net).
+               Skipped for estimated-only plans and for plans with >500 RelOps. */
+            SET @cur_relop_count = @cur_plan.value(N'
+                declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
+                count(//p:RelOp)', 'int');
+
+            IF @cur_has_actuals = 1 AND @cur_relop_count <= 500
+            BEGIN
+                ;WITH XMLNAMESPACES('http://schemas.microsoft.com/sqlserver/2004/07/showplan' AS p)
+                INSERT INTO @plan_op_thread (NodeId, Mode, ThreadId, Rows_, Scans, CPUms, Elapms)
+                SELECT
+                    ro.value('@NodeId', 'int'),
+                    ro.value('@ActualExecutionMode', 'varchar(10)'),
+                    ctr.value('@Thread', 'int'),
+                    ctr.value('@ActualRows', 'bigint'),
+                    ctr.value('@ActualEndOfScans', 'bigint'),
+                    ctr.value('@ActualCPUms', 'bigint'),
+                    ctr.value('@ActualElapsedms', 'bigint')
+                FROM @cur_plan.nodes('//p:RelOp') AS r(ro)
+                CROSS APPLY ro.nodes('p:RunTimeInformation/p:RunTimeCountersPerThread') AS c(ctr);
+
+                ;WITH XMLNAMESPACES('http://schemas.microsoft.com/sqlserver/2004/07/showplan' AS p)
+                INSERT INTO @plan_parent_child (ParentNodeId, ChildNodeId)
+                SELECT
+                    parent_ro.value('@NodeId', 'int'),
+                    child_ro.value('@NodeId', 'int')
+                FROM @cur_plan.nodes('//p:RelOp') AS p_(parent_ro)
+                CROSS APPLY parent_ro.nodes('*/p:RelOp') AS c(child_ro);
+
+                ;WITH child_sum AS (
+                    SELECT pc.ParentNodeId, t.ThreadId,
+                           ChildCPUms  = SUM(t.CPUms),
+                           ChildElapms = SUM(t.Elapms)
+                    FROM @plan_parent_child pc
+                    JOIN @plan_op_thread t ON t.NodeId = pc.ChildNodeId
+                    WHERE t.Mode = 'Row'
+                    GROUP BY pc.ParentNodeId, t.ThreadId
+                ),
+                per_thread AS (
+                    SELECT t.NodeId, t.ThreadId, t.Mode,
+                           OwnCPUms  = CASE WHEN t.Mode = 'Row' THEN t.CPUms  - ISNULL(c.ChildCPUms, 0)  ELSE t.CPUms  END,
+                           OwnElapms = CASE WHEN t.Mode = 'Row' THEN t.Elapms - ISNULL(c.ChildElapms, 0) ELSE t.Elapms END,
+                           t.Rows_, t.Scans
+                    FROM @plan_op_thread t
+                    LEFT JOIN child_sum c ON c.ParentNodeId = t.NodeId AND c.ThreadId = t.ThreadId
+                )
+                INSERT INTO @plan_op_recalc (NodeId, SumCPUms, MaxElapms, SumRows, MaxScans)
+                SELECT NodeId,
+                       SUM(CASE WHEN OwnCPUms  < 0 THEN 0 ELSE OwnCPUms  END),
+                       MAX(CASE WHEN OwnElapms < 0 THEN 0 ELSE OwnElapms END),
+                       SUM(Rows_),
+                       MAX(Scans)
+                FROM per_thread
+                GROUP BY NodeId;
+
+                /* Collapse per-thread blocks down to one summary entry per operator.
+                   Done via delete-all + insert-fresh because parallel plans label
+                   their threads 1..N (no Thread=0 to write into). */
+                WHILE EXISTS (SELECT 1 FROM @plan_op_recalc)
+                BEGIN
+                    SELECT TOP (1) @nid = NodeId, @cpu = SumCPUms, @elap = MaxElapms, @rows = SumRows, @scans = MaxScans
+                    FROM @plan_op_recalc;
+
+                    BEGIN TRY SET @cur_plan.modify(N'
+                        declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
+                        delete //p:RelOp[@NodeId=sql:variable("@nid")]/p:RunTimeInformation/p:RunTimeCountersPerThread
+                    '); END TRY BEGIN CATCH END CATCH;
+                    BEGIN TRY SET @cur_plan.modify(N'
+                        declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
+                        insert <p:RunTimeCountersPerThread Thread="0"
+                                    ActualRows="{sql:variable("@rows")}"
+                                    ActualEndOfScans="{sql:variable("@scans")}"
+                                    ActualExecutions="1"
+                                    ActualCPUms="{sql:variable("@cpu")}"
+                                    ActualElapsedms="{sql:variable("@elap")}" />
+                        into (//p:RelOp[@NodeId=sql:variable("@nid")]/p:RunTimeInformation)[1]
+                    '); END TRY BEGIN CATCH END CATCH;
+
+                    DELETE @plan_op_recalc WHERE NodeId = @nid;
+                END;
+            END;
+
+            /* 2d. Whitespace minification (text-level, after all .modify() work). */
+            SET @cur_plan_text = CAST(@cur_plan AS NVARCHAR(MAX));
+            SET @cur_plan_text = REPLACE(@cur_plan_text, NCHAR(13) + NCHAR(10), N'');
+            SET @cur_plan_text = REPLACE(@cur_plan_text, NCHAR(10), N'');
+            SET @cur_plan_text = REPLACE(@cur_plan_text, NCHAR(9), N'');
+            SET @cur_plan_text = REPLACE(@cur_plan_text, N'>  ', N'>');
+            SET @cur_plan_text = REPLACE(@cur_plan_text, N'>  ', N'>');
+            SET @cur_plan_text = REPLACE(@cur_plan_text, N'> <', N'><');
+
+            UPDATE ##BlitzCacheProcs
+               SET ai_query_plan = @cur_plan_text
+             WHERE SPID = @@SPID
+               AND SqlHandle = @cur_sql
+               AND QueryHash = @cur_hash;
+        END TRY
+        BEGIN CATCH
+            /* Catastrophic failure on this plan (e.g., processing-instruction stub
+               from the huge-plan path) - leave ai_query_plan NULL; prompt build
+               falls back to CAST(QueryPlan AS NVARCHAR(MAX)). */
+            IF @Debug >= 1
+                RAISERROR(N'Plan minimization failed for one row; falling back to raw plan.', 0, 1) WITH NOWAIT;
+        END CATCH;
+
+        FETCH NEXT FROM ai_plan_min_cursor INTO @cur_sql, @cur_hash, @cur_plan;
+    END;
+    CLOSE ai_plan_min_cursor;
+    DEALLOCATE ai_plan_min_cursor;
+
+
     /* Update ai_prompt column with query metrics for rows that have query plans */
     UPDATE p
     SET ai_prompt = COALESCE(ai_prompt, N'') + N'Here are the performance metrics we are seeing in production, as measured by the plan cache:
@@ -5364,8 +5588,15 @@ Query Text (which is cut off for long queries):
 
 ' + CASE WHEN QueryType LIKE N'Statement (parent%' THEN N' The above query is part of a batch, stored procedure, or function, so other queries may show up in the query plan. However, those other queries are irrelevant here. Focus on this specific query above, because it is one of the most resource-intensive queries in the batch. The execution plan below includes other statements in the batch, but ignore those and focus only the query above and its specific plan in the batch below. ' ELSE N' ' END + N'
 
-XML Execution Plan:
-' + CASE WHEN QueryPlan IS NULL THEN N'(Query plan could not be retrieved.)' ELSE CAST(QueryPlan AS NVARCHAR(MAX)) END + N'
+Plan summary: ' + CASE WHEN is_parallel = 1 THEN N'parallel' ELSE N'serial' END + N', ' + ISNULL(CAST(missing_index_count AS NVARCHAR(10)), N'0') + N' missing index suggestion(s).
+' + CASE WHEN ai_query_plan IS NOT NULL
+        THEN N'XML Execution Plan (minimized to reduce tokens: cost-percent attributes stripped; row-mode operator timings shown per-operator rather than cumulative; per-thread timings collapsed to one summary per operator):'
+        ELSE N'XML Execution Plan:' END + N'
+' + CASE
+        WHEN ai_query_plan IS NOT NULL THEN ai_query_plan
+        WHEN QueryPlan    IS NOT NULL THEN CAST(QueryPlan AS NVARCHAR(MAX))
+        ELSE N'(Query plan could not be retrieved.)'
+    END + N'
 
 Thank you.'
     FROM ##BlitzCacheProcs p
@@ -5385,9 +5616,25 @@ Thank you.'
     OPTION (RECOMPILE);
 
     IF @Debug = 2
-        SELECT 'After setting up ai_prompt, before calling AI' AS ai_stage, SqlHandle, QueryHash, PlanHandle, QueryPlan, ai_prompt, ai_advice, ai_raw_response
+    BEGIN
+        SELECT 'After setting up ai_prompt, before calling AI' AS ai_stage, SqlHandle, QueryHash, PlanHandle, QueryPlan, ai_prompt, ai_query_plan, ai_advice, ai_raw_response
             FROM ##BlitzCacheProcs
             WHERE SPID = @@SPID;
+
+        SELECT 'Plan minimization savings' AS ai_stage,
+               SqlHandle,
+               QueryHash,
+               OriginalBytes  = DATALENGTH(CAST(QueryPlan AS NVARCHAR(MAX))),
+               MinimizedBytes = DATALENGTH(ai_query_plan),
+               PercentSaved   = CASE WHEN DATALENGTH(CAST(QueryPlan AS NVARCHAR(MAX))) > 0
+                                     THEN 100 - (DATALENGTH(ai_query_plan) * 100
+                                                 / DATALENGTH(CAST(QueryPlan AS NVARCHAR(MAX))))
+                                END
+        FROM ##BlitzCacheProcs
+        WHERE SPID = @@SPID
+          AND ai_query_plan IS NOT NULL
+        ORDER BY OriginalBytes DESC;
+    END;
         
     IF @AI = 1
     BEGIN

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -2897,9 +2897,19 @@ END;
 ELSE
 BEGIN
   RAISERROR(N'Cleaning up old plans for your SPID', 0, 1) WITH NOWAIT;
-  /* Schema-drift guard: older versions did not have ai_query_plan; add it on the fly so @Reanalyze runs do not fail. */
+  /* Schema-drift guard: a ##BlitzCacheProcs left behind by an older version of this
+     proc may be missing the ai_* columns, so add any that are absent on the fly
+     rather than failing the @Reanalyze run. */
+  IF COL_LENGTH('tempdb..##BlitzCacheProcs','ai_prompt') IS NULL
+      ALTER TABLE ##BlitzCacheProcs ADD ai_prompt NVARCHAR(MAX) NULL;
   IF COL_LENGTH('tempdb..##BlitzCacheProcs','ai_query_plan') IS NULL
       ALTER TABLE ##BlitzCacheProcs ADD ai_query_plan NVARCHAR(MAX) NULL;
+  IF COL_LENGTH('tempdb..##BlitzCacheProcs','ai_advice') IS NULL
+      ALTER TABLE ##BlitzCacheProcs ADD ai_advice NVARCHAR(MAX) NULL;
+  IF COL_LENGTH('tempdb..##BlitzCacheProcs','ai_payload') IS NULL
+      ALTER TABLE ##BlitzCacheProcs ADD ai_payload NVARCHAR(MAX) NULL;
+  IF COL_LENGTH('tempdb..##BlitzCacheProcs','ai_raw_response') IS NULL
+      ALTER TABLE ##BlitzCacheProcs ADD ai_raw_response NVARCHAR(MAX) NULL;
   DELETE ##BlitzCacheProcs
     WHERE SPID = @@SPID
 	OPTION (RECOMPILE) ;
@@ -5322,7 +5332,8 @@ BEGIN
         Rows_    BIGINT,
         Scans    BIGINT,
         CPUms    BIGINT,
-        Elapms   BIGINT
+        Elapms   BIGINT,
+        Execs    BIGINT
     );
     /* SQL Server XQuery does not support the ancestor:: axis, so we build the
        parent-child RelOp map in two steps: first capture every ancestor-descendant
@@ -5343,7 +5354,8 @@ BEGIN
         SumCPUms  BIGINT,
         MaxElapms BIGINT,
         SumRows   BIGINT,
-        MaxScans  BIGINT
+        MaxScans  BIGINT,
+        SumExecs  BIGINT
     );
 
     DECLARE @cur_sql VARBINARY(64),
@@ -5352,7 +5364,9 @@ BEGIN
             @cur_plan_text NVARCHAR(MAX),
             @cur_has_actuals BIT,
             @cur_relop_count INT,
-            @nid INT, @cpu BIGINT, @elap BIGINT, @rows BIGINT, @scans BIGINT;
+            @cur_distinct_nodeids INT,
+            @cur_modify_errors INT,
+            @nid INT, @cpu BIGINT, @elap BIGINT, @rows BIGINT, @scans BIGINT, @execs BIGINT;
 
     DECLARE ai_plan_min_cursor CURSOR LOCAL FAST_FORWARD FOR
         SELECT SqlHandle, QueryHash, QueryPlan
@@ -5370,6 +5384,7 @@ BEGIN
             DELETE FROM @plan_anc_desc;
             DELETE FROM @plan_parent_child;
             DELETE FROM @plan_op_recalc;
+            SET @cur_modify_errors = 0;
 
             /* Does this plan have actuals? If not, estimated attributes are the
                only signal we have; do not strip estimates that lack an actual
@@ -5380,56 +5395,73 @@ BEGIN
             ') = 1 THEN 1 ELSE 0 END;
 
             /* 2a. Always-delete attributes: cost-percentage distractors per the issue, plus noise. */
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedTotalSubtreeCost'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementSubTreeCost'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateCPU'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateIO'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@AvgRowSize'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedTotalSubtreeCost'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementSubTreeCost'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateCPU'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateIO'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@AvgRowSize'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
 
             /* Compile/hardware chatter — already surfaced in the metrics block. */
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileTime'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileCPU'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileMemory'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CachedPlanSize'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@MaxCompileMemory'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedAvailableDegreeOfParallelism'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedAvailableMemoryGrant'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedPagesCached'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileTime'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileCPU'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CompileMemory'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@CachedPlanSize'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@MaxCompileMemory'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedAvailableDegreeOfParallelism'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedAvailableMemoryGrant'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedPagesCached'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
 
             /* Statement metadata of low AI value. */
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementOptmEarlyAbortReason'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementOptmLevel'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@RetrievedFromCache'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@SecurityPolicyApplied'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementOptmEarlyAbortReason'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@StatementOptmLevel'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@RetrievedFromCache'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@SecurityPolicyApplied'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
 
             /* Estimate attributes superseded by actuals — only strip when actuals exist. */
             IF @cur_has_actuals = 1
             BEGIN
-                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateRebinds'); END TRY BEGIN CATCH END CATCH;
-                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateRewinds'); END TRY BEGIN CATCH END CATCH;
-                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedRowsRead'); END TRY BEGIN CATCH END CATCH;
-                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedRowsForAllExecs'); END TRY BEGIN CATCH END CATCH;
-                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@TableCardinality'); END TRY BEGIN CATCH END CATCH;
-                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedExecutionMode'); END TRY BEGIN CATCH END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateRebinds'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimateRewinds'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedRowsRead'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedRowsForAllExecs'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@TableCardinality'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+                BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //@EstimatedExecutionMode'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
             END;
 
             /* 2b. Element deletion. */
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:OptimizerHardwareDependentProperties'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:OptimizerStatsUsage'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:TraceFlags'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:WaitStats'); END TRY BEGIN CATCH END CATCH;
-            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:ParameterList[not(p:ColumnReference)]'); END TRY BEGIN CATCH END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:OptimizerHardwareDependentProperties'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:OptimizerStatsUsage'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:TraceFlags'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:WaitStats'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
+            BEGIN TRY SET @cur_plan.modify(N'declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan"; delete //p:ParameterList[not(p:ColumnReference)]'); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
 
             /* 2c. Row-mode operator timing recalc (per-thread cumulative -> per-operator net).
-               Skipped for estimated-only plans and for plans with >500 RelOps. */
+               Skipped when:
+               - The plan is estimated-only (nothing to recalc).
+               - The plan has more than 500 RelOps. Each RelOp costs two .modify() calls
+                 (a delete plus an insert), and every .modify() rewrites the whole
+                 document, so the cap bounds a single plan to ~1,000 rewrites - roughly
+                 a second of CPU on a big plan. Plans over the cap still get the
+                 attribute/element stripping above and whitespace minification below;
+                 they only keep their original cumulative row-mode timings.
+               - NodeId values are not unique across the document. NodeId is only
+                 unique within a single statement, so on multi-statement plans
+                 (stored procedures, batches) //p:RelOp[@NodeId=...] would mix
+                 operators from different statements: the math would blend unrelated
+                 operators and the delete/insert would target the wrong nodes. */
             SET @cur_relop_count = @cur_plan.value(N'
                 declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
                 count(//p:RelOp)', 'int');
+            SET @cur_distinct_nodeids = @cur_plan.value(N'
+                declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
+                count(distinct-values(//p:RelOp/@NodeId))', 'int');
 
-            IF @cur_has_actuals = 1 AND @cur_relop_count <= 500
+            IF @cur_has_actuals = 1
+               AND @cur_relop_count <= 500
+               AND @cur_distinct_nodeids = @cur_relop_count
             BEGIN
                 ;WITH XMLNAMESPACES('http://schemas.microsoft.com/sqlserver/2004/07/showplan' AS p)
-                INSERT INTO @plan_op_thread (NodeId, Mode, ThreadId, Rows_, Scans, CPUms, Elapms)
+                INSERT INTO @plan_op_thread (NodeId, Mode, ThreadId, Rows_, Scans, CPUms, Elapms, Execs)
                 SELECT
                     ro.value('@NodeId', 'int'),
                     ro.value('@ActualExecutionMode', 'varchar(10)'),
@@ -5437,7 +5469,8 @@ BEGIN
                     ctr.value('@ActualRows', 'bigint'),
                     ctr.value('@ActualEndOfScans', 'bigint'),
                     ctr.value('@ActualCPUms', 'bigint'),
-                    ctr.value('@ActualElapsedms', 'bigint')
+                    ctr.value('@ActualElapsedms', 'bigint'),
+                    ctr.value('@ActualExecutions', 'bigint')
                 FROM @cur_plan.nodes('//p:RelOp') AS r(ro)
                 CROSS APPLY ro.nodes('p:RunTimeInformation/p:RunTimeCountersPerThread') AS c(ctr);
 
@@ -5474,16 +5507,17 @@ BEGIN
                     SELECT t.NodeId, t.ThreadId, t.Mode,
                            OwnCPUms  = CASE WHEN t.Mode = 'Row' THEN t.CPUms  - ISNULL(c.ChildCPUms, 0)  ELSE t.CPUms  END,
                            OwnElapms = CASE WHEN t.Mode = 'Row' THEN t.Elapms - ISNULL(c.ChildElapms, 0) ELSE t.Elapms END,
-                           t.Rows_, t.Scans
+                           t.Rows_, t.Scans, t.Execs
                     FROM @plan_op_thread t
                     LEFT JOIN child_sum c ON c.ParentNodeId = t.NodeId AND c.ThreadId = t.ThreadId
                 )
-                INSERT INTO @plan_op_recalc (NodeId, SumCPUms, MaxElapms, SumRows, MaxScans)
+                INSERT INTO @plan_op_recalc (NodeId, SumCPUms, MaxElapms, SumRows, MaxScans, SumExecs)
                 SELECT NodeId,
                        SUM(CASE WHEN OwnCPUms  < 0 THEN 0 ELSE OwnCPUms  END),
                        MAX(CASE WHEN OwnElapms < 0 THEN 0 ELSE OwnElapms END),
                        SUM(Rows_),
-                       MAX(Scans)
+                       MAX(Scans),
+                       SUM(Execs)
                 FROM per_thread
                 GROUP BY NodeId;
 
@@ -5492,23 +5526,23 @@ BEGIN
                    their threads 1..N (no Thread=0 to write into). */
                 WHILE EXISTS (SELECT 1 FROM @plan_op_recalc)
                 BEGIN
-                    SELECT TOP (1) @nid = NodeId, @cpu = SumCPUms, @elap = MaxElapms, @rows = SumRows, @scans = MaxScans
+                    SELECT TOP (1) @nid = NodeId, @cpu = SumCPUms, @elap = MaxElapms, @rows = SumRows, @scans = MaxScans, @execs = SumExecs
                     FROM @plan_op_recalc;
 
                     BEGIN TRY SET @cur_plan.modify(N'
                         declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
                         delete //p:RelOp[@NodeId=sql:variable("@nid")]/p:RunTimeInformation/p:RunTimeCountersPerThread
-                    '); END TRY BEGIN CATCH END CATCH;
+                    '); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
                     BEGIN TRY SET @cur_plan.modify(N'
                         declare namespace p="http://schemas.microsoft.com/sqlserver/2004/07/showplan";
                         insert <p:RunTimeCountersPerThread Thread="0"
                                     ActualRows="{sql:variable("@rows")}"
                                     ActualEndOfScans="{sql:variable("@scans")}"
-                                    ActualExecutions="1"
+                                    ActualExecutions="{sql:variable("@execs")}"
                                     ActualCPUms="{sql:variable("@cpu")}"
                                     ActualElapsedms="{sql:variable("@elap")}" />
                         into (//p:RelOp[@NodeId=sql:variable("@nid")]/p:RunTimeInformation)[1]
-                    '); END TRY BEGIN CATCH END CATCH;
+                    '); END TRY BEGIN CATCH SET @cur_modify_errors += 1; END CATCH;
 
                     DELETE @plan_op_recalc WHERE NodeId = @nid;
                 END;
@@ -5523,11 +5557,16 @@ BEGIN
             SET @cur_plan_text = REPLACE(@cur_plan_text, N'>  ', N'>');
             SET @cur_plan_text = REPLACE(@cur_plan_text, N'> <', N'><');
 
+            /* NULL-safe matching: parent procedure/batch rows carry a NULL QueryHash,
+               and a plain equality match would silently discard their minimized text. */
             UPDATE ##BlitzCacheProcs
                SET ai_query_plan = @cur_plan_text
              WHERE SPID = @@SPID
-               AND SqlHandle = @cur_sql
-               AND QueryHash = @cur_hash;
+               AND ((@cur_sql  IS NOT NULL AND SqlHandle = @cur_sql)  OR (@cur_sql  IS NULL AND SqlHandle IS NULL))
+               AND ((@cur_hash IS NOT NULL AND QueryHash = @cur_hash) OR (@cur_hash IS NULL AND QueryHash IS NULL));
+
+            IF @Debug >= 1 AND @cur_modify_errors > 0
+                RAISERROR(N'Plan minimizer: %d transformation step(s) failed on one plan; partial minimization kept.', 0, 1, @cur_modify_errors) WITH NOWAIT;
         END TRY
         BEGIN CATCH
             /* Catastrophic failure on this plan (e.g., processing-instruction stub

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5360,6 +5360,7 @@ BEGIN
 
     DECLARE @cur_sql VARBINARY(64),
             @cur_hash BINARY(8),
+            @cur_plan_handle VARBINARY(64),
             @cur_plan XML,
             @cur_plan_text NVARCHAR(MAX),
             @cur_has_actuals BIT,
@@ -5368,14 +5369,18 @@ BEGIN
             @cur_modify_errors INT,
             @nid INT, @cpu BIGINT, @elap BIGINT, @rows BIGINT, @scans BIGINT, @execs BIGINT;
 
+    /* PlanHandle is part of the key because (SqlHandle, QueryHash) is not unique
+       when the same query hash has multiple distinct plans - without it, the
+       UPDATE below would stamp the last-fetched plan's minimized text onto every
+       row sharing the pair. Mirrors the AI-call cursor's matching. */
     DECLARE ai_plan_min_cursor CURSOR LOCAL FAST_FORWARD FOR
-        SELECT SqlHandle, QueryHash, QueryPlan
+        SELECT SqlHandle, QueryHash, PlanHandle, QueryPlan
         FROM ##BlitzCacheProcs
         WHERE SPID = @@SPID
           AND QueryPlan IS NOT NULL;
 
     OPEN ai_plan_min_cursor;
-    FETCH NEXT FROM ai_plan_min_cursor INTO @cur_sql, @cur_hash, @cur_plan;
+    FETCH NEXT FROM ai_plan_min_cursor INTO @cur_sql, @cur_hash, @cur_plan_handle, @cur_plan;
 
     WHILE @@FETCH_STATUS = 0
     BEGIN
@@ -5563,7 +5568,8 @@ BEGIN
                SET ai_query_plan = @cur_plan_text
              WHERE SPID = @@SPID
                AND ((@cur_sql  IS NOT NULL AND SqlHandle = @cur_sql)  OR (@cur_sql  IS NULL AND SqlHandle IS NULL))
-               AND ((@cur_hash IS NOT NULL AND QueryHash = @cur_hash) OR (@cur_hash IS NULL AND QueryHash IS NULL));
+               AND ((@cur_hash IS NOT NULL AND QueryHash = @cur_hash) OR (@cur_hash IS NULL AND QueryHash IS NULL))
+               AND ((@cur_plan_handle IS NOT NULL AND PlanHandle = @cur_plan_handle) OR (@cur_plan_handle IS NULL AND PlanHandle IS NULL));
 
             IF @Debug >= 1 AND @cur_modify_errors > 0
                 RAISERROR(N'Plan minimizer: %d transformation step(s) failed on one plan; partial minimization kept.', 0, 1, @cur_modify_errors) WITH NOWAIT;
@@ -5576,7 +5582,7 @@ BEGIN
                 RAISERROR(N'Plan minimization failed for one row; falling back to raw plan.', 0, 1) WITH NOWAIT;
         END CATCH;
 
-        FETCH NEXT FROM ai_plan_min_cursor INTO @cur_sql, @cur_hash, @cur_plan;
+        FETCH NEXT FROM ai_plan_min_cursor INTO @cur_sql, @cur_hash, @cur_plan_handle, @cur_plan;
     END;
     CLOSE ai_plan_min_cursor;
     DEALLOCATE ai_plan_min_cursor;


### PR DESCRIPTION
## Summary
- Implements [issue #3862](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/issues/3862): minimize the query plan XML before adding it to the `@AI` prompt so we burn fewer tokens and distract the LLM less.
- Strips cost-percentage attributes (the issue's main ask: `EstimatedTotalSubtreeCost`, `EstimateCPU`, `EstimateIO`, `AvgRowSize`, etc.), drops compile/hardware chatter and verbose elements (`OptimizerHardwareDependentProperties`, `OptimizerStatsUsage`, `TraceFlags`, `WaitStats`), and for plans with actuals also strips estimates that have actual equivalents.
- Recomputes row-mode operator timings to match batch-mode semantics (per-operator net, not cumulative) per [Forrest McDaniel's post](https://forrestmcdaniel.com/2026/03/23/its-here-ai-query-tuning/), then collapses per-thread blocks down to a single `Thread="0"` summary per operator.
- Minimized text lives in a new `ai_query_plan` column on `##BlitzCacheProcs`; the existing `QueryPlan` XML column is left untouched so the result set, `@Reanalyze`, and other consumers keep working. Includes a `COL_LENGTH` / `ALTER TABLE` schema-drift guard for `@Reanalyze` runs against a stale temp table.
- Adds a one-line "Plan summary" header (parallel/serial, missing index count) and a label telling the LLM the plan was minimized, both inside the existing prompt build. `@Debug = 2` now reports per-row `OriginalBytes` / `MinimizedBytes` / `PercentSaved`.
- Estimate-aware behavior: when a plan has no `<RunTimeInformation>`, estimated attributes that lack actual equivalents are preserved (otherwise the LLM has nothing to reason about).

## Test plan
End-to-end verified on both targets:

- [x] **SQL Server 2025 lab box** — `sp_BlitzCache @AI = 2, @Debug = 2`: 3 estimated-only plans minimized, 12-13% reduction each (61 KB → 53 KB, 37 KB → 33 KB, 31 KB → 27 KB).
- [x] **Azure SQL DB (StackOverflow2010)** — `sp_BlitzCache @AI = 2, @Debug = 2`: 3 plans with actuals minimized, 21-25% reduction each (613 KB → 469 KB, 50 KB → 40 KB, 28 KB → 21 KB). The 613 KB plan processed without falling back through `TRY/CATCH`.
- [x] `RAISERROR(N'Minimizing query plan XML for AI prompt')` fires on both servers; "Plan minimization savings" projection shows up under `@Debug = 2`.
- [x] `@cur_has_actuals` probe correctly detects `<RunTimeInformation>` on Azure plans, correctly returns false on the lab box's cached estimated plans.
- [x] Round-trip sanity: minimized output parses back as valid XML; all `<RunTimeCountersPerThread>` blocks in the inspected Azure plan are `Thread="0"` summary entries; zero `EstimatedTotalSubtreeCost` attributes remaining; `<MissingIndexes>` and `<Warnings>` preserved.
- [x] Regression: `EXEC sp_BlitzCache @Top = 10;` with default args (no `@AI`) — `ai_query_plan` stays NULL, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)