### PR TITLE
Fix Codex review findings from PR 4028

### DIFF
--- a/OptionalScripts/sp_BlitzPlanCompare.sql
+++ b/OptionalScripts/sp_BlitzPlanCompare.sql
@@ -332,6 +332,10 @@ IF @StoredProcName IS NOT NULL
 BEGIN
     /* RAISERROR can't take function calls as args; capture DB_NAME() into a variable. */
     DECLARE @CurrentDbName SYSNAME = DB_NAME();
+    DECLARE @StoredProcDatabaseName SYSNAME = PARSENAME(@StoredProcName, 3);
+
+    IF @DatabaseName IS NULL AND @StoredProcDatabaseName IS NOT NULL
+        SET @DatabaseName = @StoredProcDatabaseName;
 
     /* Azure SQL DB can't do cross-DB OBJECT_ID lookups. Reject mismatches early. */
     IF @EngineEdition IN (5, 8)
@@ -1553,14 +1557,16 @@ BEGIN
        a period, space, or other special character still produce a valid identifier
        and the dynamic SQL can't be tampered with via a maliciously-named linked server. */
     DECLARE @LinkedServerSafe SYSNAME = REPLACE(REPLACE(@LinkedServer, N'[', N''), N']', N'');
-    SET @sql = N'EXEC ' + QUOTENAME(@LinkedServerSafe) + N'.master.dbo.sp_BlitzPlanCompare @QueryPlanHash = @hash;';
+    SET @sql = N'EXEC ' + QUOTENAME(@LinkedServerSafe) + N'.master.dbo.sp_BlitzPlanCompare @QueryPlanHash = @hash'
+             + CASE WHEN @DatabaseName IS NOT NULL THEN N', @DatabaseName = @dbname' ELSE N'' END
+             + N';';
 
     IF @Debug = 1
         RAISERROR('Linked-server invocation: %s (passing local QueryHash so remote can resolve its own plan with a matching query_hash)', 0, 1, @sql) WITH NOWAIT;
 
     BEGIN TRY
         INSERT INTO #RemoteEmit ([CallStack])
-        EXEC sp_executesql @sql, N'@hash BINARY(8)', @hash = @QueryHashBin;
+        EXEC sp_executesql @sql, N'@hash BINARY(8), @dbname SYSNAME', @hash = @QueryHashBin, @dbname = @DatabaseName;
 
         /* The remote returned a single string of the form:
                EXEC dbo.sp_BlitzPlanCompare @CompareToXML = N'<BlitzPlanCompareSnapshot ...>';

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -716,7 +716,7 @@ SELECT @StringToExecute = N' CASE WHEN YEAR(s.last_request_start_time) = 1900 TH
 						    +
 						    N'SUBSTRING(wt2.session_wait_info, 0, LEN(wt2.session_wait_info) ) AS top_session_waits ,'
 						    +																	
-						    N'COALESCE(r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,
+						    N'COALESCE(s.open_transaction_count, r.open_transaction_count, blocked.open_tran) AS open_transaction_count ,
 						    CASE WHEN EXISTS (  SELECT 1 
                FROM sys.dm_tran_active_transactions AS tat
                JOIN sys.dm_tran_session_transactions AS tst

--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -907,11 +907,13 @@ SELECT @StringToExecute = N' CASE WHEN YEAR(s.last_request_start_time) = 1900 TH
 
 		) AS qs_live
 
-	    WHERE s.session_id <> @@SPID 
+		WHERE s.session_id <> @@SPID 
 	    AND s.host_name IS NOT NULL
 		AND (r.database_id IS NULL OR r.database_id NOT IN (SELECT database_id FROM #WhoReadableDBs))
 	    '
-	    + CASE WHEN @ShowSleepingSPIDs = 0 THEN
+	    + CASE WHEN @ShowSleepingSPIDs = 0 AND @OnlyProblems = 1 THEN
+			    N' AND (COALESCE(DB_NAME(r.database_id), DB_NAME(blocked.dbid)) IS NOT NULL OR COALESCE(s.open_transaction_count, r.open_transaction_count, blocked.open_tran) >= 1)'
+			    WHEN @ShowSleepingSPIDs = 0 THEN
 			    N' AND COALESCE(DB_NAME(r.database_id), DB_NAME(blocked.dbid)) IS NOT NULL'
 			    WHEN @ShowSleepingSPIDs = 1 THEN
 			    N' AND (COALESCE(DB_NAME(r.database_id), DB_NAME(blocked.dbid)) IS NOT NULL OR COALESCE(r.open_transaction_count, blocked.open_tran) >= 1)'

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -754,7 +754,6 @@ BEGIN
 			WHERE BackupFile LIKE N'%[_][0-9][0-9].' + @FileExtensionBak
 			AND	BackupFile LIKE N'%' + @Database + N'%'
 			AND	(REPLACE( RIGHT( REPLACE( BackupFile, RIGHT( BackupFile, CASE WHEN PATINDEX( '%[_]%', REVERSE( BackupFile ) ) <= 7 THEN PATINDEX( '%[_]%', REVERSE( BackupFile ) ) ELSE CHARINDEX( '.', REVERSE( BackupFile ) ) END ), '' ), 18 ), '_', '' ) > @StopAt);
-			AND	(REPLACE( RIGHT( REPLACE( BackupFile, RIGHT( BackupFile, PATINDEX( '%_[0-9][0-9]%', REVERSE( BackupFile ) ) ), '' ), 18 ), '_', '' ) > @StopAt);
 
 			DELETE
 			FROM @FileList


### PR DESCRIPTION
## Summary

Fixes #4029.

Addresses the actionable Codex review findings from PR #4028:

- removes the duplicate terminated predicate in `sp_DatabaseRestore.sql` that left a standalone `AND`
- keeps sleeping sessions with open transactions visible when `sp_BlitzWho @OnlyProblems = 1` and `@ShowSleepingSPIDs = 0`
- preserves database scope when `sp_BlitzPlanCompare @StoredProcName` is supplied as a three-part name
- passes `@DatabaseName` through linked-server mode in `sp_BlitzPlanCompare`

The review items about regenerated install scripts and positional parameter shifts were left alone per Brent's replies on PR #4028.

## Testing

Against a disposable SQL Server 2022 Developer Edition container on Docker:

- `sqlcmd -d master -i sp_DatabaseRestore.sql`
- `sqlcmd -d master -i sp_BlitzWho.sql`
- `sqlcmd -d master -i OptionalScripts/sp_BlitzPlanCompare.sql`
- `EXEC dbo.sp_DatabaseRestore @VersionCheckMode = 1;`
- `EXEC dbo.sp_BlitzWho @VersionCheckMode = 1;`
- `EXEC dbo.sp_BlitzPlanCompare @VersionCheckMode = 1;`

`sp_DatabaseRestore` emitted the expected missing Ola Hallengren `dbo.CommandExecute` dependency warnings, but compiled successfully.