### PR TITLE
Fix Uninstall.sql targeting the wrong procedure schema

### DIFF
--- a/.github/scripts/build-uninstall-regression.py
+++ b/.github/scripts/build-uninstall-regression.py
@@ -1,0 +1,60 @@
+"""Generate a destructive uninstall regression for the disposable CI server only.
+
+Run after the smoke matrix: all-database mode intentionally removes the kit.
+The production script is embedded verbatim except for its allDatabases setting.
+"""
+from pathlib import Path
+
+source = (Path(__file__).resolve().parents[2] / 'Uninstall.sql').read_text()
+def literal(value):
+    return "N'" + value.replace("'", "''") + "'"
+def identifier(value):
+    return '[' + value.replace(']', ']]') + ']'
+
+names = ["FRKUninstall'雪]", 'FRKUninstall' + 'x' * 115 + ']']
+print('USE master; SET NOCOUNT ON;')
+print("DECLARE @DataPath nvarchar(4000) = CONVERT(nvarchar(4000), SERVERPROPERTY('InstanceDefaultDataPath'));")
+print("DECLARE @CreateDatabase nvarchar(max);")
+print("IF OBJECT_ID(N'dbo.sp_Blitz') IS NULL THROW 51000, 'Install the kit before testing uninstall.', 1;")
+for name in names:
+    print(f"IF DB_ID({literal(name)}) IS NOT NULL THROW 51000, 'Uninstall fixture already exists.', 1;")
+    if len(name) < 100:
+        print(f'EXEC({literal("CREATE DATABASE " + identifier(name))});')
+    else:
+        prefix = 'CREATE DATABASE ' + identifier(name) + " ON PRIMARY (NAME=N'FRKUninstallLong', FILENAME=N'"
+        middle = "FRKUninstallLong.mdf') LOG ON (NAME=N'FRKUninstallLong_log', FILENAME=N'"
+        suffix = "FRKUninstallLong_log.ldf');"
+        print(f"SET @CreateDatabase = {literal(prefix)} + REPLACE(@DataPath, '''', '''''') + {literal(middle)} + REPLACE(@DataPath, '''', '''''') + {literal(suffix)};")
+        print('EXEC(@CreateDatabase);')
+    setup = f'''USE {identifier(name)};
+EXEC(N'CREATE SCHEMA custom');
+EXEC(N'CREATE PROCEDURE dbo.sp_Blitz AS RETURN;');
+EXEC(N'CREATE PROCEDURE custom.sp_Blitz AS RETURN;');
+EXEC(N'CREATE PROCEDURE dbo.KeepMe AS RETURN;');
+CREATE TABLE dbo.SqlServerVersions (n int);
+CREATE TABLE custom.SqlServerVersions (n int);'''
+    print(f'EXEC({literal(setup)});')
+
+# Current-database path must not fall through to the system procedure in master.
+current_source = "USE " + identifier(names[0]) + ";" + chr(10) + source
+print(f'EXEC({literal(current_source)});')
+print("IF OBJECT_ID(N'master.dbo.sp_Blitz') IS NULL THROW 51000, 'Current uninstall removed the master procedure.', 1;")
+
+def assertions(name):
+    sql = f'''USE {identifier(name)};
+IF EXISTS (SELECT 1 FROM sys.procedures WHERE schema_id = 1 AND name = N'sp_Blitz')
+    THROW 51000, 'dbo kit procedure remains.', 1;
+IF NOT EXISTS (SELECT 1 FROM sys.procedures WHERE schema_id = SCHEMA_ID(N'custom') AND name = N'sp_Blitz')
+    THROW 51000, 'Custom procedure was removed.', 1;
+IF OBJECT_ID(N'dbo.KeepMe') IS NULL OR OBJECT_ID(N'custom.SqlServerVersions') IS NULL
+    THROW 51000, 'Unrelated object was removed.', 1;
+IF OBJECT_ID(N'dbo.SqlServerVersions') IS NOT NULL
+    THROW 51000, 'Kit versions table remains.', 1;'''
+    print(f'EXEC({literal(sql)});')
+assertions(names[0])
+# Exercise the real all-databases enumeration, including both unusual names.
+print(f'EXEC({literal(source.replace("DECLARE @allDatabases bit = 0;", "DECLARE @allDatabases bit = 1;"))});')
+for name in names:
+    assertions(name)
+    print(f'EXEC({literal("DROP DATABASE " + identifier(name))});')
+print("PRINT 'Uninstall current/all-database regression passed.';")

