### PR TITLE
sp_Blitz: stop flagging version high/low part of SQL Server configs (#4022)

### DIFF
--- a/Install-All-Scripts.sql
+++ b/Install-All-Scripts.sql
@@ -2388,8 +2388,6 @@ BEGIN
 					( 'tempdb metadata memory-optimized', 0, 269),
 					( 'ADR cleaner retry timeout (min)', 15, 269),
 					( 'ADR Preallocation Factor', 4, 269),
-					( 'version high part of SQL Server', 1114112, 269),
-					( 'version low part of SQL Server', 52428803, 269),
 					( 'Data processed daily limit in TB', 2147483647, 269),
 					( 'Data processed weekly limit in TB', 2147483647, 269),
 					( 'Data processed monthly limit in TB', 2147483647, 269),


### PR DESCRIPTION
## Fixes #4022

### Problem
`sp_Blitz` reported `version high part of SQL Server` and `version low part of SQL Server` under **Non-Default Server Config** (CheckID 22). These two `sp_configure` options have no meaningful "correct" value — they encode the build number — so sp_Blitz should never alert on them no matter what they're set to.

They were originally added to the `#ConfigurationDefaults` list in #3657 with hard-coded "defaults" of `1114112` / `52428803`. On any server where the actual values differ from those magic numbers (e.g. the reporter set them to `0`, which Microsoft documents as the default), CheckID 22's `WHERE cdUsed.name IS NULL` predicate fired and flagged them.

### Fix
Remove both entries from `#ConfigurationDefaults`. Because CheckID 22 uses an `INNER JOIN #ConfigurationDefaults cd ON cd.name = cr.name`, a config that isn't in the list can never be reported — exactly the desired behavior.

This was already done for `sp_Blitz.sql` in #3906, but the matching lines in `Install-All-Scripts.sql` regressed (re-introduced by a later regeneration), leaving the two files out of sync. This PR resyncs `Install-All-Scripts.sql`.

### Testing
Verified on a live instance (`sys.configurations` reports both options with `value`/`value_in_use` = `0`, `configuration_id` 1593/1594). With these entries absent from `#ConfigurationDefaults`, neither option appears in the Non-Default Server Config findings regardless of its value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)