### PR TITLE
sp_BlitzLock: replace deprecated sp_BlitzQueryStore call with sp_QuickieStore

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -2806,7 +2806,7 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
 
         RAISERROR('Finished at %s', 0, 1, @d) WITH NOWAIT;
 
-        /*Check 8 gives you more info queries for sp_BlitzCache & BlitzQueryStore*/
+        /*Check 8 gives you more info queries for sp_BlitzCache & sp_QuickieStore*/
         SET @d = CONVERT(varchar(40), GETDATE(), 109);
         RAISERROR('Check 8 more info part 1 BlitzCache %s', 0, 1, @d) WITH NOWAIT;
 
@@ -2891,7 +2891,7 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
         IF (@ProductVersionMajor >= 13 OR @Azure = 1)
         BEGIN
             SET @d = CONVERT(varchar(40), GETDATE(), 109);
-            RAISERROR('Check 8 more info part 2 BlitzQueryStore %s', 0, 1, @d) WITH NOWAIT;
+            RAISERROR('Check 8 more info part 2 sp_QuickieStore %s', 0, 1, @d) WITH NOWAIT;
 
             WITH
                 deadlock_stack AS
@@ -2923,12 +2923,16 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
                 dow.database_name,
                 object_name = ds.proc_name,
                 finding_group = N'More Info - Query',
+                /* sp_QuickieStore is Erik Darling's Query Store explorer; install it
+                   from https://erikdarling.com/sp_quickiestore/ if you don't already
+                   have it. sp_BlitzQueryStore (the prior FRK tool that lived here) is
+                   deprecated. */
                 finding =
-                    N'EXECUTE sp_BlitzQueryStore ' +
-                    N'@DatabaseName = ' +
+                    N'EXECUTE sp_QuickieStore ' +
+                    N'@database_name = ' +
                     QUOTENAME(ds.database_name, N'''') +
                     N', ' +
-                    N'@StoredProcName = ' +
+                    N'@procedure_name = ' +
                     QUOTENAME(ds.proc_only_name, N'''') +
                     N';'
             FROM deadlock_stack AS ds

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -2926,11 +2926,19 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
                 /* sp_QuickieStore is Erik Darling's Query Store explorer; install it
                    from https://erikdarling.com/sp_quickiestore/ if you don't already
                    have it. sp_BlitzQueryStore (the prior FRK tool that lived here) is
-                   deprecated. */
+                   deprecated.
+
+                   Pull @database_name from dow.database_name (derived from
+                   dow.database_id at deadlock time) rather than ds.database_name
+                   (PARSENAME(ds.proc_name, 3)). PARSENAME returns NULL for any
+                   proc_name that isn't 3-part, and QUOTENAME(NULL, '''') would
+                   NULL out the whole finding via string concat. dow.database_name
+                   is already used 4 lines up for the output column, so this stays
+                   consistent. */
                 finding =
                     N'EXECUTE sp_QuickieStore ' +
                     N'@database_name = ' +
-                    QUOTENAME(ds.database_name, N'''') +
+                    QUOTENAME(dow.database_name, N'''') +
                     N', ' +
                     N'@procedure_name = ' +
                     QUOTENAME(ds.proc_only_name, N'''') +


### PR DESCRIPTION
Fixes #4010.

## Summary

Check 8 in sp_BlitzLock emits a "More Info - Query" finding for every stored procedure that appears in a deadlock stack. That finding used to be an `EXECUTE sp_BlitzQueryStore` call — a proc that's been deprecated. Replaced with [Erik Darling's sp_QuickieStore](https://erikdarling.com/sp_quickiestore/), which serves the same purpose (Query Store explorer keyed by database + procedure name) per the discussion on the issue.

## Mapping

| sp_BlitzQueryStore | sp_QuickieStore |
|---|---|
| `@DatabaseName` | `@database_name` |
| `@StoredProcName` | `@procedure_name` |

Confirmed param names from the canonical source at https://github.com/erikdarlingdata/DarlingData/blob/main/sp_QuickieStore/sp_QuickieStore.sql.

## Other touch-ups in the same block

- Section comment at the top of Check 8 now reads `sp_QuickieStore` instead of `BlitzQueryStore`.
- Debug `RAISERROR` message ("Check 8 more info part 2 …") matches.
- Inline comment above the `finding =` block explains that sp_QuickieStore is an external Erik Darling tool the user installs separately, and notes that sp_BlitzQueryStore (its predecessor) is deprecated — so a future maintainer doesn't wonder where the old call went.

## What stays the same

- The `IF (@ProductVersionMajor >= 13 OR @Azure = 1)` guard. sp_QuickieStore also requires Query Store (SQL 2016+), so the same gate applies.

## Test plan

- [ ] On a 2016+ instance with at least one stored-proc deadlock in the event-file source, run sp_BlitzLock and confirm Check 8 emits `EXECUTE sp_QuickieStore @database_name = '…', @procedure_name = '…';` for each proc in the stack.
- [ ] Confirm Check 8 still skips silently on pre-2016 / non-Azure instances (the version guard is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)