### PR TITLE
CI: exercise sp_kill's actual kill loop

### DIFF
--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -187,6 +187,47 @@ PYTHON
 # the rest still run. One CI round should surface every problem, not just the
 # first one to blow up.
 # ---------------------------------------------------------------------------
+run_kill_step() (
+  # A subshell scopes cleanup to this step, including failures and interruption.
+  local step_file="$1" victim_pid="" token status
+  token="$(python3 -c 'import uuid; print(uuid.uuid4())')" || return 1
+  cleanup_victim() {
+    if [[ -n "$victim_pid" ]]; then
+      kill "$victim_pid" 2>/dev/null || true
+      wait "$victim_pid" 2>/dev/null || true
+    fi
+    run_query "DELETE FROM FRKSmokeTest.dbo.KillVictim WHERE Token = '$token';" >/dev/null 2>&1 || true
+  }
+  trap cleanup_victim EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d FRKSmokeTest -Q "
+SET NOCOUNT ON;
+DECLARE @Token uniqueidentifier = '$token';
+INSERT dbo.KillVictim (Token, SessionId, LoginTime)
+SELECT @Token, @@SPID, login_time FROM sys.dm_exec_sessions WHERE session_id = @@SPID;
+WAITFOR DELAY '00:05:00';
+THROW 51000, 'The dedicated victim timed out without being killed.', 1;" \
+    > "$WORK_DIR/victim.log" 2>&1 &
+  victim_pid=$!
+
+  "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -v KillVictimToken="$token" -i "$step_file"
+  status=$?
+  if [[ "$status" -ne 0 ]]; then
+    cat "$WORK_DIR/victim.log"
+  fi
+  return "$status"
+)
+
+run_step() {
+  if [[ "$2" == 'sp_kill kills a dedicated session' ]]; then
+    run_kill_step "$1"
+  else
+    "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$1"
+  fi
+}
+
 run_matrix() {
   local steps_dir="$WORK_DIR/steps"
   local step_file current_label failures=0 total=0
@@ -195,7 +236,7 @@ run_matrix() {
     current_label="$(cat "${step_file%.sql}.label")"
     total=$((total + 1))
 
-    if "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$step_file" \
+    if run_step "$step_file" "$current_label" \
          > "$WORK_DIR/step.log" 2>&1; then
       echo "  PASS  $current_label"
     else

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -200,23 +200,40 @@ EXEC dbo.sp_kill @ExecuteKills = 'N';
 --#STEP: sp_kill order by duration
 EXEC dbo.sp_kill @ExecuteKills = 'N', @OrderBy = 'duration';
 
-/*
-NOT coverage of the kill loop, despite running with @ExecuteKills = 'Y'.
-
-With a filter that matches no session, sp_kill sets @TotalKills to 0 and leaves
-through its "nothing to kill" branch; the cursor and EXEC(@KillSQL) at
-sp_kill.sql:793-840 are never reached. What this does cover is parameter
-handling and the filter/report path under the executing flag, without CI killing
-its own connection.
-
-Real coverage needs a second session held open for sp_kill to kill, respawned
-for every matrix run since the first one consumes it. Tracked in issue #4051.
-Labelled for what it is rather than what it looks like -- a step whose name
-implies coverage it does not provide is the same trap as the @VersionCheckMode
-call this whole harness replaced.
-*/
---#STEP: sp_kill executing flag with no matching session (not the kill loop)
+--#STEP: sp_kill executing flag with no matching session
 EXEC dbo.sp_kill @ExecuteKills = 'Y', @AppName = 'NoSuchApp-FRKSmokeTest';
+
+--#STEP: sp_kill kills a dedicated session
+DECLARE @Token uniqueidentifier = '$(KillVictimToken)', @VictimSpid int,
+        @LoginTime datetime, @Attempts int = 0;
+/* Wait for registration, checking session identity as well as the reusable SPID. */
+WHILE @VictimSpid IS NULL AND @Attempts < 30
+BEGIN
+    SELECT @VictimSpid = v.SessionId, @LoginTime = v.LoginTime
+    FROM FRKSmokeTest.dbo.KillVictim AS v
+    JOIN sys.dm_exec_sessions AS s
+      ON s.session_id = v.SessionId AND s.login_time = v.LoginTime
+    WHERE v.Token = @Token
+      AND s.is_user_process = 1 AND s.session_id <> @@SPID;
+    IF @VictimSpid IS NULL WAITFOR DELAY '00:00:01';
+    SET @Attempts += 1;
+END;
+IF @VictimSpid IS NULL
+    THROW 51000, 'The dedicated sp_kill victim did not become ready.', 1;
+
+EXEC dbo.sp_kill @ExecuteKills = 'Y', @SPID = @VictimSpid;
+
+SET @Attempts = 0;
+WHILE EXISTS (SELECT 1 FROM sys.dm_exec_sessions
+              WHERE session_id = @VictimSpid AND login_time = @LoginTime)
+      AND @Attempts < 10
+BEGIN
+    WAITFOR DELAY '00:00:01';
+    SET @Attempts += 1;
+END;
+IF EXISTS (SELECT 1 FROM sys.dm_exec_sessions
+           WHERE session_id = @VictimSpid AND login_time = @LoginTime)
+    THROW 51000, 'sp_kill returned without terminating the dedicated victim.', 1;
 
 --#STEP: sp_DatabaseRestore help
 EXEC dbo.sp_DatabaseRestore @Help = 1;

--- a/.github/scripts/smoke-test-seed.sql
+++ b/.github/scripts/smoke-test-seed.sql
@@ -154,5 +154,16 @@ CREATE TABLE FRKSmokeTest.dbo.BlitzChecksToSkip
 GO
 
 
+/* Per-run session identity for the dedicated sp_kill victim. */
+IF OBJECT_ID('FRKSmokeTest.dbo.KillVictim') IS NOT NULL
+    DROP TABLE FRKSmokeTest.dbo.KillVictim;
+CREATE TABLE FRKSmokeTest.dbo.KillVictim
+(
+    Token uniqueidentifier NOT NULL PRIMARY KEY,
+    SessionId smallint NOT NULL,
+    LoginTime datetime NOT NULL
+);
+GO
+
 PRINT 'Seed complete.';
 GO


### PR DESCRIPTION
The existing executing-mode smoke step matches no sessions, so it never reaches sp_kill's KILL execution loop. Keep that no-match coverage and add a step that terminates a dedicated background sqlcmd session.

The runner starts a fresh victim immediately before each kill step. The victim registers a unique run token, its SPID, and login time, then waits. The matrix waits up to 30 seconds for that identity to appear, excludes its own connection, calls sp_kill with the exact SPID, and fails if the original session remains after 10 seconds. Subshell cleanup stops the spawned client and removes its registration on success, failure, or interruption. Missing victims fail instead of silently skipping coverage.

Fixes #4051. No changes to sp_kill itself.

Validation:
- Ran the new runner function and extracted matrix step on SQL Server 2025 on Windows and SQL Server 2022 on Linux, using isolated test databases.
- Three consecutive real kills passed on each platform, demonstrating a fresh victim per invocation.
- Replaced the sp_kill invocation with a deliberate no-op in a temporary test copy. The assertion correctly failed on both platforms, and cleanup removed the victim registrations.
- Verified no test sessions remained; removed the test database and Linux container.
- Shell syntax validation and `git diff --check` pass.

The full CI matrix and its SQL Server 2017/2025 Linux jobs were not run locally. Azure SQL DB was not used for this SQL Server CI-harness change.