### PR TITLE
Trigger sp_kill smoke test

### DIFF
--- a/sp_kill.sql
+++ b/sp_kill.sql
@@ -32,7 +32,7 @@ BEGIN
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 	/*
-	sp_kill from http://FirstResponderKit.org
+	sp_kill  from http://FirstResponderKit.org
 
 	This script helps you kill queries during a performance emergency.
 


### PR DESCRIPTION
## Summary

Adds a harmless whitespace-only tweak in `sp_kill.sql` so the new SQL Server smoke-test workflow has a root-level `sp_*.sql` change to test.

## Expected result

The newly merged workflow should pick up `sp_kill.sql`, install it individually, and report the current standalone compile issue near `tempdb`.

## Validation

This PR is intentionally meant to validate the GitHub Actions workflow behavior rather than change product behavior.