### PR TITLE
CI: verify sp_Blitz skip guards under restricted permissions

### DIFF
--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -21,6 +21,52 @@ Deliberately excluded:
     code under test (issue #4046, decision 4).
 */
 
+--#STEP: sp_Blitz restricted login honors skip guards
+/* Grants happen after the runner installs the procedures. */
+GRANT EXECUTE ON dbo.sp_Blitz TO FRKSmokeLimited;
+GRANT EXECUTE ON dbo.sp_ineachdb TO FRKSmokeLimited;
+EXECUTE AS LOGIN = 'FRKSmokeLimited';
+BEGIN TRY
+    IF ISNULL(IS_SRVROLEMEMBER(N'sysadmin'), 1) <> 0
+       OR ISNULL(HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE'), 0) <> 1
+        THROW 51000, 'Restricted-login test has the wrong server permissions.', 1;
+
+    /* Prove the probes fail without guards: empty metadata is not a denial. */
+    DECLARE @Probes TABLE(CheckID int PRIMARY KEY, Query nvarchar(max));
+    INSERT @Probes VALUES
+      (202,N'SELECT TOP (0) * FROM msdb.INFORMATION_SCHEMA.COLUMNS;'),
+      (178,N'SELECT TOP (0) * FROM msdb.dbo.backupset;'),
+      (105,N'SELECT TOP (0) * FROM master.sys.extended_procedures;'),
+      (116,N'SELECT TOP (0) * FROM msdb.sys.all_columns;'),
+      (191,N'SELECT TOP (0) * FROM sys.master_files;');
+    DECLARE @ProbeID int, @Probe nvarchar(max);
+    WHILE EXISTS (SELECT 1 FROM @Probes)
+    BEGIN
+        SELECT TOP (1) @ProbeID = CheckID, @Probe = Query FROM @Probes ORDER BY CheckID;
+        BEGIN TRY
+            EXEC sys.sp_executesql @Probe;
+            THROW 51000, 'A restricted metadata probe unexpectedly succeeded.', 1;
+        END TRY
+        BEGIN CATCH
+            IF ERROR_NUMBER() NOT IN (229, 916) THROW;
+        END CATCH;
+        DELETE @Probes WHERE CheckID = @ProbeID;
+    END;
+
+    EXEC dbo.sp_Blitz
+         @CheckUserDatabaseObjects = 0,
+         @CheckProcedureCache = 0,
+         @CheckServerInfo = 1,
+         @SkipChecksDatabase = 'FRKSmokeTest',
+         @SkipChecksSchema = 'dbo',
+         @SkipChecksTable = 'LimitedLoginChecksToSkip';
+    REVERT;
+END TRY
+BEGIN CATCH
+    REVERT;
+    THROW;
+END CATCH;
+
 --#STEP: sp_Blitz default
 EXEC dbo.sp_Blitz
      @SkipChecksDatabase = 'FRKSmokeTest',

--- a/.github/scripts/smoke-test-seed.sql
+++ b/.github/scripts/smoke-test-seed.sql
@@ -154,5 +154,49 @@ CREATE TABLE FRKSmokeTest.dbo.BlitzChecksToSkip
 GO
 
 
+/* A disabled login can be impersonated by the runner, but cannot log in over the network. */
+USE master;
+IF SUSER_ID(N'FRKSmokeLimited') IS NULL
+BEGIN
+    DECLARE @CreateLimitedLogin nvarchar(max) =
+        N'CREATE LOGIN FRKSmokeLimited WITH PASSWORD = ''' + CONVERT(nvarchar(36), NEWID()) + N'aA1!'';';
+    EXEC sys.sp_executesql @CreateLimitedLogin;
+END;
+ALTER LOGIN FRKSmokeLimited DISABLE;
+GRANT VIEW SERVER STATE TO FRKSmokeLimited;
+IF CONVERT(int, SERVERPROPERTY('ProductMajorVersion')) >= 16
+    EXEC(N'GRANT VIEW SERVER PERFORMANCE STATE TO FRKSmokeLimited;');
+IF USER_ID(N'FRKSmokeLimited') IS NULL
+    CREATE USER FRKSmokeLimited FOR LOGIN FRKSmokeLimited;
+DENY SELECT ON sys.extended_procedures TO FRKSmokeLimited;
+DENY SELECT ON sys.master_files TO FRKSmokeLimited;
+GO
+USE msdb;
+IF USER_ID(N'FRKSmokeLimited') IS NULL
+    CREATE USER FRKSmokeLimited FOR LOGIN FRKSmokeLimited;
+/* An absent user alone is insufficient: msdb normally allows guest access. */
+DENY CONNECT TO FRKSmokeLimited;
+GO
+USE FRKSmokeTest;
+IF USER_ID(N'FRKSmokeLimited') IS NULL
+    CREATE USER FRKSmokeLimited FOR LOGIN FRKSmokeLimited;
+IF OBJECT_ID(N'dbo.LimitedLoginChecksToSkip') IS NOT NULL
+    DROP TABLE dbo.LimitedLoginChecksToSkip;
+CREATE TABLE dbo.LimitedLoginChecksToSkip
+(
+    DatabaseName nvarchar(128) NULL,
+    CheckID int NOT NULL PRIMARY KEY,
+    ServerName nvarchar(128) NULL
+);
+/* The five hoisted probes whose skip guards this test protects. */
+INSERT dbo.LimitedLoginChecksToSkip(CheckID) VALUES (202),(178),(105),(116),(191);
+/* Other checks requiring the deliberately denied msdb/master metadata. */
+INSERT dbo.LimitedLoginChecksToSkip(CheckID)
+VALUES (1),(2),(3),(8),(90),(92),(93),(111),(119),(186),(232),(234),(236),(256);
+GRANT SELECT ON dbo.LimitedLoginChecksToSkip TO FRKSmokeLimited;
+GO
+USE master;
+GO
+
 PRINT 'Seed complete.';
 GO


### PR DESCRIPTION
The existing sysadmin smoke runs cannot detect metadata reads that accidentally execute before their skip guards. Add a restricted-login step that proves those reads would fail, then runs sp_Blitz with the required checks skipped.

The seed creates a disabled login with VIEW SERVER STATE (and VIEW SERVER PERFORMANCE STATE on SQL Server 2022+), explicitly denies msdb access and reads of the relevant master catalog views, and grants access to a dedicated skip table. An absent msdb user alone is insufficient because guest access may still allow the probes.

The matrix uses EXECUTE AS LOGIN, checks that the caller is not sysadmin, and asserts that all five metadata probes fail with permission errors. It then executes sp_Blitz with checks 202, 178, 105, 116, and 191 skipped, plus an explicit list of unrelated checks needing the same denied metadata. REVERT runs on success and failure. No additional network credentials or runner changes are needed.

Fixes #4052. No stored-procedure changes.

Validation:
- Final seed and restricted-login step passed on Windows SQL Server 2025 and Linux SQL Server 2022.
- On each platform, removed each of the five targeted guards separately in temporary procedure copies. All five mutations failed with permission errors; the unmodified procedure passed.
- Removed test logins/users, isolated objects, and the Linux container after testing.
- `git diff --check` passes.

The full CI matrix and SQL Server 2017 Linux job were not run locally. Azure SQL DB is intentionally not the regression target: its engine-edition guards bypass these cross-database probes.