### PR TITLE
CI: actually run the kit in smoke tests, on oldest and newest SQL Server

### DIFF
--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 #
-# Runs every non-deprecated First Responder Kit script against a throwaway SQL
-# Server, twice: once with the base branch's copies and once with the pull
-# request's, then reports what changed.
+# Installs every non-deprecated First Responder Kit script onto a throwaway SQL
+# Server and runs it. Any SQL error fails the build.
 #
 # Before issue #4046 this script installed only the changed sp_*.sql and ran it
 # with @VersionCheckMode = 1 -- an unconditional early RETURN -- so no check body
-# ever executed and runtime breakage passed green. See PR #4045 for two bugs that
-# did exactly that.
+# ever executed and runtime breakage passed green. PR #4045 had two such bugs
+# reach human review; executing the scripts at all is what catches that class.
 #
-# Two outcomes, deliberately different (issue #4046, decision 1A):
-#   * A SQL error this branch introduces FAILS the build.
-#   * A difference in sp_Blitz's findings is PRINTED for a human and does not
-#     fail the build, because changing a finding is often the point of the PR.
-#
+# Deliberately simple. An earlier draft also installed the base branch's copies,
+# ran everything twice, and classified each failure as new or pre-existing using
+# error signatures, step-body comparison and replay-on-mismatch. That machinery
+# only earns its keep when the baseline is dirty, and the baseline is clean --
+# every step passes on both engine versions. It was ~155 lines that never once
+# took a decision, and it accounted for nearly every defect found while reviewing
+# this harness. If a dirty baseline ever makes "is this failure ours?" a real
+# question, bring it back then; git history has a working implementation.
+
 set -Eeuo pipefail
 
 : "${SQLCMDSERVER:=tcp:127.0.0.1,1433}"
@@ -28,23 +31,10 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 SEED_SQL="$SCRIPT_DIR/smoke-test-seed.sql"
 MATRIX_SQL="$SCRIPT_DIR/smoke-test-matrix.sql"
-MATRIX_REL_PATH=".github/scripts/smoke-test-matrix.sql"
-
-# Everything that shapes how a step runs. If the PR touches any of it, no
-# failure may be grandfathered: both passes use THIS branch's harness, so a
-# change that breaks it -- dropping -I, say -- breaks unchanged steps against
-# base and head alike and would otherwise be waved through as pre-existing.
-HARNESS_FILES=(
-  ".github/scripts/run-sql-server-smoke-tests.sh"
-  ".github/scripts/smoke-test-seed.sql"
-  ".github/scripts/smoke-test-matrix.sql"
-  ".github/workflows/sql-server-smoke-tests.yml"
-)
-harness_unchanged=0
 
 # Every non-deprecated script in the kit. sp_BlitzUpdate is deliberately absent:
-# it rewrites the procs mid-run, which would invalidate every later step and the
-# base-vs-head comparison (issue #4046, decision 4).
+# it overwrites the procs mid-run, invalidating every step after it
+# (issue #4046, decision 4).
 KIT_SCRIPTS=(
   "sp_Blitz.sql"
   "sp_BlitzAnalysis.sql"
@@ -60,11 +50,11 @@ KIT_SCRIPTS=(
   "OptionalScripts/sp_BlitzPlanCompare.sql"
 )
 
-# -I turns QUOTED_IDENTIFIER ON. sqlcmd defaults it OFF, and a procedure
-# captures the setting in force when it is created, so without this the
-# sp_BlitzFirst and sp_BlitzLock code paths that build indexed/XML expressions
-# die at runtime with Msg 1934. Every real client (SSMS, .NET, ODBC) has it ON,
-# so OFF was testing a configuration no user actually runs.
+# -I turns QUOTED_IDENTIFIER ON. sqlcmd defaults it OFF, and a procedure captures
+# the setting in force when it is created, so without this the sp_BlitzFirst and
+# sp_BlitzLock code paths that build indexed/XML expressions die at runtime with
+# Msg 1934. Every real client (SSMS, .NET, ODBC) has it ON, so OFF was testing a
+# configuration no user actually runs.
 SQLCMD_ARGS=(
   -S "$SQLCMDSERVER"
   -U "$SQLCMDUSER"
@@ -94,9 +84,6 @@ run_scalar() {
     | tr -d '[:space:]'
 }
 
-# ---------------------------------------------------------------------------
-# Wait for the container
-# ---------------------------------------------------------------------------
 wait_for_sql_server() {
   echo "Waiting for SQL Server to accept connections..."
   for attempt in {1..90}; do
@@ -121,26 +108,19 @@ wait_for_sql_server() {
 # sp_Blitz CheckID 152 divides by @MsSinceWaitsCleared, which is
 # DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP) * 60000.0 and is therefore 0
 # for the instance's first minute. Its zero-guard sits inside a branch that
-# cannot be taken while the value is 0, so sp_Blitz aborts with a divide-by-zero
-# -- see issue #4048, which tracks the fix.
-#
-# That is a real bug, but it is not one this comparison can measure: it depends
-# on how long the container took to start, so it fires on whichever pass happens
-# to run first and shows up as a spurious base-vs-head difference. Waiting the
-# window out keeps the two passes comparable. Remove this once #4048 is fixed.
+# cannot be taken while the value is 0, so sp_Blitz aborts with a divide-by-zero.
+# Tracked in issue #4048; remove this once that is fixed.
 #
 # The value must parse as a number greater than zero. Anything else -- an empty
-# result, a header line, an error -- means we have not confirmed the window has
-# passed, so keep waiting rather than assuming the best.
+# result, a header, an error -- means we have not confirmed the window has passed,
+# so keep waiting rather than assuming the best. `|| true` matters: under set -e a
+# failed command substitution would abort instead of retrying.
 # ---------------------------------------------------------------------------
 wait_for_wait_stats() {
   local uptime_minutes
 
   echo "Waiting for the instance to pass one minute of uptime (issue #4048)..."
   for attempt in {1..40}; do
-    # `|| true` matters: under set -e a failed command substitution aborts the
-    # script, which would contradict the contract above that an error means
-    # "not yet confirmed, keep waiting".
     uptime_minutes="$(run_scalar "SET NOCOUNT ON;
 SELECT DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP)
 FROM sys.databases WHERE name = 'tempdb';" || true)"
@@ -156,53 +136,16 @@ FROM sys.databases WHERE name = 'tempdb';" || true)"
   echo "::warning::Instance still reports under a minute of uptime; continuing anyway."
 }
 
-# ---------------------------------------------------------------------------
-# Materialise one branch's copy of the kit into a directory
-#
-# A script that does not exist at the given revision is skipped -- that is a
-# script the PR adds, which has no baseline to compare against.
-# ---------------------------------------------------------------------------
-materialise_kit() {
-  local revision="$1" dest="$2" script
-
-  mkdir -p "$dest/OptionalScripts"
-
-  for script in "${KIT_SCRIPTS[@]}"; do
-    if git -C "$REPO_ROOT" cat-file -e "$revision:$script" 2>/dev/null; then
-      git -C "$REPO_ROOT" show "$revision:$script" > "$dest/$script"
-    else
-      echo "  (not present at $revision, skipping: $script)"
-    fi
-  done
-}
-
 kit_proc_name() {
   basename "$1" .sql
 }
 
-# Each pass starts from absent kit objects.
-#
-# Otherwise the previous pass's procedures survive: a script deleted on head is
-# silently skipped by the install loop, and a script reduced to an empty file
-# still makes sqlcmd exit 0. Either way the head matrix would run the stale base
-# procedure and pass without ever touching the head artifact.
-drop_kit_objects() {
-  local script proc statements=""
-
-  for script in "${KIT_SCRIPTS[@]}"; do
-    proc="$(kit_proc_name "$script")"
-    statements+="IF OBJECT_ID('dbo.$proc', 'P') IS NOT NULL DROP PROCEDURE dbo.$proc;"
-  done
-
-  run_query "SET NOCOUNT ON; $statements" >/dev/null
-}
-
-# Installing without error is not proof the procedure exists.
+# Installing without error is not proof the procedure exists: a script reduced to
+# an empty file still exits sqlcmd 0.
 verify_kit_installed() {
-  local dir="$1" script proc missing=""
+  local script proc missing=""
 
   for script in "${KIT_SCRIPTS[@]}"; do
-    [[ -f "$dir/$script" ]] || continue
     proc="$(kit_proc_name "$script")"
     if [[ "$(run_scalar "SET NOCOUNT ON;
 SELECT CASE WHEN OBJECT_ID('dbo.$proc', 'P') IS NULL THEN 'MISSING' ELSE 'OK' END;" || true)" != "OK" ]]; then
@@ -217,131 +160,32 @@ SELECT CASE WHEN OBJECT_ID('dbo.$proc', 'P') IS NULL THEN 'MISSING' ELSE 'OK' EN
 }
 
 install_kit() {
-  local dir="$1" quiet="${2:-}" script
-
-  drop_kit_objects
+  local script
 
   for script in "${KIT_SCRIPTS[@]}"; do
-    [[ -f "$dir/$script" ]] || continue
-    [[ -n "$quiet" ]] || echo "  installing $script"
-    if ! run_file "$dir/$script" > "$WORK_DIR/install.log" 2>&1; then
+    if [[ ! -f "$REPO_ROOT/$script" ]]; then
+      echo "::error::Expected kit script is missing: $script"
+      return 1
+    fi
+
+    echo "  installing $script"
+    if ! run_file "$REPO_ROOT/$script" > "$WORK_DIR/install.log" 2>&1; then
       echo "::error::Failed to install $script"
       cat "$WORK_DIR/install.log"
       return 1
     fi
   done
 
-  verify_kit_installed "$dir"
-}
-
-# ---------------------------------------------------------------------------
-# Reduce a step's output to a stable error signature.
-#
-# Comparing failure *labels* alone would turn every step that fails on base into
-# a permanent allowlist entry: a PR could introduce a completely different error
-# inside that step and stay green.
-#
-# The message text has to be part of the signature, not just the number. Msg
-# 50000 is whatever RAISERROR was handed, and CommandExecute alone raises it for
-# many unrelated validation failures -- keyed on the number only, a step could
-# change from one Msg 50000 to a completely different one and still look
-# unchanged.
-#
-# Stripped, because they move without the error changing: server name (random
-# container hostname) and Procedure/Line (shift whenever a PR edits the file
-# above them).
-#
-# Quoted literals are NOT stripped wholesale. A quoted name is often the only
-# thing separating two errors -- Msg 208 for 'OldTable' and for 'NewTable' are
-# different bugs -- so blanking them all would let a real regression inherit a
-# grandfathered signature. Only quoted values containing a path separator are
-# normalised, which covers the volatile ones (rotating trace files, per-run
-# backup paths) and leaves deterministic identifiers intact.
-# ---------------------------------------------------------------------------
-error_signature() {
-  awk '
-    /^Msg [0-9]+, Level [0-9]+, State [0-9]+/ {
-      header = $0
-      if ((getline detail) > 0) { print header " :: " detail } else { print header }
-      next
-    }
-    /^Sqlcmd: Error/ { print }
-  ' "$1" 2>/dev/null \
-    | sed -E "s/, Server [^,]+,/,/; s/, Procedure [^,]+,/,/; s/, Line [0-9]+//" \
-    | sed -E "s@'[^']*[/\\\\][^']*'@'PATH'@g" \
-    | sort -u \
-    | tr '\n' ';' \
-    || true
-}
-
-# ---------------------------------------------------------------------------
-# Is this step byte-identical to the one base runs under the same label?
-#
-# Both passes execute THIS branch's matrix, so a step the PR adds or edits runs
-# against base's procedures too. A defect in the step itself -- a typo'd
-# procedure name, a bad parameter -- therefore fails identically on both passes
-# and would be waved through as "pre-existing". Only a step base also has, with
-# the same body, may be grandfathered; anything new or edited has to pass on its
-# own merits.
-# ---------------------------------------------------------------------------
-# Sets harness_unchanged. Any difference, or any file absent from base, means no.
-check_harness_unchanged() {
-  local revision="$1" file
-
-  for file in "${HARNESS_FILES[@]}"; do
-    if ! git -C "$REPO_ROOT" cat-file -e "$revision:$file" 2>/dev/null; then
-      echo "  harness file is new on this branch: $file"
-      harness_unchanged=0
-      return
-    fi
-    if ! git -C "$REPO_ROOT" show "$revision:$file" | cmp -s - "$REPO_ROOT/$file"; then
-      echo "  harness file changed on this branch: $file"
-      harness_unchanged=0
-      return
-    fi
-  done
-
-  harness_unchanged=1
-}
-
-step_unchanged_from_base() {
-  local label="$1" head_file="$2" base_label_file
-
-  [[ -d "$WORK_DIR/base-steps" ]] || return 1
-
-  for base_label_file in "$WORK_DIR/base-steps"/*.label; do
-    [[ -e "$base_label_file" ]] || return 1
-    if [[ "$(cat "$base_label_file")" == "$label" ]]; then
-      cmp -s "${base_label_file%.label}.sql" "$head_file" && return 0
-      return 1
-    fi
-  done
-
-  return 1
-}
-
-# Run one step file. Sets STEP_SIGNATURE; returns non-zero if the step failed.
-STEP_SIGNATURE=""
-run_one_step() {
-  local step_file="$1" log_file="$2"
-
-  if "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$step_file" > "$log_file" 2>&1; then
-    STEP_SIGNATURE=""
-    return 0
-  fi
-
-  STEP_SIGNATURE="$(error_signature "$log_file")"
-  return 1
+  verify_kit_installed
 }
 
 split_matrix() {
   local steps_dir="$1"
-  local matrix_file="${2:-$MATRIX_SQL}"
 
   rm -rf "$steps_dir"
   mkdir -p "$steps_dir"
 
-  python3 - "$matrix_file" "$steps_dir" <<'PYTHON'
+  python3 - "$MATRIX_SQL" "$steps_dir" <<'PYTHON'
 import os
 import sys
 
@@ -369,27 +213,22 @@ PYTHON
 }
 
 # ---------------------------------------------------------------------------
-# Run every step on its own, so one failure is attributed to one labelled step
-# and the rest of the matrix still runs. One CI round should surface every
-# problem, not just the first.
-#
-# Writes "<status><TAB><label><TAB><signature><TAB><step file>" per step.
+# Run every step on its own, so a failure is attributed to one labelled step and
+# the rest still run. One CI round should surface every problem, not just the
+# first one to blow up.
 # ---------------------------------------------------------------------------
 run_matrix() {
-  local pass_name="$1" results_file="$2"
   local steps_dir="$WORK_DIR/steps"
-  local step_file current_label failures=0
-
-  : > "$results_file"
+  local step_file current_label failures=0 total=0
 
   for step_file in "$steps_dir"/*.sql; do
     current_label="$(cat "${step_file%.sql}.label")"
+    total=$((total + 1))
 
-    if run_one_step "$step_file" "$WORK_DIR/step.log"; then
-      printf 'PASS\t%s\t\t%s\n' "$current_label" "$step_file" >> "$results_file"
+    if "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$step_file" \
+         > "$WORK_DIR/step.log" 2>&1; then
       echo "  PASS  $current_label"
     else
-      printf 'FAIL\t%s\t%s\t%s\n' "$current_label" "$STEP_SIGNATURE" "$step_file" >> "$results_file"
       echo "  FAIL  $current_label"
       # Surface the diagnostics themselves, not a blind tail: these procs print
       # result sets, so the error scrolls out of view long before the end.
@@ -398,153 +237,25 @@ run_matrix() {
         echo "--- last lines ---"
         tail -6 "$WORK_DIR/step.log"
       } | sed 's/^/        /'
+
+      {
+        echo "### Failed: \`$current_label\` on \`${MSSQL_IMAGE:-this image}\`"
+        echo '```'
+        grep -E -A2 '^(Msg [0-9]+,|Sqlcmd: Error)' "$WORK_DIR/step.log" | head -12 || true
+        echo '```'
+      } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
       failures=$((failures + 1))
     fi
   done
 
-  echo "  $pass_name: $failures failing step(s)"
-}
-
-# ---------------------------------------------------------------------------
-# sp_Blitz findings, captured through the @Output* table path so that code path
-# gets exercised too. Ordered so the two passes are directly comparable.
-#
-# Findings whose text embeds a timestamp or other per-run value are excluded --
-# CheckID 156 puts GETDATE() straight into Finding, so leaving it in would report
-# a removal and an addition on every single run and bury any real change.
-# ---------------------------------------------------------------------------
-VOLATILE_CHECK_IDS="156"
-
-# Returns non-zero, without aborting the job, when sp_Blitz cannot produce a
-# findings set. This runs the same full configuration the matrix just exercised,
-# so if sp_Blitz is failing -- including failing on base, before this branch is
-# involved at all -- this call fails too. Under `sqlcmd -b` and `set -e` that
-# would kill the run here, before the head pass, and the comparison logic that
-# exists to classify exactly that failure would never be reached. The findings
-# diff is informational, so losing it is survivable; losing the error
-# classification is not.
-capture_findings() {
-  local destination="$1"
-
-  : > "$destination"
-
-  run_query "
-SET NOCOUNT ON;
-IF OBJECT_ID('FRKSmokeTest.dbo.BlitzFindings') IS NOT NULL
-    DROP TABLE FRKSmokeTest.dbo.BlitzFindings;
-" >/dev/null 2>&1 || true
-
-  # Carries the same skip list as the matrix steps. Without it the CheckID 106
-  # trace-file race (issue #4050) could abort this run instead, which would kill
-  # the whole script rather than one labelled step.
-  run_query "
-EXEC dbo.sp_Blitz
-     @CheckUserDatabaseObjects = 1,
-     @CheckServerInfo          = 1,
-     @OutputDatabaseName       = 'FRKSmokeTest',
-     @OutputSchemaName         = 'dbo',
-     @OutputTableName          = 'BlitzFindings',
-     @SkipChecksDatabase       = 'FRKSmokeTest',
-     @SkipChecksSchema         = 'dbo',
-     @SkipChecksTable          = 'BlitzChecksToSkip';
-" >/dev/null 2>&1 || {
-    echo "  ::warning::sp_Blitz failed while capturing findings; the findings comparison will be skipped."
+  echo
+  if [[ "$failures" -gt 0 ]]; then
+    echo "::error::$failures of $total step(s) failed on ${MSSQL_IMAGE:-this image}."
     return 1
-  }
+  fi
 
-  # This output is parsed, not read. sqlcmd defaults to an 80-character screen
-  # width and truncates variable-length columns at 256, while a row here reaches
-  # ~340 (CheckID + NVARCHAR(128) DatabaseName + VARCHAR(200) Finding), so rows
-  # could wrap or clip and sort/comm would compare fragments.
-  #
-  # No -W here: sqlcmd rejects it alongside -y ("The y and the W options are
-  # mutually exclusive"), and -y is the one that lifts the truncation. Without
-  # -W the columns come back padded to the display width, so the trailing space
-  # is stripped in the pipeline below instead.
-  #
-  # 8000 rather than the "unlimited" spellings (-y 0, -w 65535) -- those are
-  # edge values whose handling varies by build, and 8000 is comfortably above
-  # the real maximum while squarely inside the documented range for both.
-  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -y 8000 -w 8000 -s '|' -Q "
-SET NOCOUNT ON;
-SELECT CONVERT(VARCHAR(10), CheckID)
-       + '|' + ISNULL(DatabaseName, '(server)')
-       + '|' + ISNULL(Finding, '')
-FROM dbo.BlitzFindings
-WHERE CheckID NOT IN ($VOLATILE_CHECK_IDS)
-ORDER BY CheckID, DatabaseName, Finding;
-" 2>"$WORK_DIR/readback.log" \
-    | sed -e 's/[[:space:]]*$//' -e '/^$/d' -e '/rows affected/d' \
-    | sort -u > "$destination" || {
-    echo "  ::warning::Reading findings back failed; the findings comparison will be skipped."
-    sed 's/^/    /' "$WORK_DIR/readback.log" | tail -10
-    return 1
-  }
-}
-
-# ---------------------------------------------------------------------------
-# Reset mutable state between passes so the two runs see the same server.
-#
-# Anything a matrix step can create has to be listed here, or the head pass
-# skips the create path the base pass already took and the comparison quietly
-# stops testing it. BlitzChecksToSkip is deliberately NOT dropped -- the seed
-# creates it once and both passes need it.
-# ---------------------------------------------------------------------------
-reset_between_passes() {
-  run_query "
-SET NOCOUNT ON;
-
-IF DB_ID('FRKSmokeTestRestored') IS NOT NULL
-BEGIN
-    ALTER DATABASE FRKSmokeTestRestored SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-    DROP DATABASE FRKSmokeTestRestored;
-END;
-
-/* Enumerated by naming convention rather than a hand-maintained list.
-
-   That list was wrong four times over: sp_BlitzLock's synonyms, sp_BlitzFirst's
-   four views, sp_BlitzWho's two, and sp_BlitzLock's BlitzLockFindings. Any proc
-   taking @OutputTableName can create objects derived from it, so naming them one
-   at a time is structurally the losing approach -- every new output path is a
-   silent gap until someone notices the head pass skipped its create branch.
-
-   Everything the kit writes into this database is Blitz-prefixed. The seed's own
-   tables (Users, Posts, CommentsHeap) are not, so they survive; BlitzChecksToSkip
-   is the one Blitz-prefixed object to keep, since the seed creates it once and
-   both passes need it.
-
-   Views before tables: dropping a table first would leave its view orphaned.
-   Both go through the target database's own sp_executesql because DROP VIEW
-   rejects a three-part name (Msg 166), unlike DROP TABLE. */
-DECLARE @drop NVARCHAR(MAX) = N'';
-
-SELECT @drop = @drop + N'DROP VIEW dbo.' + QUOTENAME(name) + N';'
-FROM FRKSmokeTest.sys.views
-WHERE name LIKE N'Blitz%'
-  AND name <> N'BlitzChecksToSkip'
-  AND SCHEMA_NAME(schema_id) = N'dbo';
-
-IF @drop <> N'' EXEC FRKSmokeTest.sys.sp_executesql @drop;
-
-SET @drop = N'';
-
-SELECT @drop = @drop + N'DROP TABLE dbo.' + QUOTENAME(name) + N';'
-FROM FRKSmokeTest.sys.tables
-WHERE name LIKE N'Blitz%'
-  AND name <> N'BlitzChecksToSkip'
-  AND SCHEMA_NAME(schema_id) = N'dbo';
-
-IF @drop <> N'' EXEC FRKSmokeTest.sys.sp_executesql @drop;
-
-/* sp_BlitzLock's synonyms, which are not Blitz-prefixed. */
-DECLARE @dropsyn NVARCHAR(MAX) = N'';
-
-SELECT @dropsyn = @dropsyn + N'DROP SYNONYM ' + QUOTENAME(name) + N';'
-FROM sys.synonyms
-WHERE name IN (N'DeadlockFindings', N'DeadLockTbl');
-
-IF @dropsyn <> N'' EXEC sys.sp_executesql @dropsyn;
-" >/dev/null
+  echo "All $total steps passed."
 }
 
 # ---------------------------------------------------------------------------
@@ -553,240 +264,18 @@ IF @dropsyn <> N'' EXEC sys.sp_executesql @dropsyn;
 wait_for_sql_server
 wait_for_wait_stats
 
-# sp_DatabaseRestore's dependencies (Ola Hallengren's CommandLog and
-# CommandExecute) are deliberately NOT installed: the only invocation left is
-# @Help = 1, which returns at sp_DatabaseRestore.sql:71, long before the
-# CommandExecute check at :255. Fetching them would add two network downloads
-# and two checksums that can redden every PR while exercising nothing. Restore
-# them alongside the execute-path step when #4049 lands.
-
 echo
 echo "=== Seeding test data ==="
 run_file "$SEED_SQL"
 
+echo
+echo "=== Installing the kit ==="
+install_kit
+
+echo
+echo "=== Running the matrix ==="
 split_matrix "$WORK_DIR/steps"
+run_matrix
 
-BASE_REVISION="${GITHUB_BASE_SHA:-}"
-if [[ -z "$BASE_REVISION" && -n "${GITHUB_BASE_REF:-}" ]]; then
-  BASE_REVISION="origin/${GITHUB_BASE_REF}"
-fi
-
-base_ran=0
-base_findings_ok=0
-head_findings_ok=0
-if [[ -n "$BASE_REVISION" ]] && git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REVISION" >/dev/null; then
-  echo
-  echo "=== Pass 1: base ($BASE_REVISION) ==="
-
-  check_harness_unchanged "$BASE_REVISION"
-  if [[ "$harness_unchanged" -eq 1 ]]; then
-    echo "  harness unchanged from base; unchanged steps may be grandfathered"
-  else
-    echo "  harness differs from base; every step must pass on its own merits"
-  fi
-
-  # Base's own copy of the matrix, so we can tell which steps this PR added or
-  # edited. Those must pass on their own merits -- see step_unchanged_from_base.
-  if git -C "$REPO_ROOT" cat-file -e "$BASE_REVISION:$MATRIX_REL_PATH" 2>/dev/null; then
-    git -C "$REPO_ROOT" show "$BASE_REVISION:$MATRIX_REL_PATH" > "$WORK_DIR/base-matrix.sql"
-    split_matrix "$WORK_DIR/base-steps" "$WORK_DIR/base-matrix.sql"
-    echo "  base matrix: $(find "$WORK_DIR/base-steps" -name '*.sql' | wc -l | tr -d ' ') step(s) to compare against"
-  else
-    echo "  base has no matrix file; every step counts as new and must pass on its own"
-  fi
-
-  materialise_kit "$BASE_REVISION" "$WORK_DIR/base"
-  install_kit "$WORK_DIR/base"
-  run_matrix "base" "$WORK_DIR/base-results.txt"
-  base_findings_ok=1
-  capture_findings "$WORK_DIR/base-findings.txt" || base_findings_ok=0
-  reset_between_passes
-  base_ran=1
-else
-  echo
-  echo "No usable base revision (GITHUB_BASE_SHA/GITHUB_BASE_REF); skipping the"
-  echo "comparison pass and checking this branch for errors only."
-  : > "$WORK_DIR/base-results.txt"
-  : > "$WORK_DIR/base-findings.txt"
-fi
-
-echo
-echo "=== Pass 2: this branch ==="
-install_kit "$REPO_ROOT"
-run_matrix "head" "$WORK_DIR/head-results.txt"
-head_findings_ok=1
-capture_findings "$WORK_DIR/head-findings.txt" || head_findings_ok=0
-
-# ---------------------------------------------------------------------------
-# Report: findings differences are informational
-# ---------------------------------------------------------------------------
-echo
-echo "=== sp_Blitz findings: base vs this branch ==="
-if [[ "$base_ran" -eq 1 && "$base_findings_ok" -eq 1 && "$head_findings_ok" -eq 1 ]]; then
-  added="$(comm -13 "$WORK_DIR/base-findings.txt" "$WORK_DIR/head-findings.txt" || true)"
-  removed="$(comm -23 "$WORK_DIR/base-findings.txt" "$WORK_DIR/head-findings.txt" || true)"
-
-  if [[ -z "$added" && -z "$removed" ]]; then
-    echo "No change. $(wc -l < "$WORK_DIR/head-findings.txt" | tr -d ' ') findings, identical to base."
-  else
-    echo "This branch changes what sp_Blitz reports. Not a failure -- review it."
-    if [[ -n "$removed" ]]; then
-      echo
-      echo "  No longer reported:"
-      sed 's/^/    - /' <<< "$removed"
-    fi
-    if [[ -n "$added" ]]; then
-      echo
-      echo "  Newly reported:"
-      sed 's/^/    + /' <<< "$added"
-    fi
-    {
-      echo "### sp_Blitz findings changed on \`${MSSQL_IMAGE:-this image}\`"
-      echo
-      echo "Informational -- review whether these are intended."
-      [[ -n "$removed" ]] && { echo; echo "**No longer reported:**"; echo '```'; echo "$removed"; echo '```'; }
-      [[ -n "$added" ]] && { echo; echo "**Newly reported:**"; echo '```'; echo "$added"; echo '```'; }
-    } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-  fi
-elif [[ "$base_ran" -ne 1 ]]; then
-  echo "Skipped (no base pass)."
-else
-  if [[ "$base_findings_ok" -ne 1 && "$head_findings_ok" -ne 1 ]]; then
-    echo "Skipped: sp_Blitz could not produce a findings set on either revision."
-  elif [[ "$base_findings_ok" -ne 1 ]]; then
-    echo "Skipped: sp_Blitz could not produce a findings set on base."
-  else
-    echo "Skipped: sp_Blitz could not produce a findings set on this branch."
-  fi
-  echo "The error classification below is unaffected."
-fi
-
-# ---------------------------------------------------------------------------
-# Report: errors decide the build
-#
-# A head failure counts as pre-existing only when the same step failed on base
-# with the same diagnostics.
-#
-# A first-attempt mismatch is not enough to blame the PR. The two passes run
-# minutes apart against one server whose state keeps moving, and transient
-# errors -- a torn default-trace read, a plan aged out mid-step -- land on
-# whichever pass is unlucky. That produced a red build on a PR that changed no
-# stored procedure at all. So every mismatch is re-confirmed before it counts:
-# retry on head, and if it still fails, put base's copies back and run it there
-# too. Only a failure that survives both is attributed to this branch.
-# ---------------------------------------------------------------------------
-echo
-echo "=== Errors ==="
-
-mismatches=""
-pre_existing=""
-
-# Look up one label's outcome in a results file: "<status><TAB><signature>".
-lookup_result() {
-  awk -F'\t' -v want="$2" '$2 == want { print $1 "\t" $3; exit }' "$1"
-}
-
-while IFS=$'\t' read -r status step_label head_signature step_file; do
-  [[ "$status" == "FAIL" ]] || continue
-
-  base_signature="$(awk -F'\t' -v want="$step_label" \
-    '$1 == "FAIL" && $2 == want { print $3; exit }' "$WORK_DIR/base-results.txt")"
-
-  if [[ -n "$base_signature" && "$base_signature" == "$head_signature" ]] \
-     && [[ "$harness_unchanged" -eq 1 ]] \
-     && step_unchanged_from_base "$step_label" "$step_file"; then
-    pre_existing+="$step_label -- $head_signature"$'\n'
-  else
-    mismatches+="$step_label"$'\t'"$head_signature"$'\t'"$step_file"$'\t'"$base_signature"$'\n'
-  fi
-done < "$WORK_DIR/head-results.txt"
-
-mismatches="$(sed '/^$/d' <<< "$mismatches")"
-new_failures=""
-
-if [[ -n "$mismatches" ]]; then
-  echo "Re-confirming $(wc -l <<< "$mismatches" | tr -d ' ') mismatch(es) before attributing them to this branch."
-  echo "Re-running the whole matrix rather than the failing steps alone: several steps"
-  echo "create persistent objects, so replaying one in place would let it skip the very"
-  echo "create branch that failed and look transient."
-
-  # Round 1: the full matrix again on head, from the same reset state the
-  # original pass started from.
-  reset_between_passes
-  install_kit "$REPO_ROOT" quiet
-  run_matrix "head re-check" "$WORK_DIR/head-recheck.txt"
-
-  still_failing=""
-  while IFS=$'\t' read -r step_label head_signature step_file base_signature; do
-    [[ -n "$step_label" ]] || continue
-    IFS=$'\t' read -r recheck_status recheck_signature < <(lookup_result "$WORK_DIR/head-recheck.txt" "$step_label")
-    if [[ "$recheck_status" == "PASS" ]]; then
-      echo "  transient: '$step_label' passed when the matrix was replayed -- not a regression"
-    else
-      still_failing+="$step_label"$'\t'"$recheck_signature"$'\t'"$step_file"$'\t'"$base_signature"$'\n'
-    fi
-  done <<< "$mismatches"
-
-  still_failing="$(sed '/^$/d' <<< "$still_failing")"
-
-  # Round 2: the full matrix against base, same way.
-  if [[ -n "$still_failing" && "$base_ran" -eq 1 ]]; then
-    echo "  replaying the matrix against base for $(wc -l <<< "$still_failing" | tr -d ' ') step(s)..."
-    reset_between_passes
-    install_kit "$WORK_DIR/base" quiet
-    run_matrix "base re-check" "$WORK_DIR/base-recheck.txt"
-
-    while IFS=$'\t' read -r step_label head_signature step_file base_signature; do
-      [[ -n "$step_label" ]] || continue
-      IFS=$'\t' read -r rebase_status rebase_signature < <(lookup_result "$WORK_DIR/base-recheck.txt" "$step_label")
-
-      if [[ "$rebase_status" == "PASS" ]]; then
-        new_failures+="$step_label -- $head_signature"$'\n'
-      elif [[ -n "$rebase_signature" ]] \
-           && [[ "$rebase_signature" == "$head_signature" ]] \
-           && [[ "$harness_unchanged" -eq 1 ]] \
-           && step_unchanged_from_base "$step_label" "$step_file"; then
-        echo "  environmental: '$step_label' fails the same way on base when replayed -- not a regression"
-        pre_existing+="$step_label -- $head_signature (confirmed on replay)"$'\n'
-      else
-        new_failures+="$step_label -- error changed: base [$rebase_signature] head [$head_signature]"$'\n'
-      fi
-    done <<< "$still_failing"
-
-    # Leave this branch's procedures installed, so the job ends as it began.
-    install_kit "$REPO_ROOT" quiet
-  elif [[ -n "$still_failing" ]]; then
-    while IFS=$'\t' read -r step_label head_signature _ _; do
-      [[ -n "$step_label" ]] || continue
-      new_failures+="$step_label -- $head_signature"$'\n'
-    done <<< "$still_failing"
-  fi
-fi
-
-pre_existing="$(sed '/^$/d' <<< "$pre_existing")"
-new_failures="$(sed '/^$/d' <<< "$new_failures")"
-
-if [[ -n "$pre_existing" ]]; then
-  echo
-  echo "Already failing on base with the same error -- not caused by this branch:"
-  sed 's/^/  ~ /' <<< "$pre_existing"
-fi
-
-if [[ -n "$new_failures" ]]; then
-  echo
-  echo "::error::This branch introduces SQL errors in $(wc -l <<< "$new_failures" | tr -d ' ') step(s)."
-  sed 's/^/  ! /' <<< "$new_failures"
-  {
-    echo "### New SQL errors on \`${MSSQL_IMAGE:-this image}\`"
-    echo
-    echo "Each was re-run against this branch and against base before being reported."
-    echo '```'
-    echo "$new_failures"
-    echo '```'
-  } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-  exit 1
-fi
-
-echo "No new SQL errors."
 echo
 echo "Smoke tests passed."

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -452,12 +452,18 @@ EXEC dbo.sp_Blitz
     return 1
   }
 
-  # -y 0 and -w 65535 matter: this output is parsed, not read. sqlcmd defaults to
-  # an 80-character screen width and truncates variable-length columns at 256,
-  # while a row here reaches ~340 (CheckID + NVARCHAR(128) DatabaseName +
-  # VARCHAR(200) Finding). Wrapped or clipped rows would make sort/comm compare
-  # fragments and quietly miss real differences.
-  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -y 0 -w 65535 -s '|' -Q "
+  # This output is parsed, not read. sqlcmd defaults to an 80-character screen
+  # width and truncates variable-length columns at 256, while a row here reaches
+  # ~340 (CheckID + NVARCHAR(128) DatabaseName + VARCHAR(200) Finding), so rows
+  # could wrap or clip and sort/comm would compare fragments.
+  #
+  # 8000 for both rather than the "unlimited" spellings (-y 0, -w 65535): those
+  # are edge values whose handling varies between sqlcmd builds, and the first
+  # attempt at this fix used them and made the readback fail outright -- which,
+  # because this path only warns, showed up as a silently skipped comparison on
+  # a green build. 8000 is comfortably above the real maximum and is squarely
+  # inside the documented range for both flags.
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -y 8000 -w 8000 -s '|' -Q "
 SET NOCOUNT ON;
 SELECT CONVERT(VARCHAR(10), CheckID)
        + '|' + ISNULL(DatabaseName, '(server)')
@@ -465,7 +471,11 @@ SELECT CONVERT(VARCHAR(10), CheckID)
 FROM dbo.BlitzFindings
 WHERE CheckID NOT IN ($VOLATILE_CHECK_IDS)
 ORDER BY CheckID, DatabaseName, Finding;
-" 2>/dev/null | sed '/^$/d;/rows affected/d' | sort -u > "$destination" || return 1
+" 2>"$WORK_DIR/readback.log" | sed '/^$/d;/rows affected/d' | sort -u > "$destination" || {
+    echo "  ::warning::Reading findings back failed; the findings comparison will be skipped."
+    sed 's/^/    /' "$WORK_DIR/readback.log" | tail -10
+    return 1
+  }
 }
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -28,6 +28,7 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 SEED_SQL="$SCRIPT_DIR/smoke-test-seed.sql"
 MATRIX_SQL="$SCRIPT_DIR/smoke-test-matrix.sql"
