### PR TITLE
sp_Blitz: attribute recompile warnings to the correct procedure schema

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -1095,10 +1095,10 @@ BEGIN
 
         DROP TABLE IF EXISTS #Recompile;
         CREATE TABLE #Recompile(
-            DBName varchar(200),
-            ProcName varchar(300),
+            DBName nvarchar(128),
+            ProcName nvarchar(128),
             RecompileFlag varchar(1),
-            SPSchema varchar(50)
+            SPSchema nvarchar(128)
         );
 
 		DROP TABLE IF EXISTS #DatabaseDefaults;
@@ -7981,10 +7981,10 @@ IF NOT EXISTS ( SELECT  1
 								EXECUTE dbo.sp_ineachdb @suppress_quotename = 1, @command = 'USE [?];
                                     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
                                     INSERT INTO #Recompile
-                                    SELECT DISTINCT DBName = DB_Name(), SPName = SO.name, SM.is_recompiled, ISR.SPECIFIC_SCHEMA
+                                    SELECT DBName = DB_Name(), SPName = SO.name, SM.is_recompiled, S.name
                                     FROM sys.sql_modules AS SM
-                                    LEFT OUTER JOIN dbo.sysobjects AS SO ON SM.object_id = SO.id and type = ''P''
-                                    LEFT OUTER JOIN INFORMATION_SCHEMA.ROUTINES AS ISR on ISR.Routine_Name = SO.name AND ISR.SPECIFIC_CATALOG = DB_Name()
+                                    INNER JOIN sys.procedures AS SO ON SM.object_id = SO.object_id
+                                    INNER JOIN sys.schemas AS S ON SO.schema_id = S.schema_id
                                     WHERE SM.is_recompiled=1  OPTION (RECOMPILE); /* oh the rich irony of recompile here */
                                     ';
                                 INSERT INTO #BlitzResults


### PR DESCRIPTION
Check 78 matches routines by name alone, so one procedure declared WITH RECOMPILE can cause a same-named procedure in another schema to be flagged. Resolve the procedure and schema by their object/schema IDs. Store the collected identifiers as nvarchar(128) so valid long and Unicode schema names survive collection.

Closes #4087.

Validation: the complete changed procedure passed a SQL Server 2022 regression with dbo.CodexTwin (WITH RECOMPILE), other.CodexTwin (without), and a second recompiling procedure in a 128-character Unicode schema. Assertions verified exactly the two actual recompiling procedures were reported, the non-recompiling twin was absent, and the long schema name was preserved. Fixture database removed; `git diff --check` passed.