### PR TITLE
sp_Blitz: skip the 32-bit edition warning on Azure SQL Database

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -3989,7 +3989,7 @@ BEGIN
 				IF NOT EXISTS ( SELECT  1
 								FROM    #SkipChecks
 								WHERE   DatabaseName IS NULL AND CheckID = 154 )
-                    AND SERVERPROPERTY('EngineEdition') <> 8
+                    AND SERVERPROPERTY('EngineEdition') NOT IN (5, 8) /* Azure SQL DB and Managed Instance */
 					BEGIN
 
 						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 154) WITH NOWAIT;


### PR DESCRIPTION
Azure SQL Database's edition label does not contain `64`, so check 154 incorrectly reports a priority-10 warning that 32-bit SQL Server is installed. Exclude EngineEdition 5 alongside the existing Managed Instance exclusion.

Closes #4085.

Validation: installed the changed sp_Blitz and its helper in an isolated schema on Azure SQL Database, ran user-object and server-info checks with persisted output, and asserted that findings were returned without check 154. Removed the test schema and verified all 21 existing dbo procedure definition hashes were unchanged. `git diff --check` passed.