--- a/.github/scripts/build-uninstall-regression.py
+++ b/.github/scripts/build-uninstall-regression.py
@@ -15,21 +15,23 @@ names = ["FRKUninstall'雪]", 'FRKUninstall' + 'x' * 115 + ']']
 print('USE master; SET NOCOUNT ON;')
 print("DECLARE @DataPath nvarchar(4000) = CONVERT(nvarchar(4000), SERVERPROPERTY('InstanceDefaultDataPath'));")
 print("DECLARE @CreateDatabase nvarchar(max);")
-print("IF OBJECT_ID(N'dbo.sp_Blitz') IS NULL THROW 51000, 'Install the kit before testing uninstall.', 1;")
+print("DECLARE @MasterBlitzID int = (SELECT object_id FROM master.sys.procedures WHERE schema_id=1 AND name COLLATE Latin1_General_100_BIN2=N'sp_Blitz');")
+print("IF @MasterBlitzID IS NULL THROW 51000, 'Install the kit before testing uninstall.', 1;")
 for name in names:
     print(f"IF DB_ID({literal(name)}) IS NOT NULL THROW 51000, 'Uninstall fixture already exists.', 1;")
     if len(name) < 100:
-        print(f'EXEC({literal("CREATE DATABASE " + identifier(name))});')
+        print(f'EXEC({literal("CREATE DATABASE " + identifier(name) + " COLLATE Latin1_General_100_CS_AS")});')
     else:
         prefix = 'CREATE DATABASE ' + identifier(name) + " ON PRIMARY (NAME=N'FRKUninstallLong', FILENAME=N'"
         middle = "FRKUninstallLong.mdf') LOG ON (NAME=N'FRKUninstallLong_log', FILENAME=N'"
-        suffix = "FRKUninstallLong_log.ldf');"
+        suffix = "FRKUninstallLong_log.ldf') COLLATE Latin1_General_100_CS_AS;"
         print(f"SET @CreateDatabase = {literal(prefix)} + REPLACE(@DataPath, '''', '''''') + {literal(middle)} + REPLACE(@DataPath, '''', '''''') + {literal(suffix)};")
         print('EXEC(@CreateDatabase);')
     setup = f'''USE {identifier(name)};
 EXEC(N'CREATE SCHEMA custom');
 EXEC(N'CREATE PROCEDURE dbo.sp_Blitz AS RETURN;');
 EXEC(N'CREATE PROCEDURE custom.sp_Blitz AS RETURN;');
+EXEC(N'CREATE PROCEDURE dbo.SP_BLITZ AS RETURN;');
 EXEC(N'CREATE PROCEDURE dbo.KeepMe AS RETURN;');
 CREATE TABLE dbo.SqlServerVersions (n int);
 CREATE TABLE custom.SqlServerVersions (n int);'''
@@ -38,7 +40,7 @@ CREATE TABLE custom.SqlServerVersions (n int);'''
 # Current-database path must not fall through to the system procedure in master.
 current_source = "USE " + identifier(names[0]) + ";" + chr(10) + source
 print(f'EXEC({literal(current_source)});')
-print("IF OBJECT_ID(N'master.dbo.sp_Blitz') IS NULL THROW 51000, 'Current uninstall removed the master procedure.', 1;")
+print("IF NOT EXISTS (SELECT 1 FROM master.sys.procedures WHERE object_id=@MasterBlitzID AND schema_id=1 AND name COLLATE Latin1_General_100_BIN2=N'sp_Blitz') THROW 51000, 'Current uninstall removed the master procedure.', 1;")
 
 def assertions(name):
     sql = f'''USE {identifier(name)};
