### PR TITLE
sp_BlitzCache: correct statement CPU and duration percentages

### DIFF
--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -2333,10 +2333,10 @@ BEGIN
                 ELSE CAST((total_worker_time / 1000.0) / COALESCE(age_minutes, DATEDIFF(mi, qs.creation_time, qs.last_execution_time)) AS MONEY)
                 END AS AverageCPUPerMinute ,
            CASE WHEN t.t_TotalWorker = 0 THEN 0
-                ELSE CAST(ROUND(100.00 * total_worker_time / t.t_TotalWorker, 2) AS MONEY)
+                ELSE CAST(ROUND(100.00 * (total_worker_time / 1000.0) / t.t_TotalWorker, 2) AS MONEY)
                 END AS PercentCPUByType,
            CASE WHEN t.t_TotalElapsed = 0 THEN 0
-                ELSE CAST(ROUND(100.00 * total_elapsed_time / t.t_TotalElapsed, 2) AS MONEY)
+                ELSE CAST(ROUND(100.00 * (total_elapsed_time / 1000.0) / t.t_TotalElapsed, 2) AS MONEY)
                 END AS PercentDurationByType,
            CASE WHEN t.t_TotalReads = 0 THEN 0
                 ELSE CAST(ROUND(100.00 * total_logical_reads / t.t_TotalReads, 2) AS MONEY)


### PR DESCRIPTION
Statement percentages divide microsecond numerators by millisecond totals, inflating CPU and duration percentages by 1,000. Convert the statement numerators to milliseconds, matching the existing procedure/function calculation.

Closes #4082.

Validation: installed the changed procedure on SQL Server 2022 and exercised statement results with both @SkipAnalysis=1 and full analysis with @ExpertMode=2. Assertions checked CPU and duration percentages against the collected totals, allowing only the documented output rounding and integer-total precision. For example, 9.355 ms of 449 ms total now reports 2.08% CPU. `git diff --check` passed.