### PR TITLE
sp_BlitzWho: continue reporting when plans exceed XML nesting limits

### DIFF
--- a/sp_BlitzWho.sql
+++ b/sp_BlitzWho.sql
@@ -644,18 +644,26 @@ SELECT @BlockingCheck = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 						DECLARE @LiveQueryPlans TABLE
 						(
 							Session_Id INT NOT NULL,
-							Query_Plan XML NOT NULL
+							Query_Plan XML NULL
 						);
 
 						'
 IF EXISTS (SELECT * FROM sys.all_columns WHERE object_id = OBJECT_ID('sys.dm_exec_query_statistics_xml') AND name = 'query_plan' AND @GetLiveQueryPlan=1)
 BEGIN
 	SET @BlockingCheck = @BlockingCheck + N'
-							INSERT INTO @LiveQueryPlans
-							SELECT	s.session_id, query_plan 
-							FROM	sys.dm_exec_sessions AS s
-							CROSS APPLY sys.dm_exec_query_statistics_xml(s.session_id)
-							WHERE	s.session_id <> @@SPID;';
+							BEGIN TRY
+								INSERT INTO @LiveQueryPlans
+								SELECT s.session_id, query_plan
+								FROM sys.dm_exec_sessions AS s
+								CROSS APPLY sys.dm_exec_query_statistics_xml(s.session_id)
+								WHERE s.session_id <> @@SPID;
+							END TRY
+							BEGIN CATCH
+								/* The DMF can raise the XML depth error before a caller can TRY_CONVERT it. */
+								IF ERROR_NUMBER() <> 6335 THROW;
+								DELETE FROM @LiveQueryPlans;
+								RAISERROR(''Live query plans could not be retrieved because a plan exceeded the XML nesting limit. Continuing without live plans.'', 10, 1) WITH NOWAIT;
+							END CATCH;';
 END
 
 
@@ -887,7 +895,9 @@ SELECT @StringToExecute = N' CASE WHEN YEAR(s.last_request_start_time) = 1900 TH
 					    OR s.session_id = b.blocking_session_id)
 		    ) AS blocked
 	    OUTER APPLY sys.dm_exec_sql_text(COALESCE(r.sql_handle, blocked.sql_handle)) AS dest
-	    OUTER APPLY sys.dm_exec_query_plan(r.plan_handle) AS derp
+	    /* Retrieve the whole batch as text so oversized XML becomes NULL before output or parameter shredding. */
+	    OUTER APPLY sys.dm_exec_text_query_plan(r.plan_handle, 0, -1) AS text_plan
+	    OUTER APPLY (SELECT TRY_CONVERT(XML, text_plan.query_plan) AS query_plan) AS derp
 	    OUTER APPLY (
 			    SELECT CONVERT(DECIMAL(38,2), SUM( ((((tsu.user_objects_alloc_page_count - user_objects_dealloc_page_count) + (tsu.internal_objects_alloc_page_count - internal_objects_dealloc_page_count)) * 8) / 1024.)) ) AS tempdb_allocations_mb
 			    FROM sys.dm_db_task_space_usage tsu


### PR DESCRIPTION
An execution plan exceeding SQL Server's XML nesting limit should not prevent sp_BlitzWho from reporting sessions. Retrieve cached plans as text and TRY_CONVERT them to XML before either returning them or extracting parameters, retaining whole-batch plan scope. Oversized cached plans become NULL.

Live plans are already XML when returned by sys.dm_exec_query_statistics_xml, so a final SELECT conversion cannot protect that retrieval. Allow NULL live plans and catch error 6335 around collection. On that error, clear the live-plan collection, emit an informational notice, and continue the session report using the existing unavailable-plan message. This omits all live plans for the affected run. Other errors are rethrown.

Fixes #4054.

Validation on SQL Server 2025 (Windows) and Azure SQL Database, using isolated procedure copies:
- Normal runs with live plans enabled and disabled, expert output, actual parameters, and outer commands passed.
- Injected 132-level XML at the cached text-plan source: output-to-table completed, retained session rows, and returned NULL cached plans.
- Injected the same XML conversion failure during live collection: the original code failed with error 6335; the updated code emitted its notice and retained session rows.
- NULL live-plan collection succeeded; an unrelated injected error 51054 still failed.
- A valid cached plan retained both XML output and compiled parameter information.
- Removed all test procedures, tables, views, and worker connections. Installed sp_BlitzWho was not changed.
- git diff --check passed; SQL CRLF line endings preserved.

The oversized-plan tests inject deterministic XML into temporary procedure copies; they do not reproduce the reporter's undisclosed query workload. SQL Server 2022 and the full CI matrix were not run locally.

Microsoft documents the XML depth limit and text-plan alternative in [sys.dm_exec_query_plan](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-exec-query-plan-transact-sql) and nullable live plans in [sys.dm_exec_query_statistics_xml](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-exec-query-statistics-xml-transact-sql).