### PR TITLE
sp_Blitz: prevent wait-stat divide-by-zero immediately after startup

### DIFF
--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -102,40 +102,6 @@ wait_for_sql_server() {
   done
 }
 
-# ---------------------------------------------------------------------------
-# Hold off until the instance has been up longer than a minute.
-#
-# sp_Blitz CheckID 152 divides by @MsSinceWaitsCleared, which is
-# DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP) * 60000.0 and is therefore 0
-# for the instance's first minute. Its zero-guard sits inside a branch that
-# cannot be taken while the value is 0, so sp_Blitz aborts with a divide-by-zero.
-# Tracked in issue #4048; remove this once that is fixed.
-#
-# The value must parse as a number greater than zero. Anything else -- an empty
-# result, a header, an error -- means we have not confirmed the window has passed,
-# so keep waiting rather than assuming the best. `|| true` matters: under set -e a
-# failed command substitution would abort instead of retrying.
-# ---------------------------------------------------------------------------
-wait_for_wait_stats() {
-  local uptime_minutes
-
-  echo "Waiting for the instance to pass one minute of uptime (issue #4048)..."
-  for attempt in {1..40}; do
-    uptime_minutes="$(run_scalar "SET NOCOUNT ON;
-SELECT DATEDIFF(MINUTE, create_date, CURRENT_TIMESTAMP)
-FROM sys.databases WHERE name = 'tempdb';" || true)"
-
-    if [[ "$uptime_minutes" =~ ^[0-9]+$ ]] && (( uptime_minutes > 0 )); then
-      echo "Uptime window cleared after ${attempt} check(s) (${uptime_minutes} minute(s) up)."
-      return 0
-    fi
-
-    sleep 5
-  done
-
-  echo "::warning::Instance still reports under a minute of uptime; continuing anyway."
-}
-
 kit_proc_name() {
   basename "$1" .sql
 }
@@ -266,7 +232,6 @@ run_matrix() {
 # Main
 # ---------------------------------------------------------------------------
 wait_for_sql_server
-wait_for_wait_stats
 
 echo
 echo "=== Seeding test data ==="

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1331,7 +1331,6 @@ BEGIN
 				IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 185) WITH NOWAIT;
 
 				SET @MsSinceWaitsCleared = (SELECT MAX(wait_time_ms) FROM sys.dm_os_wait_stats WHERE wait_type IN ('SP_SERVER_DIAGNOSTICS_SLEEP', 'QDS_PERSIST_TASK_MAIN_LOOP_SLEEP', 'REQUEST_FOR_DEADLOCK_SEARCH', 'HADR_FILESTREAM_IOMGR_IOCOMPLETION', 'LAZYWRITER_SLEEP', 'SQLTRACE_INCREMENTAL_FLUSH_SLEEP', 'DIRTY_PAGE_POLL', 'LOGMGR_QUEUE'));
-				IF @MsSinceWaitsCleared = 0 SET @MsSinceWaitsCleared = 1;
 				INSERT  INTO #BlitzResults
 						(   CheckID ,
 							Priority ,
@@ -1349,6 +1348,9 @@ BEGIN
 									+ CONVERT(NVARCHAR(100), 
 										DATEADD(MINUTE, (-1. * (@MsSinceWaitsCleared) / 1000. / 60.), GETDATE()), 120));
 			END;
+
+		/* Uptime can round down to zero during the first minute after startup. */
+		IF @MsSinceWaitsCleared = 0 SET @MsSinceWaitsCleared = 1;
 
 		/* @CpuMsSinceWaitsCleared is used for waits stats calculations */
 		


### PR DESCRIPTION
Within the first minute after startup, `@MsSinceWaitsCleared` can be zero. The existing zero guard was inside the cleared-waits branch, which cannot run when the initial value is zero, so CheckID 152 could abort sp_Blitz with error 8134.

Move the guard after that branch so it protects both the initial uptime and the cleared-waits result before `@CpuMsSinceWaitsCleared` is calculated. Remove the CI uptime delay added in #4047 specifically to work around this bug. That PR avoided the timing window; it did not fix the stored procedure.

Fixes #4048.

Validation:
- Reproduced error 8134 with the original initialization and CheckID 152 query on SQL Server 2025 using controlled DMV fixtures.
- Ran six fixture cases using the changed initialization and actual CheckID 152 query on SQL Server 2025 and Azure SQL DB: zero-minute uptime with zero, positive, or absent background waits; cleared waits with zero or positive elapsed time; and normal uptime. All pass, including assertions for elapsed time, CPU-adjusted time, cleared-waits findings, and populated CheckID 152 output.
- Full isolated procedure smoke runs completed on both platforms with `@CheckUserDatabaseObjects = 0, @CheckProcedureCache = 0, @CheckServerInfo = 1`. Removed test procedures and verified cleanup.
- Shell syntax check and `git diff --check` pass.

The startup boundary was simulated without restarting either shared test server. The full container CI matrix was not run locally. Generated installation scripts are unchanged per CONTRIBUTING.md.