### PR TITLE
sp_Blitz: preserve unrelated findings when skipping check 80

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -8242,7 +8242,7 @@ IF NOT EXISTS ( SELECT  1
 
 								DELETE br
 								FROM #BlitzResults br
-								INNER JOIN #SkipChecks sc ON sc.CheckID = 80 AND br.DatabaseName = sc.DatabaseName;
+								INNER JOIN #SkipChecks sc ON sc.CheckID = 80 AND br.CheckID = sc.CheckID AND br.DatabaseName = sc.DatabaseName;
 					        END;
                             
 	


### PR DESCRIPTION
A database-specific skip for check 80 currently deletes every finding already collected for that database. Match the finding's CheckID as well as its database when applying this skip.

Closes #4086.

Validation: ran the complete changed procedure twice on SQL Server 2022 against an isolated database with a maximum file size configured. Before skipping, findings 1, 2, 80, and 230 were present. After skipping check 80, findings 1, 2, and 230 remained and only 80 disappeared. Assertions explicitly verified the max-file-size warning was removed and the unrelated backup warning remained. Fixture database removed; `git diff --check` passed.