### PR TITLE
Added Emergency Mode to sp_blitzfirst, like what we have for sp_kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Common sp_BlitzFirst parameters include:
 * @Seconds = 5 by default. You can specify longer samples if you want to track stats during a load test or demo, for example.
 * @ShowSleepingSPIDs = 0 by default. When set to 1, shows long-running sleeping queries that might be blocking others.
 * @ExpertMode = 0 by default. When set to 1, it calls sp_BlitzWho when it starts (to show you what queries are running right now), plus outputs additional result sets for wait stats, Perfmon counters, and file stats during the sample, then finishes with one final execution of sp_BlitzWho to show you what was running at the end of the sample. When set to 2, it does the same as 1, but skips the calls to sp_BlitzWho.
+* @EmergencyMode = 1 by default. When set to 0, it runs potentially slow checks that are skipped otherwise.
 
 ### Logging sp_BlitzFirst to Tables
 

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -24,6 +24,7 @@ ALTER PROCEDURE [dbo].[sp_BlitzFirst]
     @OutputXMLasNVARCHAR TINYINT = 0 ,
     @FilterPlansByDatabase VARCHAR(MAX) = NULL ,
     @CheckProcedureCache TINYINT = 0 ,
+    @EmergencyMode TINYINT = 1 ,
     @CheckServerInfo TINYINT = 1 ,
     @FileLatencyThresholdMS INT = 100 ,
     @SinceStartup TINYINT = 0 ,
@@ -2525,8 +2526,15 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 		RAISERROR('Running CheckID 44',10,1) WITH NOWAIT;
 	END
 
+    /* This has a history of surprising bad performance,
+       see GitHub issues 2439, 2548, and 4011.
+       Waiting a long time for this during an emergency is not a worthwhile risk,
+       so we run this only if Emergency Mode is turned off and we are not in a state
+       where we know that this will be very slow.
+       Having over 20 databases is one such known slow state. */
 	IF 20 >= (SELECT COUNT(*) FROM sys.databases WHERE name NOT IN ('master', 'model', 'msdb', 'tempdb'))
 		AND @Seconds > 0
+        AND @EmergencyMode = 0 
 	BEGIN
 		CREATE TABLE #UpdatedStats (HowToStopIt NVARCHAR(4000), RowsForSorting BIGINT);
 		IF EXISTS(SELECT * FROM sys.all_objects WHERE name = 'dm_db_stats_properties')


### PR DESCRIPTION
Added Emergency Mode to `sp_blitzfirst`, like what we have for `sp_kill` but on by default rather than off.

Currently only has two states: either equal to 1 (the default) and therefore on, or not and therefore off. All that turning this on does is skip the statistics check, check ID 44.

Closes #4011.

## Screenshot
<img width="1869" height="719" alt="image" src="https://github.com/user-attachments/assets/0a794745-f293-4e65-bffe-c9a8f6735cb5" />

## Test script

```sql
DROP TABLE IF EXISTS Whatever;
SELECT * INTO Whatever FROM sys.messages;
CREATE STATISTICS Whatever ON Whatever(severity);
UPDATE STATISTICS Whatever;

SELECT 'Emergency Mode off, statistics check fires.';
EXEC sp_BlitzFirst @EmergencyMode = 0;
SELECT 'Emergency Mode on, statistics check does not fire.';
EXEC sp_BlitzFirst @EmergencyMode = 1;
SELECT 'Emergency Mode set to nonsense, statistics check does not fire.';
EXEC sp_BlitzFirst @EmergencyMode = 6;
SELECT 'Emergency Mode set to NULL, statistics check does not fire.';
EXEC sp_BlitzFirst @EmergencyMode = NULL;
SELECT 'Emergency Mode not mentioned, statistics check does not fire.';
EXEC sp_BlitzFirst;
```