### PR TITLE
sp_Blitz: recognize German SQL Server Agent service names

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -5344,7 +5344,7 @@ IF NOT EXISTS ( SELECT  1
 						  FROM
 							[sys].[dm_server_services]
 						  WHERE [status_desc] <> 'Running'
-						  AND [servicename] LIKE 'SQL Server Agent%'
+						  AND [servicename] LIKE 'SQL Server_Agent%'
 						  AND CAST(SERVERPROPERTY('Edition') AS VARCHAR(1000)) NOT LIKE '%xpress%';
 
 					END;
@@ -5382,7 +5382,7 @@ IF @IsWindowsOperatingSystem = 1
 						  WHERE ([service_account] = 'LocalSystem'
 						    OR LOWER([service_account]) = 'nt authority\system')
 						  AND [servicename] LIKE 'SQL Server%'
-						  AND [servicename] NOT LIKE 'SQL Server Agent%';
+						  AND [servicename] NOT LIKE 'SQL Server_Agent%';
 					END;
 				END;
 
@@ -5418,7 +5418,7 @@ IF @IsWindowsOperatingSystem = 1
 							[sys].[dm_server_services]
 						  WHERE ([service_account] = 'LocalSystem'
 						    OR LOWER([service_account]) = 'nt authority\system')
-						  AND [servicename] LIKE 'SQL Server Agent%';
+						  AND [servicename] LIKE 'SQL Server_Agent%';
 					END;
 				END;
 
@@ -5492,7 +5492,7 @@ IF @IsWindowsOperatingSystem = 1
 							[sys].[dm_server_services]
 						  WHERE [service_account] LIKE 'NT Service%'
 						  AND [servicename] LIKE 'SQL Server%'
-						  AND [servicename] NOT LIKE 'SQL Server Agent%'
+						  AND [servicename] NOT LIKE 'SQL Server_Agent%'
 						  AND [servicename] NOT LIKE 'SQL Server Launchpad%';
 
 					END;
@@ -5531,7 +5531,7 @@ IF @IsWindowsOperatingSystem = 1
 						  FROM
 							[sys].[dm_server_services]
 						  WHERE [service_account] LIKE 'NT Service%'
-						  AND [servicename] LIKE 'SQL Server Agent%';
+						  AND [servicename] LIKE 'SQL Server_Agent%';
 
 					END;
 					END;


### PR DESCRIPTION
German SQL Server names its Agent service `SQL Server-Agent (<instance>)`, so the existing English-only pattern misses Agent findings and can misclassify Agent as the database engine. Change all five affected `LIKE`/`NOT LIKE` predicates to `SQL Server_Agent%`, matching either the English space or German hyphen.

Fixes #4044.

Validation:
- Ran the five affected queries against English/German service fixtures, covering stopped and running Agent services, default and named instances, LocalSystem and NT Service accounts, database-engine services, and Launchpad. The original predicates fail the regression on SQL Server 2025; the updated predicates pass on SQL Server 2025 and Azure SQL DB.
- Installed isolated copies of the updated procedure and its helper, then successfully executed `@CheckUserDatabaseObjects = 0, @CheckProcedureCache = 0, @CheckServerInfo = 1` on SQL Server 2025 (17.0.4085.5) and Azure SQL DB. Removed the test procedures and verified cleanup on both.
- `git diff --check` passes.

German service names were simulated with fixtures; a German-localized SQL Server installation was not available. Generated Install scripts are unchanged, per CONTRIBUTING.md.