### PR TITLE
sp_ineachdb.sql: default to include DBs regardless of read_only

### DIFF
--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -20,7 +20,7 @@ ALTER PROCEDURE [dbo].[sp_ineachdb]
   @recovery_model_desc  nvarchar(120)  = NULL,
   @compatibility_level  tinyint        = NULL,
   @state_desc           nvarchar(120)  = N'ONLINE',
-  @is_read_only         bit = 0,
+  @is_read_only         bit = NULL,
   @is_auto_close_on     bit = NULL,
   @is_auto_shrink_on    bit = NULL,
   @is_broker_enabled    bit = NULL,


### PR DESCRIPTION
The current default of @is_read_only = 0 excludes readonly databases from sp_ineachdb output by default. This is counterintuitive and apparently undocumented. The suggested new default of NULL includes both readonly and read-write databases, allowing the user to specifically override the behavior in either direction (=0 or =1) if desired.