### PR TITLE
sp_BlitzCache: fix FOR XML error (0x0000) with @AI = 2

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5384,6 +5384,15 @@ Thank you.'
     AND QueryPlan IS NULL
     OPTION (RECOMPILE);
 
+    /* Captured query text can contain a NUL (0x0000), which is illegal in XML and breaks
+       the FOR XML serialization that renders the AI columns (Msg 6841), and is also invalid
+       in the JSON payload we POST to AI providers. Strip it here, after the prompt is built. */
+    UPDATE ##BlitzCacheProcs
+    SET ai_prompt = REPLACE(ai_prompt, NCHAR(0), N'')
+    WHERE SPID = @@SPID
+    AND ai_prompt IS NOT NULL
+    OPTION (RECOMPILE);
+
     IF @Debug = 2
         SELECT 'After setting up ai_prompt, before calling AI' AS ai_stage, SqlHandle, QueryHash, PlanHandle, QueryPlan, ai_prompt, ai_advice, ai_raw_response
             FROM ##BlitzCacheProcs
@@ -5557,9 +5566,10 @@ Thank you.'
                     SET @AIAdviceText = N'No response received from AI service.';
                 END;
 
-                /* Store the response in the ai_advice column */
+                /* Store the response in the ai_advice column. Strip any NUL (0x0000) the API may
+                   return - it's illegal in XML and would break the FOR XML rendering of these columns. */
                 UPDATE ##BlitzCacheProcs
-                SET ai_advice = @AIAdviceText, ai_raw_response = @AIResponseJSON, ai_payload = @AIPayload
+                SET ai_advice = REPLACE(@AIAdviceText, NCHAR(0), N''), ai_raw_response = REPLACE(@AIResponseJSON, NCHAR(0), N''), ai_payload = @AIPayload
                 WHERE SPID = @@SPID
                 AND ((@CurrentSqlHandle IS NOT NULL AND SqlHandle = @CurrentSqlHandle)
                      OR (@CurrentSqlHandle IS NULL AND SqlHandle IS NULL))
@@ -5580,7 +5590,7 @@ Thank you.'
 
                 -- Store the error message in ai_advice so the user knows what happened
                 UPDATE ##BlitzCacheProcs
-                SET ai_advice = @AIErrorMessage, ai_raw_response = @AIResponseJSON, ai_payload = @AIPayload
+                SET ai_advice = @AIErrorMessage, ai_raw_response = REPLACE(@AIResponseJSON, NCHAR(0), N''), ai_payload = @AIPayload
                 WHERE SPID = @@SPID
                 AND ((@CurrentSqlHandle IS NOT NULL AND SqlHandle = @CurrentSqlHandle)
                      OR (@CurrentSqlHandle IS NULL AND SqlHandle IS NULL))

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -5386,9 +5386,11 @@ Thank you.'
 
     /* Captured query text can contain a NUL (0x0000), which is illegal in XML and breaks
        the FOR XML serialization that renders the AI columns (Msg 6841), and is also invalid
-       in the JSON payload we POST to AI providers. Strip it here, after the prompt is built. */
+       in the JSON payload we POST to AI providers. Strip it here, after the prompt is built.
+       The COLLATE is required: under the default (non-binary) collations NCHAR(0) has no
+       sort weight, so a plain REPLACE never matches it and leaves the NUL in place. */
     UPDATE ##BlitzCacheProcs
-    SET ai_prompt = REPLACE(ai_prompt, NCHAR(0), N'')
+    SET ai_prompt = REPLACE(ai_prompt COLLATE Latin1_General_BIN2, NCHAR(0), N'')
     WHERE SPID = @@SPID
     AND ai_prompt IS NOT NULL
     OPTION (RECOMPILE);
@@ -5569,7 +5571,7 @@ Thank you.'
                 /* Store the response in the ai_advice column. Strip any NUL (0x0000) the API may
                    return - it's illegal in XML and would break the FOR XML rendering of these columns. */
                 UPDATE ##BlitzCacheProcs
-                SET ai_advice = REPLACE(@AIAdviceText, NCHAR(0), N''), ai_raw_response = REPLACE(@AIResponseJSON, NCHAR(0), N''), ai_payload = @AIPayload
+                SET ai_advice = REPLACE(@AIAdviceText COLLATE Latin1_General_BIN2, NCHAR(0), N''), ai_raw_response = REPLACE(@AIResponseJSON COLLATE Latin1_General_BIN2, NCHAR(0), N''), ai_payload = @AIPayload
                 WHERE SPID = @@SPID
                 AND ((@CurrentSqlHandle IS NOT NULL AND SqlHandle = @CurrentSqlHandle)
                      OR (@CurrentSqlHandle IS NULL AND SqlHandle IS NULL))
@@ -5590,7 +5592,7 @@ Thank you.'
 
                 -- Store the error message in ai_advice so the user knows what happened
                 UPDATE ##BlitzCacheProcs
-                SET ai_advice = @AIErrorMessage, ai_raw_response = REPLACE(@AIResponseJSON, NCHAR(0), N''), ai_payload = @AIPayload
+                SET ai_advice = @AIErrorMessage, ai_raw_response = REPLACE(@AIResponseJSON COLLATE Latin1_General_BIN2, NCHAR(0), N''), ai_payload = @AIPayload
                 WHERE SPID = @@SPID
                 AND ((@CurrentSqlHandle IS NOT NULL AND SqlHandle = @CurrentSqlHandle)
                      OR (@CurrentSqlHandle IS NULL AND SqlHandle IS NULL))


### PR DESCRIPTION
## Summary

Fixes #4005. Running `sp_BlitzCache @AI = 2` could abort the whole result set with:

> Msg 6841 — FOR XML could not serialize the data for the text() node because it contains a character that is invalid in XML (0x0000).

### Cause

The `@AI` columns are rendered with `FOR XML PATH('ai_prompt')` so SSMS shows them as a clickable cell. The `ai_prompt` value embeds the captured query text (`LEFT(QueryText, 4000)`) and the plan (`CAST(QueryPlan AS NVARCHAR(MAX))`). Some real-world query text contains a NUL byte (`0x0000`), which is illegal in XML, so `FOR XML` throws and the run produces no result tables. Normal runs are unaffected because they return `QueryText`/`QueryPlan` as plain `NVARCHAR`/`XML` without `FOR XML` text serialization. The same NUL is also invalid in the JSON payload POSTed to AI providers when `@AI = 1`.

### Fix

Strip `NCHAR(0)` at the source:
- from `ai_prompt` right after it is built — this covers both the `@AI = 2` display and the `@AI = 1` API payload (the payload is derived from `ai_prompt`).
- from `ai_advice` / `ai_raw_response` where API responses are stored, so the same FOR XML error can't resurface from a provider response.

Only `sp_BlitzCache.sql` is edited; the `Install-*` bundles are regenerated by maintainers per CONTRIBUTING.md.

## Test plan

- [ ] Reproduce a NUL in cached query text, run `sp_BlitzCache @SortOrder = 'CPU', @AI = 2`, confirm result tables now return without Msg 6841.
- [ ] Confirm the `[AI Prompt]` column renders as clickable XML with the NUL removed.
- [ ] Regression: `sp_BlitzCache` with no `@AI` parameter still behaves as before.

https://claude.ai/code/session_01K6hhyvNZ7aR1Z9QWVPQwqc

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6hhyvNZ7aR1Z9QWVPQwqc)_