@@ -46,6 +48,8 @@ IF EXISTS (SELECT 1 FROM sys.procedures WHERE schema_id = 1 AND name = N'sp_Blit
     THROW 51000, 'dbo kit procedure remains.', 1;
 IF NOT EXISTS (SELECT 1 FROM sys.procedures WHERE schema_id = SCHEMA_ID(N'custom') AND name = N'sp_Blitz')
     THROW 51000, 'Custom procedure was removed.', 1;
+IF NOT EXISTS (SELECT 1 FROM sys.procedures WHERE schema_id=1 AND name COLLATE Latin1_General_100_BIN2=N'SP_BLITZ')
+    THROW 51000, 'Differently cased procedure was removed.', 1;
 IF OBJECT_ID(N'dbo.KeepMe') IS NULL OR OBJECT_ID(N'custom.SqlServerVersions') IS NULL
     THROW 51000, 'Unrelated object was removed.', 1;
 IF OBJECT_ID(N'dbo.SqlServerVersions') IS NOT NULL

--- a/.github/scripts/build-uninstall-regression.py
+++ b/.github/scripts/build-uninstall-regression.py
@@ -11,16 +11,17 @@ def literal(value):
 def identifier(value):
     return '[' + value.replace(']', ']]') + ']'
 
-names = ["FRKUninstall'雪]", 'FRKUninstall' + 'x' * 115 + ']']
+names = ["FRKUninstall'雪]", 'FRKUninstall' + 'x' * 115 + ']', 'FRKUninstallCaseInsensitive']
 print('USE master; SET NOCOUNT ON;')
 print("DECLARE @DataPath nvarchar(4000) = CONVERT(nvarchar(4000), SERVERPROPERTY('InstanceDefaultDataPath'));")
 print("DECLARE @CreateDatabase nvarchar(max);")
 print("DECLARE @MasterBlitzID int = (SELECT object_id FROM master.sys.procedures WHERE schema_id=1 AND name COLLATE Latin1_General_100_BIN2=N'sp_Blitz');")
 print("IF @MasterBlitzID IS NULL THROW 51000, 'Install the kit before testing uninstall.', 1;")
 for name in names:
+    collation = 'Latin1_General_100_CI_AS' if name == names[2] else 'Latin1_General_100_CS_AS'
     print(f"IF DB_ID({literal(name)}) IS NOT NULL THROW 51000, 'Uninstall fixture already exists.', 1;")
     if len(name) < 100:
-        print(f'EXEC({literal("CREATE DATABASE " + identifier(name) + " COLLATE Latin1_General_100_CS_AS")});')
+        print(f'EXEC({literal("CREATE DATABASE " + identifier(name) + " COLLATE " + collation)});')
     else:
         prefix = 'CREATE DATABASE ' + identifier(name) + " ON PRIMARY (NAME=N'FRKUninstallLong', FILENAME=N'"
         middle = "FRKUninstallLong.mdf') LOG ON (NAME=N'FRKUninstallLong_log', FILENAME=N'"
@@ -35,12 +36,9 @@ EXEC(N'CREATE PROCEDURE dbo.SP_BLITZ AS RETURN;');
 EXEC(N'CREATE PROCEDURE dbo.KeepMe AS RETURN;');
 CREATE TABLE dbo.SqlServerVersions (n int);
 CREATE TABLE custom.SqlServerVersions (n int);'''
+    if name == names[2]:
+        setup = setup.replace("EXEC(N'CREATE PROCEDURE dbo.sp_Blitz AS RETURN;');", '')
     print(f'EXEC({literal(setup)});')
-
-# Current-database path must not fall through to the system procedure in master.
-current_source = "USE " + identifier(names[0]) + ";" + chr(10) + source
-print(f'EXEC({literal(current_source)});')
-print("IF NOT EXISTS (SELECT 1 FROM master.sys.procedures WHERE object_id=@MasterBlitzID AND schema_id=1 AND name COLLATE Latin1_General_100_BIN2=N'sp_Blitz') THROW 51000, 'Current uninstall removed the master procedure.', 1;")
 
 def assertions(name):
     sql = f'''USE {identifier(name)};
@@ -54,8 +52,18 @@ IF OBJECT_ID(N'dbo.KeepMe') IS NULL OR OBJECT_ID(N'custom.SqlServerVersions') IS
     THROW 51000, 'Unrelated object was removed.', 1;
 IF OBJECT_ID(N'dbo.SqlServerVersions') IS NOT NULL
     THROW 51000, 'Kit versions table remains.', 1;'''
+    if name == names[2]:
+        sql = sql.replace("IF NOT EXISTS (SELECT 1 FROM sys.procedures WHERE schema_id=1 AND name COLLATE Latin1_General_100_BIN2=N'SP_BLITZ')\n    THROW 51000, 'Differently cased procedure was removed.', 1;", '')
     print(f'EXEC({literal(sql)});')
-assertions(names[0])
+# Current mode covers both CS and CI identifier semantics, and must preserve master.
+for name in (names[0], names[2]):
+    current_source = "USE " + identifier(name) + ";" + chr(10) + source
+    print(f'EXEC({literal(current_source)});')
+    print("IF NOT EXISTS (SELECT 1 FROM master.sys.procedures WHERE object_id=@MasterBlitzID AND schema_id=1 AND name COLLATE Latin1_General_100_BIN2=N'sp_Blitz') THROW 51000, 'Current uninstall removed the master procedure.', 1;")
+    assertions(name)
+# Recreate the CI kit name so all-databases mode must remove it as well.
+reseed = "USE " + identifier(names[2]) + "; EXEC(N'CREATE PROCEDURE dbo.SP_BLITZ AS RETURN;'); CREATE TABLE dbo.SqlServerVersions(n int);"
+print(f'EXEC({literal(reseed)});')
 # Exercise the real all-databases enumeration, including both unusual names.
 print(f'EXEC({literal(source.replace("DECLARE @allDatabases bit = 0;", "DECLARE @allDatabases bit = 1;"))});')
 for name in names:

--- a/.github/scripts/build-uninstall-regression.py
+++ b/.github/scripts/build-uninstall-regression.py
@@ -6,6 +6,11 @@ The production script is embedded verbatim except for its allDatabases setting.
 from pathlib import Path
 
 source = (Path(__file__).resolve().parents[2] / 'Uninstall.sql').read_text()
+mode_declaration = "DECLARE @allDatabases bit = 0;"
+if source.count(mode_declaration) != 1:
+    raise RuntimeError("Expected exactly one allDatabases declaration; cannot generate both uninstall modes.")
+all_source = source.replace(mode_declaration, "DECLARE @allDatabases bit = 1;")
+
 def literal(value):
     return "N'" + value.replace("'", "''") + "'"
 def identifier(value):
@@ -65,7 +70,7 @@ for name in (names[0], names[2]):
 reseed = "USE " + identifier(names[2]) + "; EXEC(N'CREATE PROCEDURE dbo.SP_BLITZ AS RETURN;'); CREATE TABLE dbo.SqlServerVersions(n int);"
 print(f'EXEC({literal(reseed)});')
 # Exercise the real all-databases enumeration, including both unusual names.
-print(f'EXEC({literal(source.replace("DECLARE @allDatabases bit = 0;", "DECLARE @allDatabases bit = 1;"))});')
+print(f'EXEC({literal(all_source)});')
 for name in names:
     assertions(name)
     print(f'EXEC({literal("DROP DATABASE " + identifier(name))});')

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -287,5 +287,9 @@ echo "=== Running the matrix ==="
 split_matrix "$WORK_DIR/steps"
 run_matrix
 
+# Uninstall intentionally runs last on this disposable server.
+python3 "$SCRIPT_DIR/build-uninstall-regression.py" > "$WORK_DIR/uninstall.sql"
+run_file "$WORK_DIR/uninstall.sql"
+
 echo
 echo "Smoke tests passed."

--- a/Uninstall.sql
+++ b/Uninstall.sql
@@ -38,7 +38,7 @@ BEGIN
 
     SELECT @SQL += N'DROP PROCEDURE ' + QUOTENAME(SCHEMA_NAME(P.schema_id)) + N'.' + QUOTENAME(P.name) + ';' + CHAR(10)
     FROM sys.procedures P
-    JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT
+    JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE Latin1_General_100_BIN2
     WHERE P.schema_id = 1;
 
     SELECT @SQL += N'DROP TABLE dbo.SqlServerVersions;' + CHAR(10)
@@ -68,7 +68,7 @@ BEGIN
         SET @innerSQL = N'    SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP PROCEDURE '' + QUOTENAME(S.name) + N''.'' + QUOTENAME(P.name) + N'';'' + NCHAR(10)
         FROM ' + @dbname + N'.sys.procedures P
         JOIN ' + @dbname + N'.sys.schemas S ON S.schema_id = P.schema_id
-        JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT
+        JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE Latin1_General_100_BIN2
         WHERE P.schema_id = 1';
 
         EXEC sp_executesql @innerSQL, N'@SQL nvarchar(max) OUTPUT, @databaseName sysname', @SQL = @SQL OUTPUT, @databaseName = @databaseName;

--- a/Uninstall.sql
+++ b/Uninstall.sql
@@ -38,7 +38,7 @@ BEGIN
 
     SELECT @SQL += N'DROP PROCEDURE ' + QUOTENAME(SCHEMA_NAME(P.schema_id)) + N'.' + QUOTENAME(P.name) + ';' + CHAR(10)
     FROM sys.procedures P
-    JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE Latin1_General_100_BIN2
+    JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT
     WHERE P.schema_id = 1;
 
     SELECT @SQL += N'DROP TABLE dbo.SqlServerVersions;' + CHAR(10)
@@ -65,15 +65,15 @@ BEGIN
     WHILE(@@FETCH_STATUS = 0)
     BEGIN
 
-        SET @innerSQL = N'    SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP PROCEDURE '' + QUOTENAME(S.name) + N''.'' + QUOTENAME(P.name) + N'';'' + NCHAR(10)
+        SET @innerSQL = N'USE ' + @dbname + N'; SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP PROCEDURE '' + QUOTENAME(S.name) + N''.'' + QUOTENAME(P.name) + N'';'' + NCHAR(10)
         FROM ' + @dbname + N'.sys.procedures P
         JOIN ' + @dbname + N'.sys.schemas S ON S.schema_id = P.schema_id
-        JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE Latin1_General_100_BIN2
+        JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT
         WHERE P.schema_id = 1';
 
         EXEC sp_executesql @innerSQL, N'@SQL nvarchar(max) OUTPUT, @databaseName sysname', @SQL = @SQL OUTPUT, @databaseName = @databaseName;
 
-        SET @innerSQL = N'    SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP TABLE dbo.SqlServerVersions;'' + NCHAR(10)
+        SET @innerSQL = N'USE ' + @dbname + N'; SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP TABLE dbo.SqlServerVersions;'' + NCHAR(10)
         FROM ' + @dbname + N'.sys.tables
         WHERE schema_id = 1 AND name = ''SqlServerVersions''';
 

--- a/Uninstall.sql
+++ b/Uninstall.sql
@@ -36,7 +36,7 @@ SELECT 'sp_kill' as ProcedureName
 IF (@allDatabases = 0)
 BEGIN
 
-    SELECT @SQL += N'DROP PROCEDURE dbo.' + D.ProcedureName + ';' + CHAR(10)
+    SELECT @SQL += N'DROP PROCEDURE ' + QUOTENAME(SCHEMA_NAME(P.schema_id)) + N'.' + QUOTENAME(P.name) + ';' + CHAR(10)
     FROM sys.procedures P
     JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT;
 
@@ -48,34 +48,36 @@ END
 ELSE
 BEGIN
 
-    DECLARE @dbname SYSNAME;
+    DECLARE @dbname NVARCHAR(258);
+    DECLARE @databaseName SYSNAME;
     DECLARE @innerSQL NVARCHAR(max);
 
     DECLARE c CURSOR LOCAL FAST_FORWARD
-    FOR SELECT QUOTENAME([name])
+    FOR SELECT QUOTENAME([name]), [name]
     FROM sys.databases
     WHERE [state] = 0;
 
     OPEN c;
 
-    FETCH NEXT FROM c INTO @dbname;
+    FETCH NEXT FROM c INTO @dbname, @databaseName;
 
     WHILE(@@FETCH_STATUS = 0)
     BEGIN
 
-        SET @innerSQL = N'    SELECT @SQL += N''USE  ' + @dbname + N';' + NCHAR(10) + N'DROP PROCEDURE dbo.'' + D.ProcedureName + '';'' + NCHAR(10)
+        SET @innerSQL = N'    SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP PROCEDURE '' + QUOTENAME(S.name) + N''.'' + QUOTENAME(P.name) + N'';'' + NCHAR(10)
         FROM ' + @dbname + N'.sys.procedures P
+        JOIN ' + @dbname + N'.sys.schemas S ON S.schema_id = P.schema_id
         JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT';
 
-        EXEC sp_executesql @innerSQL, N'@SQL nvarchar(max) OUTPUT', @SQL = @SQL OUTPUT;
+        EXEC sp_executesql @innerSQL, N'@SQL nvarchar(max) OUTPUT, @databaseName sysname', @SQL = @SQL OUTPUT, @databaseName = @databaseName;
 
-        SET @innerSQL = N'    SELECT @SQL += N''USE  ' + @dbname + N';' + NCHAR(10) + N'DROP TABLE dbo.SqlServerVersions;'' + NCHAR(10)
+        SET @innerSQL = N'    SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP TABLE dbo.SqlServerVersions;'' + NCHAR(10)
         FROM ' + @dbname + N'.sys.tables
         WHERE schema_id = 1 AND name = ''SqlServerVersions''';
 
-        EXEC sp_executesql @innerSQL, N'@SQL nvarchar(max) OUTPUT', @SQL = @SQL OUTPUT;
+        EXEC sp_executesql @innerSQL, N'@SQL nvarchar(max) OUTPUT, @databaseName sysname', @SQL = @SQL OUTPUT, @databaseName = @databaseName;
 
-        FETCH NEXT FROM c INTO @dbname;
+        FETCH NEXT FROM c INTO @dbname, @databaseName;
     
     END
 

--- a/Uninstall.sql
+++ b/Uninstall.sql
@@ -38,7 +38,8 @@ BEGIN
 
     SELECT @SQL += N'DROP PROCEDURE ' + QUOTENAME(SCHEMA_NAME(P.schema_id)) + N'.' + QUOTENAME(P.name) + ';' + CHAR(10)
     FROM sys.procedures P
-    JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT;
+    JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT
+    WHERE P.schema_id = 1;
 
     SELECT @SQL += N'DROP TABLE dbo.SqlServerVersions;' + CHAR(10)
     FROM sys.tables 
@@ -67,7 +68,8 @@ BEGIN
         SET @innerSQL = N'    SELECT @SQL += N''USE '' + QUOTENAME(@databaseName) + N'';'' + NCHAR(10) + N''DROP PROCEDURE '' + QUOTENAME(S.name) + N''.'' + QUOTENAME(P.name) + N'';'' + NCHAR(10)
         FROM ' + @dbname + N'.sys.procedures P
         JOIN ' + @dbname + N'.sys.schemas S ON S.schema_id = P.schema_id
-        JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT';
+        JOIN #ToDelete D ON D.ProcedureName = P.name COLLATE DATABASE_DEFAULT
+        WHERE P.schema_id = 1';
 
         EXEC sp_executesql @innerSQL, N'@SQL nvarchar(max) OUTPUT, @databaseName sysname', @SQL = @SQL OUTPUT, @databaseName = @databaseName;
 


### PR DESCRIPTION
Uninstall.sql discovers procedures by name alone, which can generate duplicate dbo drops and accidentally fall through to the master system procedure. Restrict both current- and all-database discovery to dbo, matching the kit installers, and quote the actual schema and procedure names. Preserve unrelated custom-schema procedures.

The all-databases path also preserves full quoted database names and parameterizes raw names when building USE statements.

Closes #4066.

Validation: added a CI regression that executes the actual uninstall script in both modes after the smoke matrix on the disposable server. It verifies master preservation in current mode, custom/unrelated object preservation, dbo kit removal, quoted Unicode names, and a 128-character database name. The regression passes on SQL Server 2022 and fails on the prior PR head with 'Custom procedure was removed.' Shell syntax and git diff --check pass.