### PR TITLE
sp_BlitzBackups: calculate restore estimates from size divided by speed

### DIFF
--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -265,6 +265,12 @@ AS
         RETURN;
     END;
 BEGIN
+IF @RestoreSpeedFullMBps <= 0 OR @RestoreSpeedDiffMBps <= 0 OR @RestoreSpeedLogMBps <= 0
+BEGIN
+    RAISERROR('Restore speed overrides must be greater than zero, or NULL to use observed backup speeds.', 16, 1);
+    RETURN;
+END;
+
 DECLARE @StringToExecute NVARCHAR(MAX) = N'', 
 		@InnerStringToExecute NVARCHAR(MAX) = N'',
 		@ProductVersion NVARCHAR(128), 
@@ -742,18 +748,18 @@ RAISERROR('Gathering RTO worst cases', 0, 1) WITH NOWAIT;
                                                                     /* Fulls */
                                                                     (CASE WHEN @RestoreSpeedFullMBps IS NULL 
 																	   THEN wc.full_time_seconds / 60.0
-																	   ELSE @RestoreSpeedFullMBps / wc.full_file_size_mb
+																	   ELSE wc.full_file_size_mb / @RestoreSpeedFullMBps / 60.0
 																	   END)
 
                                                                     /* Diffs, which might not have been taken */
                                                                     + (CASE WHEN @RestoreSpeedDiffMBps IS NOT NULL AND wc.diff_file_size_mb IS NOT NULL
-                                                                        THEN @RestoreSpeedDiffMBps / wc.diff_file_size_mb
+                                                                        THEN wc.diff_file_size_mb / @RestoreSpeedDiffMBps / 60.0
                                                                         ELSE COALESCE(wc.diff_time_seconds,0) / 60.0
                                                                         END)
 
                                                                     /* Logs, which might not have been taken */
                                                                     + (CASE WHEN @RestoreSpeedLogMBps IS NOT NULL AND wc.log_file_size_mb IS NOT NULL
-                                                                        THEN @RestoreSpeedLogMBps / wc.log_file_size_mb
+                                                                        THEN wc.log_file_size_mb / @RestoreSpeedLogMBps / 60.0
                                                                         ELSE COALESCE(wc.log_time_seconds,0) / 60.0
                                                                         END)
 								        , RTOWorstCaseBackupFileSizeMB = wc.rto_worst_case_size_mb


### PR DESCRIPTION
Restore-speed overrides currently calculate speed divided by backup size and omit conversion to minutes, producing near-zero recovery estimates for large backups. Calculate each full, differential, and log component as MB / MB-per-second / 60. Reject zero or negative overrides before collecting history; NULL continues to use observed durations.

Closes #4069.

Validation: SQL Server 2022 isolated backup-history fixtures returned 111 minutes for a 600,000 MB full + 60,000 MB differential + 6,000 MB log at 100 MB/sec, and 55.5 minutes at 200 MB/sec. Also verified default observed durations, each override independently with the others NULL, and rejection of zero/negative values for all three parameters. Test-only result capture did not alter calculations. The exact source installed and ran successfully on Windows SQL Server 2025 with default and explicit overrides. `git diff --check` passed.