### PR TITLE
sp_BlitzLock: add @SkipExecutionPlans to skip plans and return only findings (#4013)

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -32,7 +32,8 @@ ALTER PROCEDURE
     @OutputDatabaseName sysname = NULL,
     @OutputSchemaName sysname = N'dbo',      /*ditto as below*/
     @OutputTableName sysname = N'BlitzLock', /*put a standard here no need to check later in the script*/
-    @ExportToExcel bit = 0
+    @ExportToExcel bit = 0,
+    @SkipExecutionPlans bit = 0 /*skip the execution plans result set and return only the findings rollup*/
 )
 WITH RECOMPILE
 AS
@@ -103,7 +104,10 @@ BEGIN
        
         @TargetTimestampColumnName: The name of the datetime column for filtering by date range (optional)
 
-   
+        /*Output options*/
+        @SkipExecutionPlans: Set to 1 to skip the execution plans result set and return only the findings rollup
+
+
     To learn more, visit http://FirstResponderKit.org where you can download new
     versions for free, watch training videos on how it works, get more info on
     the findings, contribute your own code, and more.
@@ -4383,9 +4387,18 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
            
                 RAISERROR('Finished at %s', 0, 1, @d) WITH NOWAIT;
 
+                /*
+                When @SkipExecutionPlans = 1, skip gathering and returning the
+                execution plans result set and jump straight to the findings rollup.
+                */
+                IF @SkipExecutionPlans = 1
+                BEGIN
+                    GOTO ReturnDeadlockFindings;
+                END;
+
                 SET @d = CONVERT(varchar(40), GETDATE(), 109);
                 RAISERROR('Getting available execution plans for deadlocks %s', 0, 1, @d) WITH NOWAIT;
-             
+
                 SELECT DISTINCT
                     available_plans =
                         'available_plans',
@@ -4576,10 +4589,12 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
                 OPTION(RECOMPILE, LOOP JOIN, HASH JOIN);
 
                 RAISERROR('Finished at %s', 0, 1, @d) WITH NOWAIT;
-           
+
+                ReturnDeadlockFindings:
+
                 SET @d = CONVERT(varchar(40), GETDATE(), 109);
                 RAISERROR('Returning findings %s', 0, 1, @d) WITH NOWAIT;
-           
+
                 SELECT
                     df.check_id,
                     df.database_name,
@@ -4737,7 +4752,9 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
             OutputTableName =
                 @OutputTableName,
             ExportToExcel =
-                @ExportToExcel;
+                @ExportToExcel,
+            SkipExecutionPlans =
+                @SkipExecutionPlans;
 
         SELECT
             declared_variables =

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -33,7 +33,7 @@ ALTER PROCEDURE
     @OutputSchemaName sysname = N'dbo',      /*ditto as below*/
     @OutputTableName sysname = N'BlitzLock', /*put a standard here no need to check later in the script*/
     @ExportToExcel bit = 0,
-    @SkipExecutionPlans bit = 0 /*skip the execution plans result set and return only the findings rollup*/
+    @SkipExecutionPlans bit = 0 /*skip the execution plans result set (still returns deadlocks + findings rollup)*/
 )
 WITH RECOMPILE
 AS


### PR DESCRIPTION
## Summary

Adds a `@SkipExecutionPlans bit = 0` parameter to `sp_BlitzLock` that lets callers bypass the execution plans result set and return only the findings rollup.

Fixes #4013.

## What changed

When `@SkipExecutionPlans = 1`, the client-output path:

- skips building `#available_plans` / `#dm_exec_query_stats`,
- skips the `sys.dm_exec_text_query_plan` calls, and
- skips the execution plans result set,

then falls through to the existing deadlock findings rollup. It uses a `GOTO ReturnDeadlockFindings` guard placed right after the deadlock results are returned to the client, with the label immediately before the findings rollup — so the only thing skipped is the plan gathering and the plan result set.

Default behavior (`@SkipExecutionPlans = 0`) is unchanged.

## Why

The execution plans result set is often the slowest part to produce and is frequently not what the user wants when triaging deadlocks — they just want the findings. This flag skips that work and result set entirely.

## Notes

- The findings rollup reads from the `#deadlock_*` temp tables, not from `#available_plans`, so skipping the plan section does not affect the rollup.
- The `@Debug` dumps for `#available_plans` and `#dm_exec_query_stats` are already guarded by `OBJECT_ID(...) IS NOT NULL`, so skipping their creation is safe under `@Debug = 1`.
- Documented in `@Help` and surfaced in the `@Debug` parameter dump.

## Testing

Installed and compiled clean on SQL Server 2022 (16.0.4255.1). Verified:

- `@SkipExecutionPlans = 1`: returns deadlock results then findings rollup, with no "Getting available execution plans" step.
- `@SkipExecutionPlans = 0` (default): still runs the execution plans gathering and result set as before.