+MATRIX_REL_PATH=".github/scripts/smoke-test-matrix.sql"
 
 # Every non-deprecated script in the kit. sp_BlitzUpdate is deliberately absent:
 # it rewrites the procs mid-run, which would invalidate every later step and the
@@ -207,6 +208,32 @@ error_signature() {
     || true
 }
 
+# ---------------------------------------------------------------------------
+# Is this step byte-identical to the one base runs under the same label?
+#
+# Both passes execute THIS branch's matrix, so a step the PR adds or edits runs
+# against base's procedures too. A defect in the step itself -- a typo'd
+# procedure name, a bad parameter -- therefore fails identically on both passes
+# and would be waved through as "pre-existing". Only a step base also has, with
+# the same body, may be grandfathered; anything new or edited has to pass on its
+# own merits.
+# ---------------------------------------------------------------------------
+step_unchanged_from_base() {
+  local label="$1" head_file="$2" base_label_file
+
+  [[ -d "$WORK_DIR/base-steps" ]] || return 1
+
+  for base_label_file in "$WORK_DIR/base-steps"/*.label; do
+    [[ -e "$base_label_file" ]] || return 1
+    if [[ "$(cat "$base_label_file")" == "$label" ]]; then
+      cmp -s "${base_label_file%.label}.sql" "$head_file" && return 0
+      return 1
+    fi
+  done
+
+  return 1
+}
+
 # Run one step file. Sets STEP_SIGNATURE; returns non-zero if the step failed.
 STEP_SIGNATURE=""
 run_one_step() {
@@ -223,11 +250,12 @@ run_one_step() {
 
 split_matrix() {
   local steps_dir="$1"
+  local matrix_file="${2:-$MATRIX_SQL}"
 
   rm -rf "$steps_dir"
   mkdir -p "$steps_dir"
 
-  python3 - "$MATRIX_SQL" "$steps_dir" <<'PYTHON'
+  python3 - "$matrix_file" "$steps_dir" <<'PYTHON'
 import os
 import sys
 
@@ -363,6 +391,18 @@ WHERE name IN (N'BlitzOutput', N'BlitzCache', N'BlitzFirst', N'BlitzFirst_FileSt
                N'BlitzFirst_WaitStats_Categories', N'BlitzWho',
                N'BlitzWho_Results', N'BlitzLock', N'BlitzIndex', N'BlitzFindings');
 
+/* sp_BlitzFirst's logging path also creates views alongside each table:
+   <FileStats>_Deltas, <PerfmonStats>_Deltas, <PerfmonStats>_Actuals and
+   <WaitStats>_Deltas. Dropping only the tables would leave the base pass's
+   views in place, so the head pass would skip all four view-creation paths. */
+DECLARE @dropview NVARCHAR(MAX) = N'';
+
+SELECT @dropview = @dropview + N'DROP VIEW FRKSmokeTest.dbo.' + QUOTENAME(name) + N';'
+FROM FRKSmokeTest.sys.views
+WHERE name IN (N'BlitzFirst_FileStats_Deltas', N'BlitzFirst_PerfmonStats_Deltas',
+               N'BlitzFirst_PerfmonStats_Actuals', N'BlitzFirst_WaitStats_Deltas');
+
+IF @dropview <> N'' EXEC sys.sp_executesql @dropview;
 IF @drop <> N'' EXEC sys.sp_executesql @drop;
 
 /* sp_BlitzLock creates synonyms when logging to a table. */
@@ -414,6 +454,17 @@ base_ran=0
 if [[ -n "$BASE_REVISION" ]] && git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REVISION" >/dev/null; then
   echo
   echo "=== Pass 1: base ($BASE_REVISION) ==="
+
+  # Base's own copy of the matrix, so we can tell which steps this PR added or
+  # edited. Those must pass on their own merits -- see step_unchanged_from_base.
+  if git -C "$REPO_ROOT" cat-file -e "$BASE_REVISION:$MATRIX_REL_PATH" 2>/dev/null; then
+    git -C "$REPO_ROOT" show "$BASE_REVISION:$MATRIX_REL_PATH" > "$WORK_DIR/base-matrix.sql"
+    split_matrix "$WORK_DIR/base-steps" "$WORK_DIR/base-matrix.sql"
+    echo "  base matrix: $(find "$WORK_DIR/base-steps" -name '*.sql' | wc -l | tr -d ' ') step(s) to compare against"
+  else
+    echo "  base has no matrix file; every step counts as new and must pass on its own"
+  fi
+
   materialise_kit "$BASE_REVISION" "$WORK_DIR/base"
   install_kit "$WORK_DIR/base"
   run_matrix "base" "$WORK_DIR/base-results.txt"
@@ -495,7 +546,8 @@ while IFS=$'\t' read -r status step_label head_signature step_file; do
   base_signature="$(awk -F'\t' -v want="$step_label" \
     '$1 == "FAIL" && $2 == want { print $3; exit }' "$WORK_DIR/base-results.txt")"
 
-  if [[ -n "$base_signature" && "$base_signature" == "$head_signature" ]]; then
+  if [[ -n "$base_signature" && "$base_signature" == "$head_signature" ]] \
+     && step_unchanged_from_base "$step_label" "$step_file"; then
     pre_existing+="$step_label -- $head_signature"$'\n'
   else
     mismatches+="$step_label"$'\t'"$head_signature"$'\t'"$step_file"$'\t'"$base_signature"$'\n'
@@ -530,7 +582,8 @@ if [[ -n "$mismatches" ]]; then
       [[ -n "$step_label" ]] || continue
       if run_one_step "$step_file" "$WORK_DIR/recheck-base.log"; then
         new_failures+="$step_label -- $head_signature"$'\n'
-      elif [[ "$STEP_SIGNATURE" == "$head_signature" ]]; then
+      elif [[ "$STEP_SIGNATURE" == "$head_signature" ]] \
+           && step_unchanged_from_base "$step_label" "$step_file"; then
         echo "  environmental: '$step_label' fails the same way on base when re-run -- not a regression"
         pre_existing+="$step_label -- $head_signature (confirmed on re-run)"$'\n'
       else

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -1,10 +1,51 @@
 #!/usr/bin/env bash
+#
+# Runs every non-deprecated First Responder Kit script against a throwaway SQL
+# Server, twice: once with the base branch's copies and once with the pull
+# request's, then reports what changed.
+#
+# Before issue #4046 this script installed only the changed sp_*.sql and ran it
+# with @VersionCheckMode = 1 -- an unconditional early RETURN -- so no check body
+# ever executed and runtime breakage passed green. See PR #4045 for two bugs that
+# did exactly that.
+#
+# Two outcomes, deliberately different (issue #4046, decision 1A):
+#   * A SQL error that the base branch does not also produce FAILS the build.
+#   * A difference in sp_Blitz's findings is PRINTED for a human and does not
+#     fail the build, because changing a finding is often the point of the PR.
+#
 set -Eeuo pipefail
 
 : "${SQLCMDSERVER:=tcp:127.0.0.1,1433}"
 : "${SQLCMDUSER:=sa}"
 : "${SQLCMDPASSWORD:?SQLCMDPASSWORD must be set}"
 : "${SQLCMD:=sqlcmd}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+SEED_SQL="$SCRIPT_DIR/smoke-test-seed.sql"
+MATRIX_SQL="$SCRIPT_DIR/smoke-test-matrix.sql"
+
+# Every non-deprecated script in the kit. sp_BlitzUpdate is deliberately absent:
+# it rewrites the procs mid-run, which would invalidate every later step and the
+# base-vs-head comparison (issue #4046, decision 4).
+KIT_SCRIPTS=(
+  "sp_Blitz.sql"
+  "sp_BlitzAnalysis.sql"
+  "sp_BlitzBackups.sql"
+  "sp_BlitzCache.sql"
+  "sp_BlitzFirst.sql"
+  "sp_BlitzIndex.sql"
+  "sp_BlitzLock.sql"
+  "sp_BlitzWho.sql"
+  "sp_DatabaseRestore.sql"
+  "sp_ineachdb.sql"
+  "sp_kill.sql"
+  "OptionalScripts/sp_BlitzPlanCompare.sql"
+)
 
 SQLCMD_ARGS=(
   -S "$SQLCMDSERVER"
@@ -13,142 +54,305 @@ SQLCMD_ARGS=(
   -C
   -b
   -r 1
-  -l 30
+  -l 60
+  -t 600
 )
 
 run_query() {
   "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -Q "$1"
 }
 
-is_root_sp_script() {
-  local path="$1"
-
-  [[ "$path" =~ ^sp_[A-Za-z0-9_]+\.sql$ && -f "$path" ]]
+run_file() {
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$1"
 }
 
-discover_changed_sp_scripts() {
-  local changed_path
-  local diff_base
-  local diff_head
-  local -a changed_paths=()
-  local -a scripts=()
+# ---------------------------------------------------------------------------
+# Wait for the container
+# ---------------------------------------------------------------------------
+wait_for_sql_server() {
+  echo "Waiting for SQL Server to accept connections..."
+  for attempt in {1..90}; do
+    if run_query "SET NOCOUNT ON; SELECT 1 AS ready;" >/dev/null 2>&1; then
+      echo "SQL Server is ready."
+      run_query "SET NOCOUNT ON; SELECT @@VERSION;"
+      return 0
+    fi
 
-  if [[ -n "${CHANGED_SQL_FILES:-}" ]]; then
-    while IFS= read -r changed_path; do
-      [[ -n "$changed_path" ]] && changed_paths+=("$changed_path")
-    done <<< "$CHANGED_SQL_FILES"
-  elif [[ -n "${GITHUB_BASE_SHA:-}" && -n "${GITHUB_HEAD_SHA:-}" ]]; then
-    diff_base="$GITHUB_BASE_SHA"
-    diff_head="$GITHUB_HEAD_SHA"
-    while IFS= read -r changed_path; do
-      [[ -n "$changed_path" ]] && changed_paths+=("$changed_path")
-    done < <(git diff --name-only --diff-filter=ACMR "$diff_base" "$diff_head" -- ':(top)sp_*.sql')
-  elif [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-    diff_base="origin/${GITHUB_BASE_REF}"
-    diff_head="HEAD"
-    while IFS= read -r changed_path; do
-      [[ -n "$changed_path" ]] && changed_paths+=("$changed_path")
-    done < <(git diff --name-only --diff-filter=ACMR "$diff_base" "$diff_head" -- ':(top)sp_*.sql')
-  else
-    echo "Unable to determine changed PR files. Set CHANGED_SQL_FILES for a manual run." >&2
-    exit 1
-  fi
+    if [[ "$attempt" -eq 90 ]]; then
+      echo "::error::SQL Server did not become ready in time." >&2
+      return 1
+    fi
 
-  for changed_path in "${changed_paths[@]}"; do
-    if is_root_sp_script "$changed_path"; then
-      scripts+=("$changed_path")
+    sleep 2
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Materialise one branch's copy of the kit into a directory
+#
+# A script that does not exist at the given revision is skipped -- that is a
+# script the PR adds, which has no baseline to compare against.
+# ---------------------------------------------------------------------------
+materialise_kit() {
+  local revision="$1" dest="$2" script
+
+  mkdir -p "$dest/OptionalScripts"
+
+  for script in "${KIT_SCRIPTS[@]}"; do
+    if git -C "$REPO_ROOT" cat-file -e "$revision:$script" 2>/dev/null; then
+      git -C "$REPO_ROOT" show "$revision:$script" > "$dest/$script"
+    else
+      echo "  (not present at $revision, skipping: $script)"
+    fi
+  done
+}
+
+install_kit() {
+  local dir="$1" script
+
+  for script in "${KIT_SCRIPTS[@]}"; do
+    [[ -f "$dir/$script" ]] || continue
+    echo "  installing $script"
+    if ! run_file "$dir/$script" > "$WORK_DIR/install.log" 2>&1; then
+      echo "::error::Failed to install $script"
+      cat "$WORK_DIR/install.log"
+      return 1
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Split the matrix on --#STEP: markers and run each step on its own.
+#
+# Each step runs separately so one failure is attributed to one labelled step
+# and the rest of the matrix still runs -- we want every problem in a single CI
+# round, not just the first.
+#
+# Writes one "<status>\t<label>" line per step to the named results file.
+# ---------------------------------------------------------------------------
+run_matrix() {
+  local label="$1" results_file="$2"
+  local steps_dir="$WORK_DIR/steps-$label"
+  local step_file current_label failures=0
+
+  rm -rf "$steps_dir"
+  mkdir -p "$steps_dir"
+
+  python3 - "$MATRIX_SQL" "$steps_dir" <<'PYTHON'
+import os
+import sys
+
+matrix_path, steps_dir = sys.argv[1], sys.argv[2]
+
+steps, label, buf = [], None, []
+with open(matrix_path, encoding="utf-8") as handle:
+    for line in handle:
+        if line.startswith("--#STEP:"):
+            if label is not None:
+                steps.append((label, "".join(buf)))
+            label = line.split(":", 1)[1].strip()
+            buf = []
+        elif label is not None:
+            buf.append(line)
+if label is not None:
+    steps.append((label, "".join(buf)))
+
+for index, (step_label, body) in enumerate(steps):
+    with open(os.path.join(steps_dir, f"{index:03d}.sql"), "w", encoding="utf-8") as handle:
+        handle.write(body)
+    with open(os.path.join(steps_dir, f"{index:03d}.label"), "w", encoding="utf-8") as handle:
+        handle.write(step_label)
+PYTHON
+
+  : > "$results_file"
+
+  for step_file in "$steps_dir"/*.sql; do
+    current_label="$(cat "${step_file%.sql}.label")"
+
+    if "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$step_file" \
+         > "$WORK_DIR/step.log" 2>&1; then
+      printf 'PASS\t%s\n' "$current_label" >> "$results_file"
+      echo "  PASS  $current_label"
+    else
+      printf 'FAIL\t%s\n' "$current_label" >> "$results_file"
+      echo "  FAIL  $current_label"
+      # Keep the error text; it is what a reviewer needs to see.
+      sed 's/^/        /' "$WORK_DIR/step.log" | tail -25
+      failures=$((failures + 1))
     fi
   done
 
-  if [[ "${#scripts[@]}" -gt 0 ]]; then
-    printf '%s\n' "${scripts[@]}" | sort -u
-  fi
+  echo "  $label: $failures failing step(s)"
 }
 
-verify_proc_installed_and_version_check() {
-  local proc_name="$1"
+# ---------------------------------------------------------------------------
+# sp_Blitz findings, captured through the @Output* table path so that code path
+# gets exercised too. Ordered so the two passes are directly comparable.
+# ---------------------------------------------------------------------------
+capture_findings() {
+  local destination="$1"
 
   run_query "
 SET NOCOUNT ON;
+IF OBJECT_ID('FRKSmokeTest.dbo.BlitzFindings') IS NOT NULL
+    DROP TABLE FRKSmokeTest.dbo.BlitzFindings;
+" >/dev/null
 
-DECLARE @ProcName sysname = N'$proc_name',
-        @ObjectId int,
-        @Version varchar(30),
-        @VersionDate datetime,
-        @Sql nvarchar(max);
+  run_query "
+EXEC dbo.sp_Blitz
+     @CheckUserDatabaseObjects = 1,
+     @CheckServerInfo          = 1,
+     @OutputDatabaseName       = 'FRKSmokeTest',
+     @OutputSchemaName         = 'dbo',
+     @OutputTableName          = 'BlitzFindings';
+" >/dev/null
 
-SET @ObjectId = OBJECT_ID(N'dbo.' + QUOTENAME(@ProcName), N'P');
-
-IF @ObjectId IS NULL
-BEGIN
-    THROW 51000, 'Expected stored procedure was not installed.', 1;
-END;
-
-IF NOT EXISTS
-(
-    SELECT 1
-    FROM sys.parameters
-    WHERE object_id = @ObjectId
-      AND name = N'@VersionCheckMode'
-)
-BEGIN
-    THROW 51001, 'Stored procedure does not expose @VersionCheckMode.', 1;
-END;
-
-SET @Sql = N'EXEC dbo.' + QUOTENAME(@ProcName) + N'
-    @Version = @Version OUTPUT,
-    @VersionDate = @VersionDate OUTPUT,
-    @VersionCheckMode = 1;';
-
-EXEC sys.sp_executesql
-    @Sql,
-    N'@Version varchar(30) OUTPUT, @VersionDate datetime OUTPUT',
-    @Version = @Version OUTPUT,
-    @VersionDate = @VersionDate OUTPUT;
-
-IF @Version IS NULL OR @VersionDate IS NULL
-BEGIN
-    THROW 51002, 'Stored procedure version check failed.', 1;
-END;
-"
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -s '|' -Q "
+SET NOCOUNT ON;
+SELECT CONVERT(VARCHAR(10), CheckID)
+       + '|' + ISNULL(DatabaseName, '(server)')
+       + '|' + ISNULL(Finding, '')
+FROM dbo.BlitzFindings
+ORDER BY CheckID, DatabaseName, Finding;
+" | sed '/^$/d;/rows affected/d' | sort -u > "$destination"
 }
 
-echo "Waiting for SQL Server to accept connections..."
-for attempt in {1..60}; do
-  if run_query "SET NOCOUNT ON; SELECT 1 AS ready;" >/dev/null 2>&1; then
-    echo "SQL Server is ready."
-    break
-  fi
+# ---------------------------------------------------------------------------
+# Reset mutable state between passes so the two runs see the same server.
+# ---------------------------------------------------------------------------
+reset_between_passes() {
+  run_query "
+SET NOCOUNT ON;
 
-  if [[ "$attempt" -eq 60 ]]; then
-    echo "SQL Server did not become ready in time." >&2
-    exit 1
-  fi
+IF DB_ID('FRKSmokeTestRestored') IS NOT NULL
+BEGIN
+    ALTER DATABASE FRKSmokeTestRestored SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE FRKSmokeTestRestored;
+END;
 
-  sleep 2
-done
+DECLARE @drop NVARCHAR(MAX) = N'';
 
-changed_scripts=()
-while IFS= read -r changed_script; do
-  [[ -n "$changed_script" ]] && changed_scripts+=("$changed_script")
-done < <(discover_changed_sp_scripts)
+SELECT @drop = @drop + N'DROP TABLE FRKSmokeTest.dbo.' + QUOTENAME(name) + N';'
+FROM FRKSmokeTest.sys.tables
+WHERE name IN (N'BlitzOutput', N'BlitzCache', N'BlitzFirst', N'BlitzFirst_FileStats',
+               N'BlitzFirst_PerfmonStats', N'BlitzFirst_WaitStats', N'BlitzWho',
+               N'BlitzWho_Results', N'BlitzLock', N'BlitzIndex', N'BlitzFindings');
 
-if [[ "${#changed_scripts[@]}" -eq 0 ]]; then
-  echo "No changed root-level sp_*.sql scripts found; skipping SQL Server smoke tests."
-  exit 0
+IF @drop <> N'' EXEC sys.sp_executesql @drop;
+" >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+wait_for_sql_server
+
+echo
+echo "=== Seeding test data ==="
+run_file "$SEED_SQL"
+
+BASE_REVISION="${GITHUB_BASE_SHA:-}"
+if [[ -z "$BASE_REVISION" && -n "${GITHUB_BASE_REF:-}" ]]; then
+  BASE_REVISION="origin/${GITHUB_BASE_REF}"
 fi
 
-echo "Changed root-level stored procedure scripts:"
-printf ' - %s\n' "${changed_scripts[@]}"
+base_ran=0
+if [[ -n "$BASE_REVISION" ]] && git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REVISION" >/dev/null; then
+  echo
+  echo "=== Pass 1: base ($BASE_REVISION) ==="
+  materialise_kit "$BASE_REVISION" "$WORK_DIR/base"
+  install_kit "$WORK_DIR/base"
+  run_matrix "base" "$WORK_DIR/base-results.txt"
+  capture_findings "$WORK_DIR/base-findings.txt"
+  reset_between_passes
+  base_ran=1
+else
+  echo
+  echo "No usable base revision (GITHUB_BASE_SHA/GITHUB_BASE_REF); skipping the"
+  echo "comparison pass and checking this branch for errors only."
+  : > "$WORK_DIR/base-results.txt"
+fi
 
-for script in "${changed_scripts[@]}"; do
-  proc_name="$(basename "$script" .sql)"
+echo
+echo "=== Pass 2: this branch ==="
+install_kit "$REPO_ROOT"
+run_matrix "head" "$WORK_DIR/head-results.txt"
+capture_findings "$WORK_DIR/head-findings.txt"
 
-  echo "Installing $script..."
-  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$script"
+# ---------------------------------------------------------------------------
+# Report: findings differences are informational
+# ---------------------------------------------------------------------------
+echo
+echo "=== sp_Blitz findings: base vs this branch ==="
+if [[ "$base_ran" -eq 1 ]]; then
+  added="$(comm -13 "$WORK_DIR/base-findings.txt" "$WORK_DIR/head-findings.txt" || true)"
+  removed="$(comm -23 "$WORK_DIR/base-findings.txt" "$WORK_DIR/head-findings.txt" || true)"
 
-  echo "Running version check for dbo.$proc_name..."
-  verify_proc_installed_and_version_check "$proc_name"
-done
+  if [[ -z "$added" && -z "$removed" ]]; then
+    echo "No change. $(wc -l < "$WORK_DIR/head-findings.txt" | tr -d ' ') findings, identical to base."
+  else
+    echo "This branch changes what sp_Blitz reports. Not a failure -- review it."
+    if [[ -n "$removed" ]]; then
+      echo
+      echo "  No longer reported:"
+      sed 's/^/    - /' <<< "$removed"
+    fi
+    if [[ -n "$added" ]]; then
+      echo
+      echo "  Newly reported:"
+      sed 's/^/    + /' <<< "$added"
+    fi
+    {
+      echo "### sp_Blitz findings changed on \`${MSSQL_IMAGE:-this image}\`"
+      echo
+      echo "Informational -- review whether these are intended."
+      [[ -n "$removed" ]] && { echo; echo "**No longer reported:**"; echo '```'; echo "$removed"; echo '```'; }
+      [[ -n "$added" ]] && { echo; echo "**Newly reported:**"; echo '```'; echo "$added"; echo '```'; }
+    } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  fi
+else
+  echo "Skipped (no base pass)."
+fi
 
-echo "Changed stored procedure smoke tests passed."
+# ---------------------------------------------------------------------------
+# Report: errors decide the build
+# ---------------------------------------------------------------------------
+echo
+echo "=== Errors ==="
+
+head_failures="$(awk -F'\t' '$1 == "FAIL" { print $2 }' "$WORK_DIR/head-results.txt" || true)"
+base_failures="$(awk -F'\t' '$1 == "FAIL" { print $2 }' "$WORK_DIR/base-results.txt" || true)"
+
+new_failures=""
+while IFS= read -r failing_step; do
+  [[ -n "$failing_step" ]] || continue
+  if ! grep -Fxq "$failing_step" <<< "$base_failures"; then
+    new_failures+="$failing_step"$'\n'
+  fi
+done <<< "$head_failures"
+
+pre_existing="$(comm -12 <(sort <<< "$head_failures") <(sort <<< "$base_failures") | sed '/^$/d' || true)"
+
+if [[ -n "$pre_existing" ]]; then
+  echo "Already failing on base -- not caused by this branch:"
+  sed 's/^/  ~ /' <<< "$pre_existing"
+fi
+
+new_failures="$(sed '/^$/d' <<< "$new_failures")"
+if [[ -n "$new_failures" ]]; then
+  echo
+  echo "::error::This branch introduces SQL errors in $(wc -l <<< "$new_failures" | tr -d ' ') step(s)."
+  sed 's/^/  ! /' <<< "$new_failures"
+  {
+    echo "### New SQL errors on \`${MSSQL_IMAGE:-this image}\`"
+    echo
+    echo '```'
+    echo "$new_failures"
+    echo '```'
+  } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 1
+fi
+
+echo "No new SQL errors."
+echo
+echo "Smoke tests passed."

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -10,7 +10,7 @@
 # did exactly that.
 #
 # Two outcomes, deliberately different (issue #4046, decision 1A):
-#   * A SQL error that the base branch does not also produce FAILS the build.
+#   * A SQL error this branch introduces FAILS the build.
 #   * A difference in sp_Blitz's findings is PRINTED for a human and does not
 #     fail the build, because changing a finding is often the point of the PR.
 #
@@ -47,12 +47,18 @@ KIT_SCRIPTS=(
   "OptionalScripts/sp_BlitzPlanCompare.sql"
 )
 
+# -I turns QUOTED_IDENTIFIER ON. sqlcmd defaults it OFF, and a procedure
+# captures the setting in force when it is created, so without this the
+# sp_BlitzFirst and sp_BlitzLock code paths that build indexed/XML expressions
+# die at runtime with Msg 1934. Every real client (SSMS, .NET, ODBC) has it ON,
+# so OFF was testing a configuration no user actually runs.
 SQLCMD_ARGS=(
   -S "$SQLCMDSERVER"
   -U "$SQLCMDUSER"
   -P "$SQLCMDPASSWORD"
   -C
   -b
+  -I
   -r 1
   -l 60
   -t 600
@@ -85,6 +91,34 @@ wait_for_sql_server() {
 
     sleep 2
   done
+}
+
+# ---------------------------------------------------------------------------
+# Hold off until the instance has been up longer than a minute.
+#
+# sp_Blitz CheckID 152 divides by @MsSinceWaitsCleared, which is
+# DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP) * 60000.0 and is therefore 0
+# for the instance's first minute. Its zero-guard sits inside a branch that
+# cannot be taken while the value is 0, so sp_Blitz aborts with a divide-by-zero
+# -- see issue #4048, which tracks the fix.
+#
+# That is a real bug, but it is not one this comparison can measure: it depends
+# on how long the container took to start, so it fires on whichever pass happens
+# to run first and shows up as a spurious base-vs-head difference. Waiting the
+# window out keeps the two passes comparable. Remove this once #4048 is fixed.
+# ---------------------------------------------------------------------------
+wait_for_wait_stats() {
+  echo "Waiting for the instance to pass one minute of uptime (issue #4048)..."
+  for attempt in {1..40}; do
+    if [[ "$(run_query "SET NOCOUNT ON;
+SELECT DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP)
+FROM sys.databases WHERE name = 'tempdb';" -h -1 -W 2>/dev/null | head -1 | tr -d '[:space:]')" != "0" ]]; then
+      echo "Uptime window cleared."
+      return 0
+    fi
+    sleep 5
+  done
+  echo "::warning::Instance still reports under a minute of uptime; continuing anyway."
 }
 
 # ---------------------------------------------------------------------------
@@ -122,18 +156,38 @@ install_kit() {
 }
 
 # ---------------------------------------------------------------------------
+# Reduce a step's output to a stable error signature.
+#
+# Comparing failure *labels* alone would turn every step that fails on base into
+# a permanent allowlist entry: a PR could introduce a completely different error
+# inside that step and stay green. Comparing the diagnostics instead means only
+# the identical error is treated as pre-existing.
+#
+# Server name and line numbers are stripped -- the container's hostname is random
+# per run, and a line number shifting is exactly the kind of change a PR makes
+# without changing the error itself.
+# ---------------------------------------------------------------------------
+error_signature() {
+  grep -oE '^(Msg [0-9]+, Level [0-9]+, State [0-9]+|Sqlcmd: Error)[^,]*' "$1" 2>/dev/null \
+    | sed -E 's/, Server [^,]+//; s/, (Procedure|Line) [^,]*//g' \
+    | sort -u \
+    | tr '\n' ';' \
+    || true
+}
+
+# ---------------------------------------------------------------------------
 # Split the matrix on --#STEP: markers and run each step on its own.
 #
 # Each step runs separately so one failure is attributed to one labelled step
 # and the rest of the matrix still runs -- we want every problem in a single CI
 # round, not just the first.
 #
-# Writes one "<status>\t<label>" line per step to the named results file.
+# Writes "<status><TAB><label><TAB><error signature>" per step.
 # ---------------------------------------------------------------------------
 run_matrix() {
   local label="$1" results_file="$2"
   local steps_dir="$WORK_DIR/steps-$label"
-  local step_file current_label failures=0
+  local step_file current_label failures=0 signature
 
   rm -rf "$steps_dir"
   mkdir -p "$steps_dir"
@@ -171,13 +225,19 @@ PYTHON
 
     if "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$step_file" \
          > "$WORK_DIR/step.log" 2>&1; then
-      printf 'PASS\t%s\n' "$current_label" >> "$results_file"
+      printf 'PASS\t%s\t\n' "$current_label" >> "$results_file"
       echo "  PASS  $current_label"
     else
-      printf 'FAIL\t%s\n' "$current_label" >> "$results_file"
+      signature="$(error_signature "$WORK_DIR/step.log")"
+      printf 'FAIL\t%s\t%s\n' "$current_label" "$signature" >> "$results_file"
       echo "  FAIL  $current_label"
-      # Keep the error text; it is what a reviewer needs to see.
-      sed 's/^/        /' "$WORK_DIR/step.log" | tail -25
+      # Surface the diagnostics themselves, not a blind tail: these procs print
+      # result sets, so the error scrolls out of view long before the end.
+      {
+        grep -E -A2 '^(Msg [0-9]+,|Sqlcmd: Error)' "$WORK_DIR/step.log" | head -24 || true
+        echo "--- last lines ---"
+        tail -6 "$WORK_DIR/step.log"
+      } | sed 's/^/        /'
       failures=$((failures + 1))
     fi
   done
@@ -188,7 +248,13 @@ PYTHON
 # ---------------------------------------------------------------------------
 # sp_Blitz findings, captured through the @Output* table path so that code path
 # gets exercised too. Ordered so the two passes are directly comparable.
+#
+# Findings whose text embeds a timestamp or other per-run value are excluded --
+# CheckID 156 puts GETDATE() straight into Finding, so leaving it in would report
+# a removal and an addition on every single run and bury any real change.
 # ---------------------------------------------------------------------------
+VOLATILE_CHECK_IDS="156"
+
 capture_findings() {
   local destination="$1"
 
@@ -213,12 +279,17 @@ SELECT CONVERT(VARCHAR(10), CheckID)
        + '|' + ISNULL(DatabaseName, '(server)')
        + '|' + ISNULL(Finding, '')
 FROM dbo.BlitzFindings
+WHERE CheckID NOT IN ($VOLATILE_CHECK_IDS)
 ORDER BY CheckID, DatabaseName, Finding;
 " | sed '/^$/d;/rows affected/d' | sort -u > "$destination"
 }
 
 # ---------------------------------------------------------------------------
 # Reset mutable state between passes so the two runs see the same server.
+#
+# Anything a matrix step can create has to be listed here, or the head pass
+# skips the create path the base pass already took and the comparison quietly
+# stops testing it.
 # ---------------------------------------------------------------------------
 reset_between_passes() {
   run_query "
@@ -235,10 +306,20 @@ DECLARE @drop NVARCHAR(MAX) = N'';
 SELECT @drop = @drop + N'DROP TABLE FRKSmokeTest.dbo.' + QUOTENAME(name) + N';'
 FROM FRKSmokeTest.sys.tables
 WHERE name IN (N'BlitzOutput', N'BlitzCache', N'BlitzFirst', N'BlitzFirst_FileStats',
-               N'BlitzFirst_PerfmonStats', N'BlitzFirst_WaitStats', N'BlitzWho',
+               N'BlitzFirst_PerfmonStats', N'BlitzFirst_WaitStats',
+               N'BlitzFirst_WaitStats_Categories', N'BlitzWho',
                N'BlitzWho_Results', N'BlitzLock', N'BlitzIndex', N'BlitzFindings');
 
 IF @drop <> N'' EXEC sys.sp_executesql @drop;
+
+/* sp_BlitzLock creates synonyms when logging to a table. */
+DECLARE @dropsyn NVARCHAR(MAX) = N'';
+
+SELECT @dropsyn = @dropsyn + N'DROP SYNONYM ' + QUOTENAME(name) + N';'
+FROM sys.synonyms
+WHERE name IN (N'DeadlockFindings', N'DeadLockTbl');
+
+IF @dropsyn <> N'' EXEC sys.sp_executesql @dropsyn;
 " >/dev/null
 }
 
@@ -246,6 +327,22 @@ IF @drop <> N'' EXEC sys.sp_executesql @drop;
 # Main
 # ---------------------------------------------------------------------------
 wait_for_sql_server
+wait_for_wait_stats
+
+# sp_DatabaseRestore aborts immediately unless Ola Hallengren's CommandExecute
+# exists in the calling database, so its execute path is untestable without it.
+# The workflow downloads and checksums the file; installing it has to wait until
+# the instance is accepting connections, so it happens here.
+if [[ -n "${COMMANDEXECUTE_SQL:-}" ]]; then
+  if [[ -f "$COMMANDEXECUTE_SQL" ]]; then
+    echo
+    echo "=== Installing CommandExecute (sp_DatabaseRestore dependency) ==="
+    run_file "$COMMANDEXECUTE_SQL"
+  else
+    echo "::error::COMMANDEXECUTE_SQL is set to '$COMMANDEXECUTE_SQL' but that file does not exist." >&2
+    exit 1
+  fi
+fi
 
 echo
 echo "=== Seeding test data ==="
@@ -271,6 +368,7 @@ else
   echo "No usable base revision (GITHUB_BASE_SHA/GITHUB_BASE_REF); skipping the"
   echo "comparison pass and checking this branch for errors only."
   : > "$WORK_DIR/base-results.txt"
+  : > "$WORK_DIR/base-findings.txt"
 fi
 
 echo
@@ -316,29 +414,42 @@ fi
 
 # ---------------------------------------------------------------------------
 # Report: errors decide the build
+#
+# A head failure counts as pre-existing only when the same step failed on base
+# with the same diagnostics. A step that fails on base for one reason and on
+# head for another is a new error.
 # ---------------------------------------------------------------------------
 echo
 echo "=== Errors ==="
 
-head_failures="$(awk -F'\t' '$1 == "FAIL" { print $2 }' "$WORK_DIR/head-results.txt" || true)"
-base_failures="$(awk -F'\t' '$1 == "FAIL" { print $2 }' "$WORK_DIR/base-results.txt" || true)"
-
 new_failures=""
-while IFS= read -r failing_step; do
-  [[ -n "$failing_step" ]] || continue
-  if ! grep -Fxq "$failing_step" <<< "$base_failures"; then
-    new_failures+="$failing_step"$'\n'
-  fi
-done <<< "$head_failures"
+pre_existing=""
 
-pre_existing="$(comm -12 <(sort <<< "$head_failures") <(sort <<< "$base_failures") | sed '/^$/d' || true)"
+while IFS=$'\t' read -r status step_label head_signature; do
+  [[ "$status" == "FAIL" ]] || continue
+
+  base_signature="$(awk -F'\t' -v want="$step_label" \
+    '$1 == "FAIL" && $2 == want { print $3; exit }' "$WORK_DIR/base-results.txt")"
+
+  if [[ -n "$base_signature" && "$base_signature" == "$head_signature" ]]; then
+    pre_existing+="$step_label -- $head_signature"$'\n'
+  else
+    if [[ -n "$base_signature" ]]; then
+      new_failures+="$step_label -- error changed: base [$base_signature] head [$head_signature]"$'\n'
+    else
+      new_failures+="$step_label -- $head_signature"$'\n'
+    fi
+  fi
+done < "$WORK_DIR/head-results.txt"
+
+pre_existing="$(sed '/^$/d' <<< "$pre_existing")"
+new_failures="$(sed '/^$/d' <<< "$new_failures")"
 
 if [[ -n "$pre_existing" ]]; then
-  echo "Already failing on base -- not caused by this branch:"
+  echo "Already failing on base with the same error -- not caused by this branch:"
   sed 's/^/  ~ /' <<< "$pre_existing"
 fi
 
-new_failures="$(sed '/^$/d' <<< "$new_failures")"
 if [[ -n "$new_failures" ]]; then
   echo
   echo "::error::This branch introduces SQL errors in $(wc -l <<< "$new_failures" | tr -d ' ') step(s)."

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -204,6 +204,10 @@ with open(matrix_path, encoding="utf-8") as handle:
 if label is not None:
     steps.append((label, "".join(buf)))
 
+duplicates = {label for label, _ in steps if [l for l, _ in steps].count(label) > 1}
+if duplicates:
+    sys.exit("Duplicate --#STEP: labels in the matrix: " + ", ".join(sorted(duplicates)))
+
 for index, (step_label, body) in enumerate(steps):
     with open(os.path.join(steps_dir, f"{index:03d}.sql"), "w", encoding="utf-8") as handle:
         handle.write(body)

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -72,6 +72,15 @@ run_file() {
   "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$1"
 }
 
+# Single bare value, no headers or row counts. run_query cannot do this: it only
+# forwards "$1", so any extra sqlcmd flags handed to it are silently dropped.
+run_scalar() {
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -h -1 -W -Q "$1" 2>/dev/null \
+    | sed '/^$/d;/rows affected/d' \
+    | head -1 \
+    | tr -d '[:space:]'
+}
+
 # ---------------------------------------------------------------------------
 # Wait for the container
 # ---------------------------------------------------------------------------
@@ -106,18 +115,28 @@ wait_for_sql_server() {
 # on how long the container took to start, so it fires on whichever pass happens
 # to run first and shows up as a spurious base-vs-head difference. Waiting the
 # window out keeps the two passes comparable. Remove this once #4048 is fixed.
+#
+# The value must parse as a number greater than zero. Anything else -- an empty
+# result, a header line, an error -- means we have not confirmed the window has
+# passed, so keep waiting rather than assuming the best.
 # ---------------------------------------------------------------------------
 wait_for_wait_stats() {
+  local uptime_minutes
+
   echo "Waiting for the instance to pass one minute of uptime (issue #4048)..."
   for attempt in {1..40}; do
-    if [[ "$(run_query "SET NOCOUNT ON;
+    uptime_minutes="$(run_scalar "SET NOCOUNT ON;
 SELECT DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP)
-FROM sys.databases WHERE name = 'tempdb';" -h -1 -W 2>/dev/null | head -1 | tr -d '[:space:]')" != "0" ]]; then
-      echo "Uptime window cleared."
+FROM sys.databases WHERE name = 'tempdb';")"
+
+    if [[ "$uptime_minutes" =~ ^[0-9]+$ ]] && (( uptime_minutes > 0 )); then
+      echo "Uptime window cleared after ${attempt} check(s) (${uptime_minutes} minute(s) up)."
       return 0
     fi
+
     sleep 5
   done
+
   echo "::warning::Instance still reports under a minute of uptime; continuing anyway."
 }
 
@@ -142,11 +161,11 @@ materialise_kit() {
 }
 
 install_kit() {
-  local dir="$1" script
+  local dir="$1" quiet="${2:-}" script
 
   for script in "${KIT_SCRIPTS[@]}"; do
     [[ -f "$dir/$script" ]] || continue
-    echo "  installing $script"
+    [[ -n "$quiet" ]] || echo "  installing $script"
     if ! run_file "$dir/$script" > "$WORK_DIR/install.log" 2>&1; then
       echo "::error::Failed to install $script"
       cat "$WORK_DIR/install.log"
@@ -160,34 +179,50 @@ install_kit() {
 #
 # Comparing failure *labels* alone would turn every step that fails on base into
 # a permanent allowlist entry: a PR could introduce a completely different error
-# inside that step and stay green. Comparing the diagnostics instead means only
-# the identical error is treated as pre-existing.
+# inside that step and stay green.
 #
-# Server name and line numbers are stripped -- the container's hostname is random
-# per run, and a line number shifting is exactly the kind of change a PR makes
-# without changing the error itself.
+# The message text has to be part of the signature, not just the number. Msg
+# 50000 is whatever RAISERROR was handed, and CommandExecute alone raises it for
+# many unrelated validation failures -- keyed on the number only, a step could
+# change from one Msg 50000 to a completely different one and still look
+# unchanged.
+#
+# Stripped, because they move without the error changing: server name (random
+# container hostname), Procedure/Line (shift whenever a PR edits the file above
+# them), and any quoted literal (file paths and object names vary per run).
 # ---------------------------------------------------------------------------
 error_signature() {
-  grep -oE '^(Msg [0-9]+, Level [0-9]+, State [0-9]+|Sqlcmd: Error)[^,]*' "$1" 2>/dev/null \
-    | sed -E 's/, Server [^,]+//; s/, (Procedure|Line) [^,]*//g' \
+  awk '
+    /^Msg [0-9]+, Level [0-9]+, State [0-9]+/ {
+      header = $0
+      if ((getline detail) > 0) { print header " :: " detail } else { print header }
+      next
+    }
+    /^Sqlcmd: Error/ { print }
+  ' "$1" 2>/dev/null \
+    | sed -E "s/, Server [^,]+,/,/; s/, Procedure [^,]+,/,/; s/, Line [0-9]+//" \
+    | sed -E "s/'[^']*'/'X'/g" \
     | sort -u \
     | tr '\n' ';' \
     || true
 }
 
-# ---------------------------------------------------------------------------
-# Split the matrix on --#STEP: markers and run each step on its own.
-#
-# Each step runs separately so one failure is attributed to one labelled step
-# and the rest of the matrix still runs -- we want every problem in a single CI
-# round, not just the first.
-#
-# Writes "<status><TAB><label><TAB><error signature>" per step.
-# ---------------------------------------------------------------------------
-run_matrix() {
-  local label="$1" results_file="$2"
-  local steps_dir="$WORK_DIR/steps-$label"
-  local step_file current_label failures=0 signature
+# Run one step file. Sets STEP_SIGNATURE; returns non-zero if the step failed.
+STEP_SIGNATURE=""
+run_one_step() {
+  local step_file="$1" log_file="$2"
+
+  if "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$step_file" > "$log_file" 2>&1; then
+    STEP_SIGNATURE=""
+    return 0
+  fi
+
+  STEP_SIGNATURE="$(error_signature "$log_file")"
+  return 1
+}
+
+split_matrix() {
+  local steps_dir="$1"
 
   rm -rf "$steps_dir"
   mkdir -p "$steps_dir"
@@ -217,19 +252,30 @@ for index, (step_label, body) in enumerate(steps):
     with open(os.path.join(steps_dir, f"{index:03d}.label"), "w", encoding="utf-8") as handle:
         handle.write(step_label)
 PYTHON
+}
+
+# ---------------------------------------------------------------------------
+# Run every step on its own, so one failure is attributed to one labelled step
+# and the rest of the matrix still runs. One CI round should surface every
+# problem, not just the first.
+#
+# Writes "<status><TAB><label><TAB><signature><TAB><step file>" per step.
+# ---------------------------------------------------------------------------
+run_matrix() {
+  local pass_name="$1" results_file="$2"
+  local steps_dir="$WORK_DIR/steps"
+  local step_file current_label failures=0
 
   : > "$results_file"
 
   for step_file in "$steps_dir"/*.sql; do
     current_label="$(cat "${step_file%.sql}.label")"
 
-    if "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$step_file" \
-         > "$WORK_DIR/step.log" 2>&1; then
-      printf 'PASS\t%s\t\n' "$current_label" >> "$results_file"
+    if run_one_step "$step_file" "$WORK_DIR/step.log"; then
+      printf 'PASS\t%s\t\t%s\n' "$current_label" "$step_file" >> "$results_file"
       echo "  PASS  $current_label"
     else
-      signature="$(error_signature "$WORK_DIR/step.log")"
-      printf 'FAIL\t%s\t%s\n' "$current_label" "$signature" >> "$results_file"
+      printf 'FAIL\t%s\t%s\t%s\n' "$current_label" "$STEP_SIGNATURE" "$step_file" >> "$results_file"
       echo "  FAIL  $current_label"
       # Surface the diagnostics themselves, not a blind tail: these procs print
       # result sets, so the error scrolls out of view long before the end.
@@ -242,7 +288,7 @@ PYTHON
     fi
   done
 
-  echo "  $label: $failures failing step(s)"
+  echo "  $pass_name: $failures failing step(s)"
 }
 
 # ---------------------------------------------------------------------------
@@ -295,7 +341,8 @@ ORDER BY CheckID, DatabaseName, Finding;
 #
 # Anything a matrix step can create has to be listed here, or the head pass
 # skips the create path the base pass already took and the comparison quietly
-# stops testing it.
+# stops testing it. BlitzChecksToSkip is deliberately NOT dropped -- the seed
+# creates it once and both passes need it.
 # ---------------------------------------------------------------------------
 reset_between_passes() {
   run_query "
@@ -335,24 +382,28 @@ IF @dropsyn <> N'' EXEC sys.sp_executesql @dropsyn;
 wait_for_sql_server
 wait_for_wait_stats
 
-# sp_DatabaseRestore aborts immediately unless Ola Hallengren's CommandExecute
-# exists in the calling database, so its execute path is untestable without it.
-# The workflow downloads and checksums the file; installing it has to wait until
-# the instance is accepting connections, so it happens here.
-if [[ -n "${COMMANDEXECUTE_SQL:-}" ]]; then
-  if [[ -f "$COMMANDEXECUTE_SQL" ]]; then
-    echo
-    echo "=== Installing CommandExecute (sp_DatabaseRestore dependency) ==="
-    run_file "$COMMANDEXECUTE_SQL"
-  else
-    echo "::error::COMMANDEXECUTE_SQL is set to '$COMMANDEXECUTE_SQL' but that file does not exist." >&2
+# sp_DatabaseRestore aborts unless Ola Hallengren's CommandExecute exists in the
+# calling database, and CommandExecute in turn refuses @LogToTable = 'Y' unless
+# dbo.CommandLog exists -- sp_DatabaseRestore always passes 'Y'. Both are needed
+# or the restore path is untestable. The workflow downloads and checksums them;
+# installing has to wait until the instance is up, so it happens here. CommandLog
+# first: CommandExecute checks for it at runtime.
+for dependency in "${COMMANDLOG_SQL:-}" "${COMMANDEXECUTE_SQL:-}"; do
+  [[ -n "$dependency" ]] || continue
+  if [[ ! -f "$dependency" ]]; then
+    echo "::error::Expected dependency '$dependency' does not exist." >&2
     exit 1
   fi
-fi
+  echo
+  echo "=== Installing $(basename "$dependency") (sp_DatabaseRestore dependency) ==="
+  run_file "$dependency"
+done
 
 echo
 echo "=== Seeding test data ==="
 run_file "$SEED_SQL"
+
+split_matrix "$WORK_DIR/steps"
 
 BASE_REVISION="${GITHUB_BASE_SHA:-}"
 if [[ -z "$BASE_REVISION" && -n "${GITHUB_BASE_REF:-}" ]]; then
@@ -422,16 +473,23 @@ fi
 # Report: errors decide the build
 #
 # A head failure counts as pre-existing only when the same step failed on base
-# with the same diagnostics. A step that fails on base for one reason and on
-# head for another is a new error.
+# with the same diagnostics.
+#
+# A first-attempt mismatch is not enough to blame the PR. The two passes run
+# minutes apart against one server whose state keeps moving, and transient
+# errors -- a torn default-trace read, a plan aged out mid-step -- land on
+# whichever pass is unlucky. That produced a red build on a PR that changed no
+# stored procedure at all. So every mismatch is re-confirmed before it counts:
+# retry on head, and if it still fails, put base's copies back and run it there
+# too. Only a failure that survives both is attributed to this branch.
 # ---------------------------------------------------------------------------
 echo
 echo "=== Errors ==="
 
-new_failures=""
+mismatches=""
 pre_existing=""
 
-while IFS=$'\t' read -r status step_label head_signature; do
+while IFS=$'\t' read -r status step_label head_signature step_file; do
   [[ "$status" == "FAIL" ]] || continue
 
   base_signature="$(awk -F'\t' -v want="$step_label" \
@@ -440,18 +498,60 @@ while IFS=$'\t' read -r status step_label head_signature; do
   if [[ -n "$base_signature" && "$base_signature" == "$head_signature" ]]; then
     pre_existing+="$step_label -- $head_signature"$'\n'
   else
-    if [[ -n "$base_signature" ]]; then
-      new_failures+="$step_label -- error changed: base [$base_signature] head [$head_signature]"$'\n'
-    else
-      new_failures+="$step_label -- $head_signature"$'\n'
-    fi
+    mismatches+="$step_label"$'\t'"$head_signature"$'\t'"$step_file"$'\t'"$base_signature"$'\n'
   fi
 done < "$WORK_DIR/head-results.txt"
+
+mismatches="$(sed '/^$/d' <<< "$mismatches")"
+new_failures=""
+
+if [[ -n "$mismatches" ]]; then
+  echo "Re-confirming $(wc -l <<< "$mismatches" | tr -d ' ') mismatch(es) before attributing them to this branch..."
+
+  # Round 1: does it still fail on head?
+  still_failing=""
+  while IFS=$'\t' read -r step_label head_signature step_file base_signature; do
+    [[ -n "$step_label" ]] || continue
+    if run_one_step "$step_file" "$WORK_DIR/recheck.log"; then
+      echo "  transient: '$step_label' passed on retry against this branch -- not a regression"
+    else
+      still_failing+="$step_label"$'\t'"$STEP_SIGNATURE"$'\t'"$step_file"$'\t'"$base_signature"$'\n'
+    fi
+  done <<< "$mismatches"
+
+  still_failing="$(sed '/^$/d' <<< "$still_failing")"
+
+  # Round 2: reinstall base and see whether it fails there too, now.
+  if [[ -n "$still_failing" && "$base_ran" -eq 1 ]]; then
+    echo "  reinstalling base to re-test $(wc -l <<< "$still_failing" | tr -d ' ') step(s) against it..."
+    install_kit "$WORK_DIR/base" quiet
+
+    while IFS=$'\t' read -r step_label head_signature step_file base_signature; do
+      [[ -n "$step_label" ]] || continue
+      if run_one_step "$step_file" "$WORK_DIR/recheck-base.log"; then
+        new_failures+="$step_label -- $head_signature"$'\n'
+      elif [[ "$STEP_SIGNATURE" == "$head_signature" ]]; then
+        echo "  environmental: '$step_label' fails the same way on base when re-run -- not a regression"
+        pre_existing+="$step_label -- $head_signature (confirmed on re-run)"$'\n'
+      else
+        new_failures+="$step_label -- error changed: base [$STEP_SIGNATURE] head [$head_signature]"$'\n'
+      fi
+    done <<< "$still_failing"
+
+    install_kit "$REPO_ROOT" quiet
+  elif [[ -n "$still_failing" ]]; then
+    while IFS=$'\t' read -r step_label head_signature _ _; do
+      [[ -n "$step_label" ]] || continue
+      new_failures+="$step_label -- $head_signature"$'\n'
+    done <<< "$still_failing"
+  fi
+fi
 
 pre_existing="$(sed '/^$/d' <<< "$pre_existing")"
 new_failures="$(sed '/^$/d' <<< "$new_failures")"
 
 if [[ -n "$pre_existing" ]]; then
+  echo
   echo "Already failing on base with the same error -- not caused by this branch:"
   sed 's/^/  ~ /' <<< "$pre_existing"
 fi
@@ -463,6 +563,7 @@ if [[ -n "$new_failures" ]]; then
   {
     echo "### New SQL errors on \`${MSSQL_IMAGE:-this image}\`"
     echo
+    echo "Each was re-run against this branch and against base before being reported."
     echo '```'
     echo "$new_failures"
     echo '```'

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -500,39 +500,43 @@ BEGIN
     DROP DATABASE FRKSmokeTestRestored;
 END;
 
+/* Enumerated by naming convention rather than a hand-maintained list.
+
+   That list was wrong four times over: sp_BlitzLock's synonyms, sp_BlitzFirst's
+   four views, sp_BlitzWho's two, and sp_BlitzLock's BlitzLockFindings. Any proc
+   taking @OutputTableName can create objects derived from it, so naming them one
+   at a time is structurally the losing approach -- every new output path is a
+   silent gap until someone notices the head pass skipped its create branch.
+
+   Everything the kit writes into this database is Blitz-prefixed. The seed's own
+   tables (Users, Posts, CommentsHeap) are not, so they survive; BlitzChecksToSkip
+   is the one Blitz-prefixed object to keep, since the seed creates it once and
+   both passes need it.
+
+   Views before tables: dropping a table first would leave its view orphaned.
+   Both go through the target database's own sp_executesql because DROP VIEW
+   rejects a three-part name (Msg 166), unlike DROP TABLE. */
 DECLARE @drop NVARCHAR(MAX) = N'';
 
-SELECT @drop = @drop + N'DROP TABLE FRKSmokeTest.dbo.' + QUOTENAME(name) + N';'
-FROM FRKSmokeTest.sys.tables
-WHERE name IN (N'BlitzOutput', N'BlitzCache', N'BlitzFirst', N'BlitzFirst_FileStats',
-               N'BlitzFirst_PerfmonStats', N'BlitzFirst_WaitStats',
-               N'BlitzFirst_WaitStats_Categories', N'BlitzWho',
-               N'BlitzWho_Results', N'BlitzLock', N'BlitzIndex', N'BlitzFindings');
-
-/* sp_BlitzFirst's logging path also creates views alongside each table:
-   <FileStats>_Deltas, <PerfmonStats>_Deltas, <PerfmonStats>_Actuals and
-   <WaitStats>_Deltas. Dropping only the tables would leave the base pass's
-   views in place, so the head pass would skip all four view-creation paths. */
-DECLARE @dropview NVARCHAR(MAX) = N'';
-
-/* DROP VIEW rejects a three-part name -- 'DROP VIEW' does not allow specifying
-   the database name as a prefix (Msg 166), unlike DROP TABLE, which accepts one.
-   So the statement is built with two-part names and executed inside the target
-   database via its own sp_executesql. */
-SELECT @dropview = @dropview + N'DROP VIEW dbo.' + QUOTENAME(name) + N';'
+SELECT @drop = @drop + N'DROP VIEW dbo.' + QUOTENAME(name) + N';'
 FROM FRKSmokeTest.sys.views
-WHERE name IN (N'BlitzFirst_FileStats_Deltas', N'BlitzFirst_PerfmonStats_Deltas',
-               N'BlitzFirst_PerfmonStats_Actuals', N'BlitzFirst_WaitStats_Deltas',
-               /* sp_BlitzWho makes <table>_Deltas for whatever table it logs to,
-                  once via sp_BlitzFirst's @OutputTableNameBlitzWho and once from
-                  the direct sp_BlitzWho step. */
-               N'BlitzWho_Deltas', N'BlitzWho_Results_Deltas')
+WHERE name LIKE N'Blitz%'
+  AND name <> N'BlitzChecksToSkip'
   AND SCHEMA_NAME(schema_id) = N'dbo';
 
-IF @dropview <> N'' EXEC FRKSmokeTest.sys.sp_executesql @dropview;
-IF @drop <> N'' EXEC sys.sp_executesql @drop;
+IF @drop <> N'' EXEC FRKSmokeTest.sys.sp_executesql @drop;
 
-/* sp_BlitzLock creates synonyms when logging to a table. */
+SET @drop = N'';
+
+SELECT @drop = @drop + N'DROP TABLE dbo.' + QUOTENAME(name) + N';'
+FROM FRKSmokeTest.sys.tables
+WHERE name LIKE N'Blitz%'
+  AND name <> N'BlitzChecksToSkip'
+  AND SCHEMA_NAME(schema_id) = N'dbo';
+
+IF @drop <> N'' EXEC FRKSmokeTest.sys.sp_executesql @drop;
+
+/* sp_BlitzLock's synonyms, which are not Blitz-prefixed. */
 DECLARE @dropsyn NVARCHAR(MAX) = N'';
 
 SELECT @dropsyn = @dropsyn + N'DROP SYNONYM ' + QUOTENAME(name) + N';'
@@ -738,7 +742,8 @@ if [[ -n "$mismatches" ]]; then
 
       if [[ "$rebase_status" == "PASS" ]]; then
         new_failures+="$step_label -- $head_signature"$'\n'
-      elif [[ "$rebase_signature" == "$head_signature" ]] \
+      elif [[ -n "$rebase_signature" ]] \
+           && [[ "$rebase_signature" == "$head_signature" ]] \
            && [[ "$harness_unchanged" -eq 1 ]] \
            && step_unchanged_from_base "$step_label" "$step_file"; then
         echo "  environmental: '$step_label' fails the same way on base when replayed -- not a regression"

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -138,9 +138,12 @@ wait_for_wait_stats() {
 
   echo "Waiting for the instance to pass one minute of uptime (issue #4048)..."
   for attempt in {1..40}; do
+    # `|| true` matters: under set -e a failed command substitution aborts the
+    # script, which would contradict the contract above that an error means
+    # "not yet confirmed, keep waiting".
     uptime_minutes="$(run_scalar "SET NOCOUNT ON;
 SELECT DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP)
-FROM sys.databases WHERE name = 'tempdb';")"
+FROM sys.databases WHERE name = 'tempdb';" || true)"
 
     if [[ "$uptime_minutes" =~ ^[0-9]+$ ]] && (( uptime_minutes > 0 )); then
       echo "Uptime window cleared after ${attempt} check(s) (${uptime_minutes} minute(s) up)."
@@ -202,7 +205,7 @@ verify_kit_installed() {
     [[ -f "$dir/$script" ]] || continue
     proc="$(kit_proc_name "$script")"
     if [[ "$(run_scalar "SET NOCOUNT ON;
-SELECT CASE WHEN OBJECT_ID('dbo.$proc', 'P') IS NULL THEN 'MISSING' ELSE 'OK' END;")" != "OK" ]]; then
+SELECT CASE WHEN OBJECT_ID('dbo.$proc', 'P') IS NULL THEN 'MISSING' ELSE 'OK' END;" || true)" != "OK" ]]; then
       missing+="$proc "
     fi
   done
@@ -500,7 +503,11 @@ DECLARE @dropview NVARCHAR(MAX) = N'';
 SELECT @dropview = @dropview + N'DROP VIEW dbo.' + QUOTENAME(name) + N';'
 FROM FRKSmokeTest.sys.views
 WHERE name IN (N'BlitzFirst_FileStats_Deltas', N'BlitzFirst_PerfmonStats_Deltas',
-               N'BlitzFirst_PerfmonStats_Actuals', N'BlitzFirst_WaitStats_Deltas')
+               N'BlitzFirst_PerfmonStats_Actuals', N'BlitzFirst_WaitStats_Deltas',
+               /* sp_BlitzWho makes <table>_Deltas for whatever table it logs to,
+                  once via sp_BlitzFirst's @OutputTableNameBlitzWho and once from
+                  the direct sp_BlitzWho step. */
+               N'BlitzWho_Deltas', N'BlitzWho_Results_Deltas')
   AND SCHEMA_NAME(schema_id) = N'dbo';
 
 IF @dropview <> N'' EXEC FRKSmokeTest.sys.sp_executesql @dropview;
@@ -651,6 +658,11 @@ echo "=== Errors ==="
 mismatches=""
 pre_existing=""
 
+# Look up one label's outcome in a results file: "<status><TAB><signature>".
+lookup_result() {
+  awk -F'\t' -v want="$2" '$2 == want { print $1 "\t" $3; exit }' "$1"
+}
+
 while IFS=$'\t' read -r status step_label head_signature step_file; do
   [[ "$status" == "FAIL" ]] || continue
 
@@ -670,40 +682,54 @@ mismatches="$(sed '/^$/d' <<< "$mismatches")"
 new_failures=""
 
 if [[ -n "$mismatches" ]]; then
-  echo "Re-confirming $(wc -l <<< "$mismatches" | tr -d ' ') mismatch(es) before attributing them to this branch..."
+  echo "Re-confirming $(wc -l <<< "$mismatches" | tr -d ' ') mismatch(es) before attributing them to this branch."
+  echo "Re-running the whole matrix rather than the failing steps alone: several steps"
+  echo "create persistent objects, so replaying one in place would let it skip the very"
+  echo "create branch that failed and look transient."
 
-  # Round 1: does it still fail on head?
+  # Round 1: the full matrix again on head, from the same reset state the
+  # original pass started from.
+  reset_between_passes
+  install_kit "$REPO_ROOT" quiet
+  run_matrix "head re-check" "$WORK_DIR/head-recheck.txt"
+
   still_failing=""
   while IFS=$'\t' read -r step_label head_signature step_file base_signature; do
     [[ -n "$step_label" ]] || continue
-    if run_one_step "$step_file" "$WORK_DIR/recheck.log"; then
-      echo "  transient: '$step_label' passed on retry against this branch -- not a regression"
+    IFS=$'\t' read -r recheck_status recheck_signature < <(lookup_result "$WORK_DIR/head-recheck.txt" "$step_label")
+    if [[ "$recheck_status" == "PASS" ]]; then
+      echo "  transient: '$step_label' passed when the matrix was replayed -- not a regression"
     else
-      still_failing+="$step_label"$'\t'"$STEP_SIGNATURE"$'\t'"$step_file"$'\t'"$base_signature"$'\n'
+      still_failing+="$step_label"$'\t'"$recheck_signature"$'\t'"$step_file"$'\t'"$base_signature"$'\n'
     fi
   done <<< "$mismatches"
 
   still_failing="$(sed '/^$/d' <<< "$still_failing")"
 
-  # Round 2: reinstall base and see whether it fails there too, now.
+  # Round 2: the full matrix against base, same way.
   if [[ -n "$still_failing" && "$base_ran" -eq 1 ]]; then
-    echo "  reinstalling base to re-test $(wc -l <<< "$still_failing" | tr -d ' ') step(s) against it..."
+    echo "  replaying the matrix against base for $(wc -l <<< "$still_failing" | tr -d ' ') step(s)..."
+    reset_between_passes
     install_kit "$WORK_DIR/base" quiet
+    run_matrix "base re-check" "$WORK_DIR/base-recheck.txt"
 
     while IFS=$'\t' read -r step_label head_signature step_file base_signature; do
       [[ -n "$step_label" ]] || continue
-      if run_one_step "$step_file" "$WORK_DIR/recheck-base.log"; then
+      IFS=$'\t' read -r rebase_status rebase_signature < <(lookup_result "$WORK_DIR/base-recheck.txt" "$step_label")
+
+      if [[ "$rebase_status" == "PASS" ]]; then
         new_failures+="$step_label -- $head_signature"$'\n'
-      elif [[ "$STEP_SIGNATURE" == "$head_signature" ]] \
+      elif [[ "$rebase_signature" == "$head_signature" ]] \
            && [[ "$harness_unchanged" -eq 1 ]] \
            && step_unchanged_from_base "$step_label" "$step_file"; then
-        echo "  environmental: '$step_label' fails the same way on base when re-run -- not a regression"
-        pre_existing+="$step_label -- $head_signature (confirmed on re-run)"$'\n'
+        echo "  environmental: '$step_label' fails the same way on base when replayed -- not a regression"
+        pre_existing+="$step_label -- $head_signature (confirmed on replay)"$'\n'
       else
-        new_failures+="$step_label -- error changed: base [$STEP_SIGNATURE] head [$head_signature]"$'\n'
+        new_failures+="$step_label -- error changed: base [$rebase_signature] head [$head_signature]"$'\n'
       fi
     done <<< "$still_failing"
 
+    # Leave this branch's procedures installed, so the job ends as it began.
     install_kit "$REPO_ROOT" quiet
   elif [[ -n "$still_failing" ]]; then
     while IFS=$'\t' read -r step_label head_signature _ _; do

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -329,14 +329,24 @@ run_matrix() {
 # ---------------------------------------------------------------------------
 VOLATILE_CHECK_IDS="156"
 
+# Returns non-zero, without aborting the job, when sp_Blitz cannot produce a
+# findings set. This runs the same full configuration the matrix just exercised,
+# so if sp_Blitz is failing -- including failing on base, before this branch is
+# involved at all -- this call fails too. Under `sqlcmd -b` and `set -e` that
+# would kill the run here, before the head pass, and the comparison logic that
+# exists to classify exactly that failure would never be reached. The findings
+# diff is informational, so losing it is survivable; losing the error
+# classification is not.
 capture_findings() {
   local destination="$1"
+
+  : > "$destination"
 
   run_query "
 SET NOCOUNT ON;
 IF OBJECT_ID('FRKSmokeTest.dbo.BlitzFindings') IS NOT NULL
     DROP TABLE FRKSmokeTest.dbo.BlitzFindings;
-" >/dev/null
+" >/dev/null 2>&1 || true
 
   # Carries the same skip list as the matrix steps. Without it the CheckID 106
   # trace-file race (issue #4050) could abort this run instead, which would kill
@@ -351,7 +361,10 @@ EXEC dbo.sp_Blitz
      @SkipChecksDatabase       = 'FRKSmokeTest',
      @SkipChecksSchema         = 'dbo',
      @SkipChecksTable          = 'BlitzChecksToSkip';
-" >/dev/null
+" >/dev/null 2>&1 || {
+    echo "  ::warning::sp_Blitz failed while capturing findings; the findings comparison will be skipped."
+    return 1
+  }
 
   "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -s '|' -Q "
 SET NOCOUNT ON;
@@ -361,7 +374,7 @@ SELECT CONVERT(VARCHAR(10), CheckID)
 FROM dbo.BlitzFindings
 WHERE CheckID NOT IN ($VOLATILE_CHECK_IDS)
 ORDER BY CheckID, DatabaseName, Finding;
-" | sed '/^$/d;/rows affected/d' | sort -u > "$destination"
+" 2>/dev/null | sed '/^$/d;/rows affected/d' | sort -u > "$destination" || return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -451,6 +464,8 @@ if [[ -z "$BASE_REVISION" && -n "${GITHUB_BASE_REF:-}" ]]; then
 fi
 
 base_ran=0
+base_findings_ok=0
+head_findings_ok=0
 if [[ -n "$BASE_REVISION" ]] && git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REVISION" >/dev/null; then
   echo
   echo "=== Pass 1: base ($BASE_REVISION) ==="
@@ -468,7 +483,8 @@ if [[ -n "$BASE_REVISION" ]] && git -C "$REPO_ROOT" rev-parse --verify --quiet "
   materialise_kit "$BASE_REVISION" "$WORK_DIR/base"
   install_kit "$WORK_DIR/base"
   run_matrix "base" "$WORK_DIR/base-results.txt"
-  capture_findings "$WORK_DIR/base-findings.txt"
+  base_findings_ok=1
+  capture_findings "$WORK_DIR/base-findings.txt" || base_findings_ok=0
   reset_between_passes
   base_ran=1
 else
@@ -483,14 +499,15 @@ echo
 echo "=== Pass 2: this branch ==="
 install_kit "$REPO_ROOT"
 run_matrix "head" "$WORK_DIR/head-results.txt"
-capture_findings "$WORK_DIR/head-findings.txt"
+head_findings_ok=1
+capture_findings "$WORK_DIR/head-findings.txt" || head_findings_ok=0
 
 # ---------------------------------------------------------------------------
 # Report: findings differences are informational
 # ---------------------------------------------------------------------------
 echo
 echo "=== sp_Blitz findings: base vs this branch ==="
-if [[ "$base_ran" -eq 1 ]]; then
+if [[ "$base_ran" -eq 1 && "$base_findings_ok" -eq 1 && "$head_findings_ok" -eq 1 ]]; then
   added="$(comm -13 "$WORK_DIR/base-findings.txt" "$WORK_DIR/head-findings.txt" || true)"
   removed="$(comm -23 "$WORK_DIR/base-findings.txt" "$WORK_DIR/head-findings.txt" || true)"
 
@@ -516,8 +533,17 @@ if [[ "$base_ran" -eq 1 ]]; then
       [[ -n "$added" ]] && { echo; echo "**Newly reported:**"; echo '```'; echo "$added"; echo '```'; }
     } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
   fi
-else
+elif [[ "$base_ran" -ne 1 ]]; then
   echo "Skipped (no base pass)."
+else
+  if [[ "$base_findings_ok" -ne 1 && "$head_findings_ok" -ne 1 ]]; then
+    echo "Skipped: sp_Blitz could not produce a findings set on either revision."
+  elif [[ "$base_findings_ok" -ne 1 ]]; then
+    echo "Skipped: sp_Blitz could not produce a findings set on base."
+  else
+    echo "Skipped: sp_Blitz could not produce a findings set on this branch."
+  fi
+  echo "The error classification below is unaffected."
 fi
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -452,7 +452,12 @@ EXEC dbo.sp_Blitz
     return 1
   }
 
-  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -s '|' -Q "
+  # -y 0 and -w 65535 matter: this output is parsed, not read. sqlcmd defaults to
+  # an 80-character screen width and truncates variable-length columns at 256,
+  # while a row here reaches ~340 (CheckID + NVARCHAR(128) DatabaseName +
+  # VARCHAR(200) Finding). Wrapped or clipped rows would make sort/comm compare
+  # fragments and quietly miss real differences.
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -y 0 -w 65535 -s '|' -Q "
 SET NOCOUNT ON;
 SELECT CONVERT(VARCHAR(10), CheckID)
        + '|' + ISNULL(DatabaseName, '(server)')

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -410,12 +410,17 @@ WHERE name IN (N'BlitzOutput', N'BlitzCache', N'BlitzFirst', N'BlitzFirst_FileSt
    views in place, so the head pass would skip all four view-creation paths. */
 DECLARE @dropview NVARCHAR(MAX) = N'';
 
-SELECT @dropview = @dropview + N'DROP VIEW FRKSmokeTest.dbo.' + QUOTENAME(name) + N';'
+/* DROP VIEW rejects a three-part name -- 'DROP VIEW' does not allow specifying
+   the database name as a prefix (Msg 166), unlike DROP TABLE, which accepts one.
+   So the statement is built with two-part names and executed inside the target
+   database via its own sp_executesql. */
+SELECT @dropview = @dropview + N'DROP VIEW dbo.' + QUOTENAME(name) + N';'
 FROM FRKSmokeTest.sys.views
 WHERE name IN (N'BlitzFirst_FileStats_Deltas', N'BlitzFirst_PerfmonStats_Deltas',
-               N'BlitzFirst_PerfmonStats_Actuals', N'BlitzFirst_WaitStats_Deltas');
+               N'BlitzFirst_PerfmonStats_Actuals', N'BlitzFirst_WaitStats_Deltas')
+  AND SCHEMA_NAME(schema_id) = N'dbo';
 
-IF @dropview <> N'' EXEC sys.sp_executesql @dropview;
+IF @dropview <> N'' EXEC FRKSmokeTest.sys.sp_executesql @dropview;
 IF @drop <> N'' EXEC sys.sp_executesql @drop;
 
 /* sp_BlitzLock creates synonyms when logging to a table. */

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -264,13 +264,19 @@ IF OBJECT_ID('FRKSmokeTest.dbo.BlitzFindings') IS NOT NULL
     DROP TABLE FRKSmokeTest.dbo.BlitzFindings;
 " >/dev/null
 
+  # Carries the same skip list as the matrix steps. Without it the CheckID 106
+  # trace-file race (issue #4050) could abort this run instead, which would kill
+  # the whole script rather than one labelled step.
   run_query "
 EXEC dbo.sp_Blitz
      @CheckUserDatabaseObjects = 1,
      @CheckServerInfo          = 1,
      @OutputDatabaseName       = 'FRKSmokeTest',
      @OutputSchemaName         = 'dbo',
-     @OutputTableName          = 'BlitzFindings';
+     @OutputTableName          = 'BlitzFindings',
+     @SkipChecksDatabase       = 'FRKSmokeTest',
+     @SkipChecksSchema         = 'dbo',
+     @SkipChecksTable          = 'BlitzChecksToSkip';
 " >/dev/null
 
   "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -s '|' -Q "

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -30,6 +30,18 @@ SEED_SQL="$SCRIPT_DIR/smoke-test-seed.sql"
 MATRIX_SQL="$SCRIPT_DIR/smoke-test-matrix.sql"
 MATRIX_REL_PATH=".github/scripts/smoke-test-matrix.sql"
 
+# Everything that shapes how a step runs. If the PR touches any of it, no
+# failure may be grandfathered: both passes use THIS branch's harness, so a
+# change that breaks it -- dropping -I, say -- breaks unchanged steps against
+# base and head alike and would otherwise be waved through as pre-existing.
+HARNESS_FILES=(
+  ".github/scripts/run-sql-server-smoke-tests.sh"
+  ".github/scripts/smoke-test-seed.sql"
+  ".github/scripts/smoke-test-matrix.sql"
+  ".github/workflows/sql-server-smoke-tests.yml"
+)
+harness_unchanged=0
+
 # Every non-deprecated script in the kit. sp_BlitzUpdate is deliberately absent:
 # it rewrites the procs mid-run, which would invalidate every later step and the
 # base-vs-head comparison (issue #4046, decision 4).
@@ -161,8 +173,50 @@ materialise_kit() {
   done
 }
 
+kit_proc_name() {
+  basename "$1" .sql
+}
+
+# Each pass starts from absent kit objects.
+#
+# Otherwise the previous pass's procedures survive: a script deleted on head is
+# silently skipped by the install loop, and a script reduced to an empty file
+# still makes sqlcmd exit 0. Either way the head matrix would run the stale base
+# procedure and pass without ever touching the head artifact.
+drop_kit_objects() {
+  local script proc statements=""
+
+  for script in "${KIT_SCRIPTS[@]}"; do
+    proc="$(kit_proc_name "$script")"
+    statements+="IF OBJECT_ID('dbo.$proc', 'P') IS NOT NULL DROP PROCEDURE dbo.$proc;"
+  done
+
+  run_query "SET NOCOUNT ON; $statements" >/dev/null
+}
+
+# Installing without error is not proof the procedure exists.
+verify_kit_installed() {
+  local dir="$1" script proc missing=""
+
+  for script in "${KIT_SCRIPTS[@]}"; do
+    [[ -f "$dir/$script" ]] || continue
+    proc="$(kit_proc_name "$script")"
+    if [[ "$(run_scalar "SET NOCOUNT ON;
+SELECT CASE WHEN OBJECT_ID('dbo.$proc', 'P') IS NULL THEN 'MISSING' ELSE 'OK' END;")" != "OK" ]]; then
+      missing+="$proc "
+    fi
+  done
+
+  if [[ -n "$missing" ]]; then
+    echo "::error::Installed without error but these procedures do not exist: $missing"
+    return 1
+  fi
+}
+
 install_kit() {
   local dir="$1" quiet="${2:-}" script
+
+  drop_kit_objects
 
   for script in "${KIT_SCRIPTS[@]}"; do
     [[ -f "$dir/$script" ]] || continue
@@ -173,6 +227,8 @@ install_kit() {
       return 1
     fi
   done
+
+  verify_kit_installed "$dir"
 }
 
 # ---------------------------------------------------------------------------
@@ -189,8 +245,15 @@ install_kit() {
 # unchanged.
 #
 # Stripped, because they move without the error changing: server name (random
-# container hostname), Procedure/Line (shift whenever a PR edits the file above
-# them), and any quoted literal (file paths and object names vary per run).
+# container hostname) and Procedure/Line (shift whenever a PR edits the file
+# above them).
+#
+# Quoted literals are NOT stripped wholesale. A quoted name is often the only
+# thing separating two errors -- Msg 208 for 'OldTable' and for 'NewTable' are
+# different bugs -- so blanking them all would let a real regression inherit a
+# grandfathered signature. Only quoted values containing a path separator are
+# normalised, which covers the volatile ones (rotating trace files, per-run
+# backup paths) and leaves deterministic identifiers intact.
 # ---------------------------------------------------------------------------
 error_signature() {
   awk '
@@ -202,7 +265,7 @@ error_signature() {
     /^Sqlcmd: Error/ { print }
   ' "$1" 2>/dev/null \
     | sed -E "s/, Server [^,]+,/,/; s/, Procedure [^,]+,/,/; s/, Line [0-9]+//" \
-    | sed -E "s/'[^']*'/'X'/g" \
+    | sed -E "s@'[^']*[/\\\\][^']*'@'PATH'@g" \
     | sort -u \
     | tr '\n' ';' \
     || true
@@ -218,6 +281,26 @@ error_signature() {
 # the same body, may be grandfathered; anything new or edited has to pass on its
 # own merits.
 # ---------------------------------------------------------------------------
+# Sets harness_unchanged. Any difference, or any file absent from base, means no.
+check_harness_unchanged() {
+  local revision="$1" file
+
+  for file in "${HARNESS_FILES[@]}"; do
+    if ! git -C "$REPO_ROOT" cat-file -e "$revision:$file" 2>/dev/null; then
+      echo "  harness file is new on this branch: $file"
+      harness_unchanged=0
+      return
+    fi
+    if ! git -C "$REPO_ROOT" show "$revision:$file" | cmp -s - "$REPO_ROOT/$file"; then
+      echo "  harness file changed on this branch: $file"
+      harness_unchanged=0
+      return
+    fi
+  done
+
+  harness_unchanged=1
+}
+
 step_unchanged_from_base() {
   local label="$1" head_file="$2" base_label_file
 
@@ -440,22 +523,12 @@ IF @dropsyn <> N'' EXEC sys.sp_executesql @dropsyn;
 wait_for_sql_server
 wait_for_wait_stats
 
-# sp_DatabaseRestore aborts unless Ola Hallengren's CommandExecute exists in the
-# calling database, and CommandExecute in turn refuses @LogToTable = 'Y' unless
-# dbo.CommandLog exists -- sp_DatabaseRestore always passes 'Y'. Both are needed
-# or the restore path is untestable. The workflow downloads and checksums them;
-# installing has to wait until the instance is up, so it happens here. CommandLog
-# first: CommandExecute checks for it at runtime.
-for dependency in "${COMMANDLOG_SQL:-}" "${COMMANDEXECUTE_SQL:-}"; do
-  [[ -n "$dependency" ]] || continue
-  if [[ ! -f "$dependency" ]]; then
-    echo "::error::Expected dependency '$dependency' does not exist." >&2
-    exit 1
-  fi
-  echo
-  echo "=== Installing $(basename "$dependency") (sp_DatabaseRestore dependency) ==="
-  run_file "$dependency"
-done
+# sp_DatabaseRestore's dependencies (Ola Hallengren's CommandLog and
+# CommandExecute) are deliberately NOT installed: the only invocation left is
+# @Help = 1, which returns at sp_DatabaseRestore.sql:71, long before the
+# CommandExecute check at :255. Fetching them would add two network downloads
+# and two checksums that can redden every PR while exercising nothing. Restore
+# them alongside the execute-path step when #4049 lands.
 
 echo
 echo "=== Seeding test data ==="
@@ -474,6 +547,13 @@ head_findings_ok=0
 if [[ -n "$BASE_REVISION" ]] && git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REVISION" >/dev/null; then
   echo
   echo "=== Pass 1: base ($BASE_REVISION) ==="
+
+  check_harness_unchanged "$BASE_REVISION"
+  if [[ "$harness_unchanged" -eq 1 ]]; then
+    echo "  harness unchanged from base; unchanged steps may be grandfathered"
+  else
+    echo "  harness differs from base; every step must pass on its own merits"
+  fi
 
   # Base's own copy of the matrix, so we can tell which steps this PR added or
   # edited. Those must pass on their own merits -- see step_unchanged_from_base.
@@ -578,6 +658,7 @@ while IFS=$'\t' read -r status step_label head_signature step_file; do
     '$1 == "FAIL" && $2 == want { print $3; exit }' "$WORK_DIR/base-results.txt")"
 
   if [[ -n "$base_signature" && "$base_signature" == "$head_signature" ]] \
+     && [[ "$harness_unchanged" -eq 1 ]] \
      && step_unchanged_from_base "$step_label" "$step_file"; then
     pre_existing+="$step_label -- $head_signature"$'\n'
   else
@@ -614,6 +695,7 @@ if [[ -n "$mismatches" ]]; then
       if run_one_step "$step_file" "$WORK_DIR/recheck-base.log"; then
         new_failures+="$step_label -- $head_signature"$'\n'
       elif [[ "$STEP_SIGNATURE" == "$head_signature" ]] \
+           && [[ "$harness_unchanged" -eq 1 ]] \
            && step_unchanged_from_base "$step_label" "$step_file"; then
         echo "  environmental: '$step_label' fails the same way on base when re-run -- not a regression"
         pre_existing+="$step_label -- $head_signature (confirmed on re-run)"$'\n'

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -457,13 +457,15 @@ EXEC dbo.sp_Blitz
   # ~340 (CheckID + NVARCHAR(128) DatabaseName + VARCHAR(200) Finding), so rows
   # could wrap or clip and sort/comm would compare fragments.
   #
-  # 8000 for both rather than the "unlimited" spellings (-y 0, -w 65535): those
-  # are edge values whose handling varies between sqlcmd builds, and the first
-  # attempt at this fix used them and made the readback fail outright -- which,
-  # because this path only warns, showed up as a silently skipped comparison on
-  # a green build. 8000 is comfortably above the real maximum and is squarely
-  # inside the documented range for both flags.
-  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -W -y 8000 -w 8000 -s '|' -Q "
+  # No -W here: sqlcmd rejects it alongside -y ("The y and the W options are
+  # mutually exclusive"), and -y is the one that lifts the truncation. Without
+  # -W the columns come back padded to the display width, so the trailing space
+  # is stripped in the pipeline below instead.
+  #
+  # 8000 rather than the "unlimited" spellings (-y 0, -w 65535) -- those are
+  # edge values whose handling varies by build, and 8000 is comfortably above
+  # the real maximum while squarely inside the documented range for both.
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -h -1 -y 8000 -w 8000 -s '|' -Q "
 SET NOCOUNT ON;
 SELECT CONVERT(VARCHAR(10), CheckID)
        + '|' + ISNULL(DatabaseName, '(server)')
@@ -471,7 +473,9 @@ SELECT CONVERT(VARCHAR(10), CheckID)
 FROM dbo.BlitzFindings
 WHERE CheckID NOT IN ($VOLATILE_CHECK_IDS)
 ORDER BY CheckID, DatabaseName, Finding;
-" 2>"$WORK_DIR/readback.log" | sed '/^$/d;/rows affected/d' | sort -u > "$destination" || {
+" 2>"$WORK_DIR/readback.log" \
+    | sed -e 's/[[:space:]]*$//' -e '/^$/d' -e '/rows affected/d' \
+    | sort -u > "$destination" || {
     echo "  ::warning::Reading findings back failed; the findings comparison will be skipped."
     sed 's/^/    /' "$WORK_DIR/readback.log" | tail -10
     return 1

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -57,6 +57,24 @@ EXEC dbo.sp_Blitz
      @SkipChecksSchema   = 'dbo',
      @SkipChecksTable    = 'BlitzChecksToSkip';
 
+/*
+The exact configuration run-sql-server-smoke-tests.sh uses to capture findings
+for the base-vs-head comparison. That capture is guarded so a failure degrades
+the informational diff instead of killing the run -- which means an error unique
+to this combination would only ever be a warning. Running it here too puts it
+through the error classifier, where a new failure fails the build.
+*/
+--#STEP: sp_Blitz findings-capture configuration
+EXEC dbo.sp_Blitz
+     @CheckUserDatabaseObjects = 1,
+     @CheckServerInfo          = 1,
+     @OutputDatabaseName       = 'FRKSmokeTest',
+     @OutputSchemaName         = 'dbo',
+     @OutputTableName          = 'BlitzFindings',
+     @SkipChecksDatabase       = 'FRKSmokeTest',
+     @SkipChecksSchema         = 'dbo',
+     @SkipChecksTable          = 'BlitzChecksToSkip';
+
 --#STEP: sp_BlitzCache all sort orders
 EXEC dbo.sp_BlitzCache @SortOrder = 'all';
 

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -21,22 +21,41 @@ Deliberately excluded:
 */
 
 --#STEP: sp_Blitz default
-EXEC dbo.sp_Blitz;
+EXEC dbo.sp_Blitz
+     @SkipChecksDatabase = 'FRKSmokeTest',
+     @SkipChecksSchema   = 'dbo',
+     @SkipChecksTable    = 'BlitzChecksToSkip';
 
 --#STEP: sp_Blitz full check
-EXEC dbo.sp_Blitz @CheckUserDatabaseObjects = 1, @CheckServerInfo = 1;
+EXEC dbo.sp_Blitz
+     @CheckUserDatabaseObjects = 1,
+     @CheckServerInfo          = 1,
+     @SkipChecksDatabase = 'FRKSmokeTest',
+     @SkipChecksSchema   = 'dbo',
+     @SkipChecksTable    = 'BlitzChecksToSkip';
 
 --#STEP: sp_Blitz markdown output
-EXEC dbo.sp_Blitz @OutputType = 'MARKDOWN';
+EXEC dbo.sp_Blitz
+     @OutputType = 'MARKDOWN',
+     @SkipChecksDatabase = 'FRKSmokeTest',
+     @SkipChecksSchema   = 'dbo',
+     @SkipChecksTable    = 'BlitzChecksToSkip';
 
 --#STEP: sp_Blitz count output
-EXEC dbo.sp_Blitz @OutputType = 'COUNT';
+EXEC dbo.sp_Blitz
+     @OutputType = 'COUNT',
+     @SkipChecksDatabase = 'FRKSmokeTest',
+     @SkipChecksSchema   = 'dbo',
+     @SkipChecksTable    = 'BlitzChecksToSkip';
 
 --#STEP: sp_Blitz to table
 EXEC dbo.sp_Blitz
      @OutputDatabaseName = 'FRKSmokeTest',
      @OutputSchemaName   = 'dbo',
-     @OutputTableName    = 'BlitzOutput';
+     @OutputTableName    = 'BlitzOutput',
+     @SkipChecksDatabase = 'FRKSmokeTest',
+     @SkipChecksSchema   = 'dbo',
+     @SkipChecksTable    = 'BlitzChecksToSkip';
 
 --#STEP: sp_BlitzCache all sort orders
 EXEC dbo.sp_BlitzCache @SortOrder = 'all';
@@ -170,6 +189,13 @@ EXEC dbo.sp_DatabaseRestore @Help = 1;
 /*
 Requires Ola Hallengren's dbo.CommandExecute, which sp_DatabaseRestore refuses to
 run without. CI installs it into master before this runs; see the workflow.
+
+KNOWN FAILING on Linux: @MoveFiles defaults to 1, and that path splits the
+filename off PhysicalName with a hardcoded backslash, so on a forward-slash path
+CHARINDEX returns 0 and LEFT(..., -1) raises Msg 537. Tracked in issue #4049.
+Left in deliberately: it fails identically on base and head, so the comparison
+classifies it as pre-existing and it does not fail the build. It turns green on
+its own once #4049 is fixed.
 */
 --#STEP: sp_DatabaseRestore restore from seeded backups
 EXEC dbo.sp_DatabaseRestore

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -227,9 +227,13 @@ EXEC dbo.sp_DatabaseRestore @Help = 1;
 /*
 sp_DatabaseRestore's execute path is NOT covered here, and deliberately so.
 
-Its dependencies are installed (CommandLog + CommandExecute, fetched by the
-workflow), so the procedure runs -- but it cannot complete against a Linux
-fixture. @MoveFiles defaults to 1, and that path handles paths with a hardcoded
+Its dependencies (Ola Hallengren's CommandLog + CommandExecute) are deliberately
+NOT installed either -- see the re-enabling note below. They were, briefly, and
+that is how the bug underneath was found: with both present the procedure runs
+far enough to fail against a Linux fixture rather than stopping at the
+missing-dependency check.
+
+@MoveFiles defaults to 1, and that path handles paths with a hardcoded
 backslash in two places: it splits the filename off PhysicalName with
 CHARINDEX('\\', ...), which returns 0 on a forward-slash path and makes
 LEFT(..., -1) raise Msg 537; and it joins the backup directory to the file name

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -58,13 +58,12 @@ EXEC dbo.sp_Blitz
      @SkipChecksTable    = 'BlitzChecksToSkip';
 
 /*
-The exact configuration run-sql-server-smoke-tests.sh uses to capture findings
-for the base-vs-head comparison. That capture is guarded so a failure degrades
-the informational diff instead of killing the run -- which means an error unique
-to this combination would only ever be a warning. Running it here too puts it
-through the error classifier, where a new failure fails the build.
+Both @Check* flags together with table output and a skip list -- a combination
+none of the other steps covers, and the one most likely to be run in anger.
+The trailing SELECT exercises the columns anything reading those results depends
+on, so a rename of CheckID, DatabaseName or Finding fails here.
 */
---#STEP: sp_Blitz findings-capture configuration
+--#STEP: sp_Blitz full check to table with skip list
 EXEC dbo.sp_Blitz
      @CheckUserDatabaseObjects = 1,
      @CheckServerInfo          = 1,

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -204,12 +204,21 @@ EXEC dbo.sp_kill @ExecuteKills = 'N';
 EXEC dbo.sp_kill @ExecuteKills = 'N', @OrderBy = 'duration';
 
 /*
-Exercises the kill code path -- building and executing the KILL statements --
-with a filter that matches no session, so CI never kills its own connection.
-Killing a real session would need a second connection held open alongside this
-one; worth adding, but out of scope for the first pass.
+NOT coverage of the kill loop, despite running with @ExecuteKills = 'Y'.
+
+With a filter that matches no session, sp_kill sets @TotalKills to 0 and leaves
+through its "nothing to kill" branch; the cursor and EXEC(@KillSQL) at
+sp_kill.sql:793-840 are never reached. What this does cover is parameter
+handling and the filter/report path under the executing flag, without CI killing
+its own connection.
+
+Real coverage needs a second session held open for sp_kill to kill, respawned
+for every matrix run since the first one consumes it. Tracked in issue #4051.
+Labelled for what it is rather than what it looks like -- a step whose name
+implies coverage it does not provide is the same trap as the @VersionCheckMode
+call this whole harness replaced.
 */
---#STEP: sp_kill execute path with no matching session
+--#STEP: sp_kill executing flag with no matching session (not the kill loop)
 EXEC dbo.sp_kill @ExecuteKills = 'Y', @AppName = 'NoSuchApp-FRKSmokeTest';
 
 --#STEP: sp_DatabaseRestore help

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -187,24 +187,28 @@ EXEC dbo.sp_kill @ExecuteKills = 'Y', @AppName = 'NoSuchApp-FRKSmokeTest';
 EXEC dbo.sp_DatabaseRestore @Help = 1;
 
 /*
-Requires Ola Hallengren's dbo.CommandExecute, which sp_DatabaseRestore refuses to
-run without. CI installs it into master before this runs; see the workflow.
+sp_DatabaseRestore's execute path is NOT covered here, and deliberately so.
 
-KNOWN FAILING on Linux: @MoveFiles defaults to 1, and that path splits the
-filename off PhysicalName with a hardcoded backslash, so on a forward-slash path
-CHARINDEX returns 0 and LEFT(..., -1) raises Msg 537. Tracked in issue #4049.
-Left in deliberately: it fails identically on base and head, so the comparison
-classifies it as pre-existing and it does not fail the build. It turns green on
-its own once #4049 is fixed.
+Its dependencies are installed (CommandLog + CommandExecute, fetched by the
+workflow), so the procedure runs -- but it cannot complete against a Linux
+fixture. @MoveFiles defaults to 1, and that path handles paths with a hardcoded
+backslash in two places: it splits the filename off PhysicalName with
+CHARINDEX('\\', ...), which returns 0 on a forward-slash path and makes
+LEFT(..., -1) raise Msg 537; and it joins the backup directory to the file name
+with a backslash, producing '/var/opt/mssql/data/\\FRKSmokeTest_Full2.bak'.
+
+Tracked in issue #4049. A permanently-failing step is worse than an absent one:
+it trains everyone to expect red and it advertises coverage that does not exist.
+So this stays at @Help until #4049 lands, at which point the invocation below
+should be uncommented.
+
+    EXEC dbo.sp_DatabaseRestore
+         @Database            = 'FRKSmokeTest',
+         @RestoreDatabaseName = 'FRKSmokeTestRestored',
+         @BackupPathFull      = '/var/opt/mssql/data/',
+         @RunRecovery         = 1,
+         @ExistingDBAction    = 3;
 */
---#STEP: sp_DatabaseRestore restore from seeded backups
-EXEC dbo.sp_DatabaseRestore
-     @Database            = 'FRKSmokeTest',
-     @RestoreDatabaseName = 'FRKSmokeTestRestored',
-     @BackupPathFull      = '/var/opt/mssql/data/',
-     @RunRecovery         = 1,
-     @ExistingDBAction    = 3,
-     @Debug               = 1;
 
 --#STEP: sp_BlitzPlanCompare help
 EXEC dbo.sp_BlitzPlanCompare @Help = 1;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -75,6 +75,17 @@ EXEC dbo.sp_Blitz
      @SkipChecksSchema         = 'dbo',
      @SkipChecksTable          = 'BlitzChecksToSkip';
 
+/* The readback the comparison performs, so that renaming or removing CheckID,
+   DatabaseName or Finding fails this classified step instead of silently
+   downgrading the findings diff to "Skipped". The volatile-CheckID filter the
+   runner applies is deliberately not reproduced here -- this exists to prove the
+   columns the readback depends on, not to duplicate the filter. */
+SELECT CONVERT(VARCHAR(10), CheckID)
+       + '|' + ISNULL(DatabaseName, '(server)')
+       + '|' + ISNULL(Finding, '')
+FROM FRKSmokeTest.dbo.BlitzFindings
+ORDER BY CheckID, DatabaseName, Finding;
+
 --#STEP: sp_BlitzCache all sort orders
 EXEC dbo.sp_BlitzCache @SortOrder = 'all';
 
@@ -217,8 +228,14 @@ with a backslash, producing '/var/opt/mssql/data/\\FRKSmokeTest_Full2.bak'.
 
 Tracked in issue #4049. A permanently-failing step is worse than an absent one:
 it trains everyone to expect red and it advertises coverage that does not exist.
-So this stays at @Help until #4049 lands, at which point the invocation below
-should be uncommented.
+So this stays at @Help until #4049 lands.
+
+Re-enabling takes TWO changes, not one. Uncommenting the invocation below on its
+own will fail immediately on sp_DatabaseRestore's CommandExecute prerequisite
+check: the workflow no longer fetches Ola Hallengren's CommandLog and
+CommandExecute, because with only @Help left nothing could reach them. Restore
+the workflow's dependency step (its URL and both SHA-256 hashes are preserved in
+a comment there) and this invocation together.
 
     EXEC dbo.sp_DatabaseRestore
          @Database            = 'FRKSmokeTest',

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -1,0 +1,200 @@
+/*
+The commands CI runs against every non-deprecated script in the kit.
+
+Seeded from Documentation/Development/Test in Azure.sql and extended to cover
+the scripts that file does not reach. Kept separate from that file so CI can add
+setup and teardown that a hand-run script should not carry (issue #4046,
+decision 2B) -- if you add a parameter combination to one, consider the other.
+
+FORMAT: every step starts with a line reading
+
+    --#STEP: <label>
+
+run-sql-server-smoke-tests.sh splits the file on those markers and runs each
+step as its own sqlcmd batch, so a failure is attributed to one labelled step
+and the remaining steps still run. That means each step must stand alone --
+variables do not carry across steps.
+
+Deliberately excluded:
+  * sp_BlitzUpdate -- it overwrites the procs mid-run, which would invalidate
+    every step after it and the base-vs-head comparison (issue #4046, decision 4).
+*/
+
+--#STEP: sp_Blitz default
+EXEC dbo.sp_Blitz;
+
+--#STEP: sp_Blitz full check
+EXEC dbo.sp_Blitz @CheckUserDatabaseObjects = 1, @CheckServerInfo = 1;
+
+--#STEP: sp_Blitz markdown output
+EXEC dbo.sp_Blitz @OutputType = 'MARKDOWN';
+
+--#STEP: sp_Blitz count output
+EXEC dbo.sp_Blitz @OutputType = 'COUNT';
+
+--#STEP: sp_Blitz to table
+EXEC dbo.sp_Blitz
+     @OutputDatabaseName = 'FRKSmokeTest',
+     @OutputSchemaName   = 'dbo',
+     @OutputTableName    = 'BlitzOutput';
+
+--#STEP: sp_BlitzCache all sort orders
+EXEC dbo.sp_BlitzCache @SortOrder = 'all';
+
+--#STEP: sp_BlitzCache expert mode
+EXEC dbo.sp_BlitzCache @ExpertMode = 1;
+
+--#STEP: sp_BlitzCache to table
+EXEC dbo.sp_BlitzCache
+     @OutputDatabaseName = 'FRKSmokeTest',
+     @OutputSchemaName   = 'dbo',
+     @OutputTableName    = 'BlitzCache';
+
+--#STEP: sp_BlitzCache filtered to database
+EXEC dbo.sp_BlitzCache @DatabaseName = 'FRKSmokeTest';
+
+--#STEP: sp_BlitzFirst 5 seconds expert mode
+EXEC dbo.sp_BlitzFirst @Seconds = 5, @ExpertMode = 1;
+
+--#STEP: sp_BlitzFirst since startup
+EXEC dbo.sp_BlitzFirst @SinceStartup = 1;
+
+--#STEP: sp_BlitzFirst to tables
+EXEC dbo.sp_BlitzFirst
+     @OutputDatabaseName         = 'FRKSmokeTest',
+     @OutputSchemaName           = 'dbo',
+     @OutputTableName            = 'BlitzFirst',
+     @OutputTableNameFileStats   = 'BlitzFirst_FileStats',
+     @OutputTableNamePerfmonStats= 'BlitzFirst_PerfmonStats',
+     @OutputTableNameWaitStats   = 'BlitzFirst_WaitStats',
+     @OutputTableNameBlitzCache  = 'BlitzCache',
+     @OutputTableNameBlitzWho    = 'BlitzWho';
+
+--#STEP: sp_BlitzIndex mode 0
+EXEC dbo.sp_BlitzIndex @DatabaseName = 'FRKSmokeTest', @Mode = 0;
+
+--#STEP: sp_BlitzIndex mode 1
+EXEC dbo.sp_BlitzIndex @DatabaseName = 'FRKSmokeTest', @Mode = 1;
+
+--#STEP: sp_BlitzIndex mode 2
+EXEC dbo.sp_BlitzIndex @DatabaseName = 'FRKSmokeTest', @Mode = 2;
+
+--#STEP: sp_BlitzIndex mode 3
+EXEC dbo.sp_BlitzIndex @DatabaseName = 'FRKSmokeTest', @Mode = 3;
+
+--#STEP: sp_BlitzIndex mode 4
+EXEC dbo.sp_BlitzIndex @DatabaseName = 'FRKSmokeTest', @Mode = 4;
+
+--#STEP: sp_BlitzIndex single table
+EXEC dbo.sp_BlitzIndex @DatabaseName = 'FRKSmokeTest', @TableName = 'Users';
+
+--#STEP: sp_BlitzIndex all databases
+EXEC dbo.sp_BlitzIndex @GetAllDatabases = 1, @Mode = 0;
+
+--#STEP: sp_BlitzIndex to table
+EXEC dbo.sp_BlitzIndex
+     @DatabaseName       = 'FRKSmokeTest',
+     @Mode               = 0,
+     @OutputDatabaseName = 'FRKSmokeTest',
+     @OutputSchemaName   = 'dbo',
+     @OutputTableName    = 'BlitzIndex';
+
+--#STEP: sp_BlitzLock default
+EXEC dbo.sp_BlitzLock;
+
+--#STEP: sp_BlitzLock to table
+EXEC dbo.sp_BlitzLock
+     @OutputDatabaseName = 'FRKSmokeTest',
+     @OutputSchemaName   = 'dbo',
+     @OutputTableName    = 'BlitzLock';
+
+--#STEP: sp_BlitzWho expert mode
+EXEC dbo.sp_BlitzWho @ExpertMode = 1;
+
+--#STEP: sp_BlitzWho normal mode
+EXEC dbo.sp_BlitzWho @ExpertMode = 0;
+
+--#STEP: sp_BlitzWho to table
+EXEC dbo.sp_BlitzWho
+     @OutputDatabaseName = 'FRKSmokeTest',
+     @OutputSchemaName   = 'dbo',
+     @OutputTableName    = 'BlitzWho_Results';
+
+--#STEP: sp_BlitzBackups default
+EXEC dbo.sp_BlitzBackups;
+
+--#STEP: sp_BlitzBackups restore speeds
+EXEC dbo.sp_BlitzBackups
+     @HoursBack             = 168,
+     @RestoreSpeedFullMBps  = 100,
+     @RestoreSpeedDiffMBps  = 100,
+     @RestoreSpeedLogMBps   = 100;
+
+/* Depends on the sp_BlitzFirst logging step above having created its tables. */
+--#STEP: sp_BlitzAnalysis default
+EXEC dbo.sp_BlitzAnalysis @OutputDatabaseName = 'FRKSmokeTest', @OutputSchemaName = 'dbo';
+
+--#STEP: sp_BlitzAnalysis filtered to database
+EXEC dbo.sp_BlitzAnalysis
+     @OutputDatabaseName = 'FRKSmokeTest',
+     @OutputSchemaName   = 'dbo',
+     @Databasename       = 'FRKSmokeTest';
+
+--#STEP: sp_ineachdb simple command
+EXEC dbo.sp_ineachdb @command = N'SELECT DB_NAME() AS CurrentDatabase;';
+
+--#STEP: sp_ineachdb user databases only
+EXEC dbo.sp_ineachdb @command = N'SELECT COUNT(*) AS TableCount FROM sys.tables;', @user_only = 1;
+
+--#STEP: sp_ineachdb three part name rewrite
+EXEC dbo.sp_ineachdb @command = N'SELECT TOP (1) name FROM [?].sys.tables;', @user_only = 1;
+
+--#STEP: sp_kill report only
+EXEC dbo.sp_kill @ExecuteKills = 'N';
+
+--#STEP: sp_kill order by duration
+EXEC dbo.sp_kill @ExecuteKills = 'N', @OrderBy = 'duration';
+
+/*
+Exercises the kill code path -- building and executing the KILL statements --
+with a filter that matches no session, so CI never kills its own connection.
+Killing a real session would need a second connection held open alongside this
+one; worth adding, but out of scope for the first pass.
+*/
+--#STEP: sp_kill execute path with no matching session
+EXEC dbo.sp_kill @ExecuteKills = 'Y', @AppName = 'NoSuchApp-FRKSmokeTest';
+
+--#STEP: sp_DatabaseRestore help
+EXEC dbo.sp_DatabaseRestore @Help = 1;
+
+--#STEP: sp_DatabaseRestore restore from seeded backups
+EXEC dbo.sp_DatabaseRestore
+     @Database            = 'FRKSmokeTest',
+     @RestoreDatabaseName = 'FRKSmokeTestRestored',
+     @BackupPathFull      = '/var/opt/mssql/data/',
+     @RunRecovery         = 1,
+     @ExistingDBAction    = 3,
+     @Debug               = 1;
+
+--#STEP: sp_BlitzPlanCompare help
+EXEC dbo.sp_BlitzPlanCompare @Help = 1;
+
+/*
+Picks a plan handle out of the cache the seed step populated. If the cache has
+been swept the step still has to run clean, so the EXEC is guarded rather than
+allowed to fail on a NULL hash.
+*/
+--#STEP: sp_BlitzPlanCompare against a cached plan
+DECLARE @QueryHash BINARY(8);
+
+SELECT TOP (1) @QueryHash = qs.query_hash
+FROM sys.dm_exec_query_stats AS qs
+CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
+WHERE st.text LIKE N'%FRKSmokeTest%'
+   OR st.text LIKE N'%CommentsHeap%'
+ORDER BY qs.last_execution_time DESC;
+
+IF @QueryHash IS NOT NULL
+    EXEC dbo.sp_BlitzPlanCompare @QueryHash = @QueryHash, @DatabaseName = 'FRKSmokeTest';
+ELSE
+    PRINT 'No cached plan matched; skipping sp_BlitzPlanCompare comparison.';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -167,6 +167,10 @@ EXEC dbo.sp_kill @ExecuteKills = 'Y', @AppName = 'NoSuchApp-FRKSmokeTest';
 --#STEP: sp_DatabaseRestore help
 EXEC dbo.sp_DatabaseRestore @Help = 1;
 
+/*
+Requires Ola Hallengren's dbo.CommandExecute, which sp_DatabaseRestore refuses to
+run without. CI installs it into master before this runs; see the workflow.
+*/
 --#STEP: sp_DatabaseRestore restore from seeded backups
 EXEC dbo.sp_DatabaseRestore
      @Database            = 'FRKSmokeTest',
@@ -180,21 +184,34 @@ EXEC dbo.sp_DatabaseRestore
 EXEC dbo.sp_BlitzPlanCompare @Help = 1;
 
 /*
-Picks a plan handle out of the cache the seed step populated. If the cache has
-been swept the step still has to run clean, so the EXEC is guarded rather than
-allowed to fail on a NULL hash.
+Runs a uniquely marked query in FRKSmokeTest's own context, then finds that plan
+by its marker AND by the plan's dbid. The dbid filter matters: this outer batch
+runs in master and its text also contains the marker, so without it the lookup
+can pick up the master-context plan and sp_BlitzPlanCompare's @DatabaseName
+filter then fails to match it.
+
+If the plan cannot be found the step fails loudly rather than skipping quietly --
+a comparison that silently never runs is worse than no step at all.
 */
 --#STEP: sp_BlitzPlanCompare against a cached plan
-DECLARE @QueryHash BINARY(8);
+EXEC FRKSmokeTest.sys.sp_executesql
+     N'SELECT /* FRKPlanCompareMarker */ COUNT_BIG(*) AS MarkedCount
+       FROM dbo.Users AS u
+       JOIN dbo.Posts AS p ON p.OwnerUserId = u.Id
+       WHERE u.Reputation > 10;';
 
-SELECT TOP (1) @QueryHash = qs.query_hash
+DECLARE @QueryPlanHash BINARY(8);
+
+SELECT TOP (1) @QueryPlanHash = qs.query_plan_hash
 FROM sys.dm_exec_query_stats AS qs
 CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
-WHERE st.text LIKE N'%FRKSmokeTest%'
-   OR st.text LIKE N'%CommentsHeap%'
-ORDER BY qs.last_execution_time DESC;
+CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
+WHERE st.text LIKE N'%FRKPlanCompareMarker%'
+  AND pa.attribute = 'dbid'
+  AND CONVERT(INT, pa.value) = DB_ID('FRKSmokeTest')
+ORDER BY qs.creation_time DESC;
 
-IF @QueryHash IS NOT NULL
-    EXEC dbo.sp_BlitzPlanCompare @QueryHash = @QueryHash, @DatabaseName = 'FRKSmokeTest';
-ELSE
-    PRINT 'No cached plan matched; skipping sp_BlitzPlanCompare comparison.';
+IF @QueryPlanHash IS NULL
+    RAISERROR('Seeded marker query was not found in the plan cache; sp_BlitzPlanCompare was not exercised.', 16, 1);
+
+EXEC dbo.sp_BlitzPlanCompare @QueryPlanHash = @QueryPlanHash, @DatabaseName = 'FRKSmokeTest';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -16,8 +16,9 @@ and the remaining steps still run. That means each step must stand alone --
 variables do not carry across steps.
 
 Deliberately excluded:
-  * sp_BlitzUpdate -- it overwrites the procs mid-run, which would invalidate
-    every step after it and the base-vs-head comparison (issue #4046, decision 4).
+  * sp_BlitzUpdate -- it replaces the kit's procedures mid-run, so every step
+    after it would be exercising whatever it just downloaded rather than the
+    code under test (issue #4046, decision 4).
 */
 
 --#STEP: sp_Blitz default
@@ -60,8 +61,6 @@ EXEC dbo.sp_Blitz
 /*
 Both @Check* flags together with table output and a skip list -- a combination
 none of the other steps covers, and the one most likely to be run in anger.
-The trailing SELECT exercises the columns anything reading those results depends
-on, so a rename of CheckID, DatabaseName or Finding fails here.
 */
 --#STEP: sp_Blitz full check to table with skip list
 EXEC dbo.sp_Blitz
@@ -74,11 +73,10 @@ EXEC dbo.sp_Blitz
      @SkipChecksSchema         = 'dbo',
      @SkipChecksTable          = 'BlitzChecksToSkip';
 
-/* The readback the comparison performs, so that renaming or removing CheckID,
-   DatabaseName or Finding fails this classified step instead of silently
-   downgrading the findings diff to "Skipped". The volatile-CheckID filter the
-   runner applies is deliberately not reproduced here -- this exists to prove the
-   columns the readback depends on, not to duplicate the filter. */
+/* Reads the rows back out, so that renaming or dropping CheckID, DatabaseName
+   or Finding fails this step. Those columns are what anything consuming a
+   persisted sp_Blitz result set depends on, and writing the table proves only
+   that it was created, not that it is still shaped the way callers expect. */
 SELECT CONVERT(VARCHAR(10), CheckID)
        + '|' + ISNULL(DatabaseName, '(server)')
        + '|' + ISNULL(Finding, '')

--- a/.github/scripts/smoke-test-seed.sql
+++ b/.github/scripts/smoke-test-seed.sql
@@ -7,8 +7,8 @@ no index usage, so most checks bind against empty tables and report nothing.
 That still catches runtime errors, but it does not exercise much. This builds
 the smallest state that makes the scripts do real work.
 
-Runs once per CI job, before either pass. Nothing in here should depend on the
-version of the kit being tested.
+Runs once per CI job, before the kit is installed. Nothing in here should depend
+on the version of the kit being tested.
 */
 SET NOCOUNT ON;
 GO

--- a/.github/scripts/smoke-test-seed.sql
+++ b/.github/scripts/smoke-test-seed.sql
@@ -137,5 +137,35 @@ BACKUP DATABASE FRKSmokeTest
     WITH INIT, FORMAT, NAME = 'FRKSmokeTest full 2';
 GO
 
+/* ---------------------------------------------------------------------------
+   Checks CI skips, and why.
+
+   CheckID 106 reads the live default trace with fn_trace_gettable. That file is
+   being written continuously -- more so here, because the smoke test itself does
+   constant DDL -- and a read that lands on a torn or rolling file raises Msg 568,
+   which aborts the whole sp_Blitz run rather than just that check. It fired on
+   one of six sp_Blitz calls in a single CI run, which would mean red builds on
+   pull requests that changed nothing. Tracked in issue #4050; remove this row
+   once that is fixed.
+
+   Feeding it through @SkipChecksTable rather than hard-coding an exclusion has a
+   side benefit: the skip-checks code path is itself exercised on every run.
+   --------------------------------------------------------------------------- */
+IF OBJECT_ID('FRKSmokeTest.dbo.BlitzChecksToSkip') IS NOT NULL
+    DROP TABLE FRKSmokeTest.dbo.BlitzChecksToSkip;
+GO
+
+CREATE TABLE FRKSmokeTest.dbo.BlitzChecksToSkip
+(
+    DatabaseName NVARCHAR(128) NULL,
+    CheckID      INT           NULL,
+    ServerName   NVARCHAR(128) NULL
+);
+GO
+
+INSERT FRKSmokeTest.dbo.BlitzChecksToSkip (DatabaseName, CheckID, ServerName)
+VALUES (NULL, 106, NULL);  /* issue #4050 */
+GO
+
 PRINT 'Seed complete.';
 GO

--- a/.github/scripts/smoke-test-seed.sql
+++ b/.github/scripts/smoke-test-seed.sql
@@ -59,19 +59,22 @@ CREATE TABLE dbo.CommentsHeap
 );
 GO
 
+/* CHECKSUM(NEWID()) can return -2147483648, and ABS() of INT_MIN overflows --
+   which would abort the seed, and with it the whole job, at random. Widening to
+   BIGINT before ABS keeps that from turning CI flaky. */
 INSERT dbo.Users (DisplayName, Reputation, CreationDate)
 SELECT TOP (2000)
        LEFT(CONVERT(NVARCHAR(40), NEWID()), 20),
-       ABS(CHECKSUM(NEWID())) % 50000,
-       DATEADD(DAY, -(ABS(CHECKSUM(NEWID())) % 3000), GETDATE())
+       ABS(CAST(CHECKSUM(NEWID()) AS BIGINT)) % 50000,
+       DATEADD(DAY, -(ABS(CAST(CHECKSUM(NEWID()) AS BIGINT)) % 3000), GETDATE())
 FROM sys.all_objects a
 CROSS JOIN sys.all_objects b;
 
 INSERT dbo.Posts (OwnerUserId, Score, CreationDate, Title)
 SELECT TOP (5000)
-       ABS(CHECKSUM(NEWID())) % 2000 + 1,
-       ABS(CHECKSUM(NEWID())) % 100,
-       DATEADD(DAY, -(ABS(CHECKSUM(NEWID())) % 1000), GETDATE()),
+       ABS(CAST(CHECKSUM(NEWID()) AS BIGINT)) % 2000 + 1,
+       ABS(CAST(CHECKSUM(NEWID()) AS BIGINT)) % 100,
+       DATEADD(DAY, -(ABS(CAST(CHECKSUM(NEWID()) AS BIGINT)) % 1000), GETDATE()),
        LEFT(CONVERT(NVARCHAR(250), NEWID()), 50)
 FROM sys.all_objects a
 CROSS JOIN sys.all_objects b;

--- a/.github/scripts/smoke-test-seed.sql
+++ b/.github/scripts/smoke-test-seed.sql
@@ -1,0 +1,141 @@
+/*
+Seeds the throwaway CI SQL Server so the First Responder Kit scripts have
+something real to look at.
+
+A stock container has no user databases, no backup history, no plan cache and
+no index usage, so most checks bind against empty tables and report nothing.
+That still catches runtime errors, but it does not exercise much. This builds
+the smallest state that makes the scripts do real work.
+
+Runs once per CI job, before either pass. Nothing in here should depend on the
+version of the kit being tested.
+*/
+SET NOCOUNT ON;
+GO
+
+/* ---------------------------------------------------------------------------
+   Test database
+   --------------------------------------------------------------------------- */
+IF DB_ID('FRKSmokeTest') IS NOT NULL
+BEGIN
+    ALTER DATABASE FRKSmokeTest SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE FRKSmokeTest;
+END;
+GO
+
+CREATE DATABASE FRKSmokeTest;
+GO
+
+/* FULL recovery so log backups are legal and sp_BlitzBackups has an RPO to report */
+ALTER DATABASE FRKSmokeTest SET RECOVERY FULL;
+GO
+
+USE FRKSmokeTest;
+GO
+
+CREATE TABLE dbo.Users
+(
+    Id           INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_Users PRIMARY KEY CLUSTERED,
+    DisplayName  NVARCHAR(40)  NULL,
+    Reputation   INT           NOT NULL,
+    CreationDate DATETIME      NOT NULL
+);
+
+CREATE TABLE dbo.Posts
+(
+    Id           INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_Posts PRIMARY KEY CLUSTERED,
+    OwnerUserId  INT           NULL,
+    Score        INT           NOT NULL,
+    CreationDate DATETIME      NOT NULL,
+    Title        NVARCHAR(250) NULL
+);
+
+/* A heap, so sp_BlitzIndex has a heap to complain about */
+CREATE TABLE dbo.CommentsHeap
+(
+    Id     INT         NOT NULL,
+    Body   NVARCHAR(200) NULL,
+    Filler CHAR(100)   NOT NULL
+);
+GO
+
+INSERT dbo.Users (DisplayName, Reputation, CreationDate)
+SELECT TOP (2000)
+       LEFT(CONVERT(NVARCHAR(40), NEWID()), 20),
+       ABS(CHECKSUM(NEWID())) % 50000,
+       DATEADD(DAY, -(ABS(CHECKSUM(NEWID())) % 3000), GETDATE())
+FROM sys.all_objects a
+CROSS JOIN sys.all_objects b;
+
+INSERT dbo.Posts (OwnerUserId, Score, CreationDate, Title)
+SELECT TOP (5000)
+       ABS(CHECKSUM(NEWID())) % 2000 + 1,
+       ABS(CHECKSUM(NEWID())) % 100,
+       DATEADD(DAY, -(ABS(CHECKSUM(NEWID())) % 1000), GETDATE()),
+       LEFT(CONVERT(NVARCHAR(250), NEWID()), 50)
+FROM sys.all_objects a
+CROSS JOIN sys.all_objects b;
+
+INSERT dbo.CommentsHeap (Id, Body, Filler)
+SELECT TOP (1000)
+       ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+       LEFT(CONVERT(NVARCHAR(200), NEWID()), 40),
+       'x'
+FROM sys.all_objects a
+CROSS JOIN sys.all_objects b;
+GO
+
+/* Deliberately duplicate + unused indexes so sp_BlitzIndex has findings */
+CREATE INDEX IX_Users_Reputation      ON dbo.Users (Reputation);
+CREATE INDEX IX_Users_Reputation_Dupe ON dbo.Users (Reputation);
+CREATE INDEX IX_Posts_OwnerUserId     ON dbo.Posts (OwnerUserId) INCLUDE (Score);
+CREATE INDEX IX_Posts_Score           ON dbo.Posts (Score);
+GO
+
+/* ---------------------------------------------------------------------------
+   Plan cache activity, so sp_BlitzCache and sp_BlitzWho have something to read
+   --------------------------------------------------------------------------- */
+DECLARE @i INT = 0;
+WHILE @i < 20
+BEGIN
+    SELECT TOP (100) u.DisplayName, SUM(p.Score) AS TotalScore
+    FROM dbo.Users AS u
+    JOIN dbo.Posts AS p ON p.OwnerUserId = u.Id
+    WHERE u.Reputation > @i * 100
+    GROUP BY u.DisplayName
+    ORDER BY TotalScore DESC;
+
+    SELECT COUNT_BIG(*) FROM dbo.CommentsHeap WHERE Body LIKE N'A%';
+
+    SET @i += 1;
+END;
+GO
+
+USE master;
+GO
+
+/* ---------------------------------------------------------------------------
+   Backup history, so sp_Blitz backup checks and sp_BlitzBackups have data,
+   and sp_DatabaseRestore has real files to enumerate.
+
+   /var/opt/mssql/data always exists in the mssql Linux image; the container's
+   own backup directory does not necessarily.
+   --------------------------------------------------------------------------- */
+BACKUP DATABASE FRKSmokeTest
+    TO DISK = '/var/opt/mssql/data/FRKSmokeTest_Full.bak'
+    WITH INIT, FORMAT, NAME = 'FRKSmokeTest full';
+GO
+
+BACKUP LOG FRKSmokeTest
+    TO DISK = '/var/opt/mssql/data/FRKSmokeTest_Log.trn'
+    WITH INIT, FORMAT, NAME = 'FRKSmokeTest log';
+GO
+
+/* A second full backup so backup-history checks see more than one row */
+BACKUP DATABASE FRKSmokeTest
+    TO DISK = '/var/opt/mssql/data/FRKSmokeTest_Full2.bak'
+    WITH INIT, FORMAT, NAME = 'FRKSmokeTest full 2';
+GO
+
+PRINT 'Seed complete.';
+GO

--- a/.github/workflows/sql-server-smoke-tests.yml
+++ b/.github/workflows/sql-server-smoke-tests.yml
@@ -19,7 +19,7 @@ jobs:
     # a version-specific break is obvious.
     name: ${{ matrix.label }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -35,8 +35,6 @@ jobs:
       SQLCMDUSER: sa
       SQLCMDPASSWORD: Testing-Only-Passw0rd!
       MSSQL_IMAGE: ${{ matrix.image }}
-      GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     services:
       sqlserver:
@@ -54,10 +52,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
-        with:
-          # Full history: the run installs the base branch's copy of every
-          # script to compare against, which needs the base commit present.
-          fetch-depth: 0
 
       - name: Install sqlcmd
         run: |

--- a/.github/workflows/sql-server-smoke-tests.yml
+++ b/.github/workflows/sql-server-smoke-tests.yml
@@ -68,20 +68,27 @@ jobs:
           echo "/opt/mssql-tools18/bin" >> "$GITHUB_PATH"
 
       # sp_DatabaseRestore refuses to run without Ola Hallengren's
-      # dbo.CommandExecute, so without this its execute path is never covered.
-      # It is not vendored in this repo, so CI fetches it and verifies the
-      # checksum: if upstream changes, this fails loudly rather than silently
-      # running different code. Update the hash deliberately after reviewing
+      # dbo.CommandExecute, and CommandExecute in turn refuses @LogToTable = 'Y'
+      # -- which sp_DatabaseRestore always passes -- unless dbo.CommandLog
+      # exists. Both are required or the restore path stays uncovered.
+      #
+      # Neither is vendored in this repo, so CI fetches them and verifies their
+      # checksums: if upstream changes, this fails loudly rather than silently
+      # running different code. Update the hashes deliberately after reviewing
       # the upstream diff.
-      - name: Fetch CommandExecute (sp_DatabaseRestore dependency)
+      - name: Fetch sp_DatabaseRestore dependencies
         env:
-          COMMANDEXECUTE_URL: https://raw.githubusercontent.com/olahallengren/sql-server-maintenance-solution/master/CommandExecute.sql
+          OLA_BASE_URL: https://raw.githubusercontent.com/olahallengren/sql-server-maintenance-solution/master
           COMMANDEXECUTE_SHA256: 80e65a63e0dd81a8073c69b538ba222381354bd3435ba6141e6fb8eb6acbb070
+          COMMANDLOG_SHA256: 7a508fa7ed562ec5ee09d4f587f7f2a87f7a4eb3c57450602ee99cdeb4e18b31
         run: |
-          curl -sSL --fail "$COMMANDEXECUTE_URL" -o "$RUNNER_TEMP/CommandExecute.sql"
+          curl -sSL --fail "$OLA_BASE_URL/CommandExecute.sql" -o "$RUNNER_TEMP/CommandExecute.sql"
+          curl -sSL --fail "$OLA_BASE_URL/CommandLog.sql"     -o "$RUNNER_TEMP/CommandLog.sql"
           echo "$COMMANDEXECUTE_SHA256  $RUNNER_TEMP/CommandExecute.sql" | sha256sum -c -
+          echo "$COMMANDLOG_SHA256  $RUNNER_TEMP/CommandLog.sql" | sha256sum -c -
 
       - name: Run SQL Server smoke tests
         env:
           COMMANDEXECUTE_SQL: ${{ runner.temp }}/CommandExecute.sql
+          COMMANDLOG_SQL: ${{ runner.temp }}/CommandLog.sql
         run: bash .github/scripts/run-sql-server-smoke-tests.sh

--- a/.github/workflows/sql-server-smoke-tests.yml
+++ b/.github/workflows/sql-server-smoke-tests.yml
@@ -67,28 +67,15 @@ jobs:
           sudo env ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev
           echo "/opt/mssql-tools18/bin" >> "$GITHUB_PATH"
 
-      # sp_DatabaseRestore refuses to run without Ola Hallengren's
-      # dbo.CommandExecute, and CommandExecute in turn refuses @LogToTable = 'Y'
-      # -- which sp_DatabaseRestore always passes -- unless dbo.CommandLog
-      # exists. Both are required or the restore path stays uncovered.
+      # sp_DatabaseRestore's dependencies (Ola Hallengren's CommandLog and
+      # CommandExecute) are not fetched here. The only invocation left in the
+      # matrix is @Help = 1, which returns before the procedure's CommandExecute
+      # check, so downloading them would add two network dependencies and two
+      # checksums that can redden every PR without exercising anything. Restore
+      # this step together with the execute-path test when #4049 lands:
       #
-      # Neither is vendored in this repo, so CI fetches them and verifies their
-      # checksums: if upstream changes, this fails loudly rather than silently
-      # running different code. Update the hashes deliberately after reviewing
-      # the upstream diff.
-      - name: Fetch sp_DatabaseRestore dependencies
-        env:
-          OLA_BASE_URL: https://raw.githubusercontent.com/olahallengren/sql-server-maintenance-solution/master
-          COMMANDEXECUTE_SHA256: 80e65a63e0dd81a8073c69b538ba222381354bd3435ba6141e6fb8eb6acbb070
-          COMMANDLOG_SHA256: 7a508fa7ed562ec5ee09d4f587f7f2a87f7a4eb3c57450602ee99cdeb4e18b31
-        run: |
-          curl -sSL --fail "$OLA_BASE_URL/CommandExecute.sql" -o "$RUNNER_TEMP/CommandExecute.sql"
-          curl -sSL --fail "$OLA_BASE_URL/CommandLog.sql"     -o "$RUNNER_TEMP/CommandLog.sql"
-          echo "$COMMANDEXECUTE_SHA256  $RUNNER_TEMP/CommandExecute.sql" | sha256sum -c -
-          echo "$COMMANDLOG_SHA256  $RUNNER_TEMP/CommandLog.sql" | sha256sum -c -
-
+      #   OLA_BASE_URL: https://raw.githubusercontent.com/olahallengren/sql-server-maintenance-solution/master
+      #   CommandExecute.sql sha256 80e65a63e0dd81a8073c69b538ba222381354bd3435ba6141e6fb8eb6acbb070
+      #   CommandLog.sql     sha256 7a508fa7ed562ec5ee09d4f587f7f2a87f7a4eb3c57450602ee99cdeb4e18b31
       - name: Run SQL Server smoke tests
-        env:
-          COMMANDEXECUTE_SQL: ${{ runner.temp }}/CommandExecute.sql
-          COMMANDLOG_SQL: ${{ runner.temp }}/CommandLog.sql
         run: bash .github/scripts/run-sql-server-smoke-tests.sh

--- a/.github/workflows/sql-server-smoke-tests.yml
+++ b/.github/workflows/sql-server-smoke-tests.yml
@@ -67,5 +67,21 @@ jobs:
           sudo env ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev
           echo "/opt/mssql-tools18/bin" >> "$GITHUB_PATH"
 
+      # sp_DatabaseRestore refuses to run without Ola Hallengren's
+      # dbo.CommandExecute, so without this its execute path is never covered.
+      # It is not vendored in this repo, so CI fetches it and verifies the
+      # checksum: if upstream changes, this fails loudly rather than silently
+      # running different code. Update the hash deliberately after reviewing
+      # the upstream diff.
+      - name: Fetch CommandExecute (sp_DatabaseRestore dependency)
+        env:
+          COMMANDEXECUTE_URL: https://raw.githubusercontent.com/olahallengren/sql-server-maintenance-solution/master/CommandExecute.sql
+          COMMANDEXECUTE_SHA256: 80e65a63e0dd81a8073c69b538ba222381354bd3435ba6141e6fb8eb6acbb070
+        run: |
+          curl -sSL --fail "$COMMANDEXECUTE_URL" -o "$RUNNER_TEMP/CommandExecute.sql"
+          echo "$COMMANDEXECUTE_SHA256  $RUNNER_TEMP/CommandExecute.sql" | sha256sum -c -
+
       - name: Run SQL Server smoke tests
+        env:
+          COMMANDEXECUTE_SQL: ${{ runner.temp }}/CommandExecute.sql
         run: bash .github/scripts/run-sql-server-smoke-tests.sh

--- a/.github/workflows/sql-server-smoke-tests.yml
+++ b/.github/workflows/sql-server-smoke-tests.yml
@@ -13,23 +13,40 @@ permissions:
 
 jobs:
   smoke-tests:
-    name: Install and smoke test First Responder Kit
+    # Oldest supported and newest available. SQL Server 2016 left extended
+    # support on 2026-07-14, which makes 2017 the oldest version worth testing;
+    # 2025 is the current release. Both run to completion even if one fails, so
+    # a version-specific break is obvious.
+    name: ${{ matrix.label }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: mcr.microsoft.com/mssql/server:2017-latest
+            label: SQL Server 2017 (oldest supported)
+          - image: mcr.microsoft.com/mssql/server:2025-latest
+            label: SQL Server 2025 (newest)
 
     env:
       SQLCMDSERVER: tcp:127.0.0.1,1433
       SQLCMDUSER: sa
       SQLCMDPASSWORD: Testing-Only-Passw0rd!
+      MSSQL_IMAGE: ${{ matrix.image }}
       GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     services:
       sqlserver:
-        image: mcr.microsoft.com/mssql/server:2022-latest
+        image: ${{ matrix.image }}
         env:
           ACCEPT_EULA: Y
           MSSQL_PID: Developer
+          # 2017 images read SA_PASSWORD; later images read MSSQL_SA_PASSWORD.
+          # Setting both keeps one service definition working across the matrix.
+          SA_PASSWORD: Testing-Only-Passw0rd!
           MSSQL_SA_PASSWORD: Testing-Only-Passw0rd!
         ports:
           - 1433:1433
@@ -38,6 +55,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
         with:
+          # Full history: the run installs the base branch's copy of every
+          # script to compare against, which needs the base commit present.
           fetch-depth: 0
 
       - name: Install sqlcmd


### PR DESCRIPTION
Closes #4046.

## The problem

The smoke test installed only the changed `sp_*.sql` and ran it once, with `@VersionCheckMode = 1` — an unconditional early `RETURN` at [sp_Blitz.sql#L75-L78](https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/blob/0d78c1e170ca6c530e5fc55077a868a51d5f7927/sp_Blitz.sql#L75-L78). No check body ever executed, so it proved the script parsed and nothing more.

#4045 is the evidence: two runtime breakages passed it green and had to be caught by human review. Neither was catchable at install time — one was a variable inside a string literal, the other left the outer T-SQL validly balanced.

## What this does

Seeds a database, installs all 12 non-deprecated scripts, verifies each procedure actually exists, runs a 39-step matrix, and fails the build on any SQL error. On SQL Server 2017 and 2025.

- **All 12 non-deprecated scripts**, through `.github/scripts/smoke-test-matrix.sql` — the `@Output*` table paths, `sp_BlitzIndex` modes 0-4, `sp_ineachdb`'s three-part-name rewrite, `sp_BlitzPlanCompare` against a real cached plan. Seeded from `Documentation/Development/Test in Azure.sql`, kept separate so CI can carry setup a hand-run script shouldn't (decision 2B). `sp_BlitzUpdate` is excluded: it overwrites the procs mid-run (decision 4).
- **Each step runs on its own**, split on `--#STEP:` markers, so a failure names one step and the rest still run — one CI round surfaces every problem, not just the first.
- **`sqlcmd -I`**, so procedures are created with `QUOTED_IDENTIFIER ON`. Without it `sqlcmd`'s OFF default is captured at `CREATE` time and the `sp_BlitzFirst`/`sp_BlitzLock` XML paths die with `Msg 1934` — a configuration no real client uses.
- **Install is verified**, not assumed: a script reduced to an empty file still exits `sqlcmd` 0, so every expected procedure is checked with `OBJECT_ID`.
- **Real seed state** — 2,000 users / 5,000 posts, a heap, duplicate and unused indexes, full and log backups, plan cache activity. An empty server makes most checks bind against empty tables and report nothing.
- **Two engine versions** — 2017 (oldest in support; 2016 left extended support 2026-07-14) and 2025, `fail-fast: false`.

## What was removed, and why

An earlier revision of this PR also installed the base branch's copies, ran everything twice, and classified each failure as new or pre-existing — error signatures, step-body comparison, harness-file comparison, replay-on-mismatch. About 155 lines answering one question: *is this failure the PR's fault?*

It's gone. Three reasons:

1. **It never took a decision.** Every run logged `harness differs from base; every step must pass on its own merits`, because the harness files themselves keep changing. The machinery has not once been the thing that decided an outcome.
2. **Grandfathering only matters when the baseline is dirty.** The baseline is clean — 0 failing steps on both engines. When every step passes, "is this pre-existing?" has no instances.
3. **It was where the defects lived.** Nearly every problem found while reviewing this harness was in that code, several of them regressions introduced while fixing others.

The runner went from 792 lines to **281**, and CI from two passes to one. Git history has a working implementation if a dirty baseline ever makes the question real.

## What is deliberately *not* covered

Stated plainly, because a step whose name implies coverage it lacks is the same defect as the `@VersionCheckMode` call this replaces:

- **`sp_kill`'s kill loop.** The matrix runs `@ExecuteKills = 'Y'` against a filter matching no session, so `sp_kill` sets `@TotalKills` to 0 and exits its nothing-to-kill branch; the cursor and `EXEC(@KillSQL)` at `sp_kill.sql:793-840` are never reached. Parameter and filter handling *are* covered. Real coverage needs a second session held open — **#4051**.
- **`sp_DatabaseRestore`'s execute path.** Stays at `@Help` until **#4049**; its Ola Hallengren dependencies aren't installed either, since nothing could reach them.
- **Windows-only paths.** The containers are Linux, so `@IsWindowsOperatingSystem = 0` and `xp_regread`, `xp_cmdshell` and cluster DMVs aren't exercised. Binding still happens, so both #4045 bugs would have been caught.
- **Azure SQL DB.** Not possible with a container; deferred per decision 3A.

## Bugs this found

All pre-existing on `dev`, all filed separately:

- **#4048** — `sp_Blitz` divides by zero when the server has been up under a minute. `@MsSinceWaitsCleared` is `DATEDIFF(MINUTE, ...)`, so it's `0`, and the zero-guard sits inside a branch that can't be taken while the value is `0`. Reproduced on both engine versions.
- **#4049** — `sp_DatabaseRestore`'s `@MoveFiles = 1` (the default) is broken on Linux: two hardcoded backslashes, one splitting the filename off `PhysicalName` (`Msg 537`), one joining the backup directory to the file name.
- **#4050** — `sp_Blitz` aborts entirely when a read of the live default trace lands on a torn file (`Msg 568`), dropping every finding after CheckID 106.

CI works around #4048 (waits out the uptime window) and #4050 (skips CheckID 106 via `@SkipChecksTable`, which incidentally exercises that previously untested path). Both carry comments pointing at their issues and should come out when they're fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMPBMMANLaFgSQ73GTgBW7