### PR TITLE
sp_Blitz: continue when CheckID 106 cannot read the default trace

### DIFF
--- a/.github/scripts/smoke-test-seed.sql
+++ b/.github/scripts/smoke-test-seed.sql
@@ -140,20 +140,7 @@ BACKUP DATABASE FRKSmokeTest
     WITH INIT, FORMAT, NAME = 'FRKSmokeTest full 2';
 GO
 
-/* ---------------------------------------------------------------------------
-   Checks CI skips, and why.
-
-   CheckID 106 reads the live default trace with fn_trace_gettable. That file is
-   being written continuously -- more so here, because the smoke test itself does
-   constant DDL -- and a read that lands on a torn or rolling file raises Msg 568,
-   which aborts the whole sp_Blitz run rather than just that check. It fired on
-   one of six sp_Blitz calls in a single CI run, which would mean red builds on
-   pull requests that changed nothing. Tracked in issue #4050; remove this row
-   once that is fixed.
-
-   Feeding it through @SkipChecksTable rather than hard-coding an exclusion has a
-   side benefit: the skip-checks code path is itself exercised on every run.
-   --------------------------------------------------------------------------- */
+/* Keep an empty skip table to exercise the @SkipChecksTable input path. */
 IF OBJECT_ID('FRKSmokeTest.dbo.BlitzChecksToSkip') IS NOT NULL
     DROP TABLE FRKSmokeTest.dbo.BlitzChecksToSkip;
 GO
@@ -166,9 +153,6 @@ CREATE TABLE FRKSmokeTest.dbo.BlitzChecksToSkip
 );
 GO
 
-INSERT FRKSmokeTest.dbo.BlitzChecksToSkip (DatabaseName, CheckID, ServerName)
-VALUES (NULL, 106, NULL);  /* issue #4050 */
-GO
 
 PRINT 'Seed complete.';
 GO

--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -10129,6 +10129,7 @@ IF NOT EXISTS ( SELECT  1
 
 								IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 106) WITH NOWAIT;
 								
+								BEGIN TRY
 								INSERT  INTO #BlitzResults
 										( CheckID ,
 										  Priority ,
@@ -10149,6 +10150,15 @@ IF NOT EXISTS ( SELECT  1
 												) as Details
 										FROM    ::fn_trace_gettable( @base_tracefilename, default )
 										WHERE EventClass BETWEEN 65500 and 65600;
+                                END TRY
+                                BEGIN CATCH
+                                    /* The live trace can roll over or be mid-write after the earlier read succeeded. */
+                                    SET @TraceFileIssue = 1;
+                                    INSERT INTO #BlitzResults (CheckID, Priority, FindingsGroup, Finding, URL, Details)
+                                    VALUES (106, 250, 'Server Info', 'Default Trace Could Not Be Read',
+                                        'https://www.brentozar.com/go/trace',
+                                        'Unable to read the default trace. Other checks will continue. Error: ' + ERROR_MESSAGE());
+                                END CATCH;
 							END; /* CheckID 106 */
 
 							IF NOT EXISTS ( SELECT  1


### PR DESCRIPTION
CheckID 106 reads the live default trace a second time after an earlier protected read. A file rollover or incomplete write between those reads can raise an error and abort sp_Blitz.

Wrap the second read in TRY/CATCH. On failure, return a priority-250 `Default Trace Could Not Be Read` finding containing the error message, then continue with the remaining checks. The other fn_trace_gettable call already has error handling.

Remove the CheckID 106 skip introduced for CI in #4047, retaining the empty skip table so the @SkipChecksTable input path is still exercised.

Fixes #4050.

Validation:
- Normal full procedure smoke runs passed on SQL Server 2025 and Azure SQL DB with `@CheckUserDatabaseObjects = 0, @CheckProcedureCache = 0, @CheckServerInfo = 1`.
- In an isolated SQL Server procedure copy, directed only the second fn_trace_gettable read to a deliberately missing trace file. Verified that the error becomes the CheckID 106 warning, includes the failing file in its details, and later wait-stat checks still reach the output table.
- Removed all temporary test procedures/output tables and verified cleanup on both platforms.
- `git diff --check` passes.

The intermittent mid-write error 568 itself was not reproduced; the regression exercises a real file-read failure at the same statement. Azure SQL DB smoke testing verifies compatibility, since it has no default trace. Generated installation scripts are unchanged per CONTRIBUTING.md.