### PR TITLE
sp_BlitzCache: validate unsupported sort and query-filter combinations

### DIFF
--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -141,6 +141,58 @@ EXEC dbo.sp_BlitzCache
      @OutputSchemaName   = 'dbo',
      @OutputTableName    = 'BlitzCache';
 
+--#STEP: sp_BlitzCache rejects unsupported filters before reanalysis
+/* Populate real results in this session so @Reanalyze cannot silently fall
+   back to a fresh collection. */
+EXEC dbo.sp_BlitzCache @Top = 1;
+IF OBJECT_ID(N'tempdb..##BlitzCacheResults') IS NULL
+    THROW 51000, 'Reanalysis fixture was not created.', 1;
+DECLARE @Cases TABLE (SortOrder varchar(50), QueryFilter varchar(10));
+INSERT @Cases
+SELECT s.SortOrder, f.QueryFilter
+FROM (VALUES ('memory grant'), ('avg memory grant'), ('unused grant'), ('duplicate')) s(SortOrder)
+CROSS JOIN (VALUES ('procedures'), ('functions')) f(QueryFilter);
+INSERT @Cases VALUES ('spills', 'functions'), ('avg spills', 'functions'),
+    ('average memory grants', 'procedures'), ('duplicates', 'functions'),
+    ('query hash, average memory grants', 'procedures');
+DECLARE @Sort varchar(50), @Filter varchar(10), @Reanalyze bit;
+BEGIN TRY
+    WHILE EXISTS (SELECT 1 FROM @Cases)
+    BEGIN
+        SELECT TOP (1) @Sort = SortOrder, @Filter = QueryFilter FROM @Cases;
+        SET @Reanalyze = 0;
+        WHILE @Reanalyze IS NOT NULL
+        BEGIN
+            BEGIN TRY
+                EXEC dbo.sp_BlitzCache @Top = 1, @SortOrder = @Sort,
+                     @QueryFilter = @Filter, @Reanalyze = @Reanalyze;
+                THROW 51000, 'Unsupported sort/filter combination was accepted.', 1;
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() <> 50000 OR
+                   (ERROR_MESSAGE() NOT LIKE 'This sort order requires statement statistics.%'
+                    AND ERROR_MESSAGE() NOT LIKE 'Function statistics do not support sorting by spills.%')
+                    THROW;
+            END CATCH;
+            SET @Reanalyze = CASE WHEN @Reanalyze = 0 THEN 1 END;
+        END;
+        DELETE @Cases WHERE SortOrder = @Sort AND QueryFilter = @Filter;
+    END;
+    DROP TABLE ##BlitzCacheResults;
+END TRY
+BEGIN CATCH
+    DROP TABLE IF EXISTS ##BlitzCacheResults;
+    THROW;
+END CATCH;
+
+--#STEP: sp_BlitzCache supported filters and query-hash aliases
+EXEC dbo.sp_BlitzCache @Top = 1, @QueryFilter = 'procedures', @SortOrder = 'cpu';
+EXEC dbo.sp_BlitzCache @Top = 1, @QueryFilter = 'functions', @SortOrder = 'cpu';
+EXEC dbo.sp_BlitzCache @Top = 1, @QueryFilter = 'procedures', @SortOrder = 'spills';
+EXEC dbo.sp_BlitzCache @Top = 1, @QueryFilter = 'statements', @SortOrder = 'average memory grants';
+EXEC dbo.sp_BlitzCache @Top = 1, @QueryFilter = 'statements', @SortOrder = 'query hash, average reads';
+EXEC dbo.sp_BlitzCache @Top = 1, @QueryFilter = 'statements', @SortOrder = 'query hash';
+
 --#STEP: sp_BlitzCache filtered to database
 EXEC dbo.sp_BlitzCache @DatabaseName = 'FRKSmokeTest';
 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -868,6 +868,70 @@ IF (
    END;
 
 
+/* Normalize and reject incompatible filters before collecting plan-cache data. */
+DECLARE @SortByQueryHash bit = CASE WHEN @SortOrder LIKE 'query hash%' THEN 1 ELSE 0 END;
+IF @SortByQueryHash = 1
+BEGIN
+	/* When they ran it, @SortOrder probably looked like 'query hash, cpu', so strip the first sort order out: */
+    SELECT @SortOrder = LTRIM(REPLACE(REPLACE(@SortOrder,'query hash', ''), ',', ''));
+
+	/* If they just called it with @SortOrder = 'query hash', set it to 'cpu' for backwards compatibility: */
+	IF @SortOrder = '' SET @SortOrder = 'cpu';
+
+END;
+
+SET @SortOrder = REPLACE(REPLACE(@SortOrder, 'average', 'avg'), '.', '');
+
+SET @SortOrder = CASE
+                     WHEN @SortOrder IN ('executions per minute','execution per minute','executions / minute','execution / minute','xpm') THEN 'avg executions'
+                     WHEN @SortOrder IN ('recent compilations','recent compilation','compile') THEN 'compiles'
+                     WHEN @SortOrder IN ('read') THEN 'reads'
+                     WHEN @SortOrder IN ('avg read') THEN 'avg reads'
+                     WHEN @SortOrder IN ('write') THEN 'writes'
+                     WHEN @SortOrder IN ('avg write') THEN 'avg writes'
+                     WHEN @SortOrder IN ('memory grants') THEN 'memory grant'
+                     WHEN @SortOrder IN ('avg memory grants') THEN 'avg memory grant'
+                     WHEN @SortOrder IN ('unused grants','unused memory', 'unused memory grant', 'unused memory grants') THEN 'unused grant'
+                     WHEN @SortOrder IN ('spill') THEN 'spills'
+                     WHEN @SortOrder IN ('avg spill') THEN 'avg spills'
+                     WHEN @SortOrder IN ('execution') THEN 'executions'
+                     WHEN @SortOrder IN ('duplicates') THEN 'duplicate'
+                 ELSE @SortOrder END
+
+RAISERROR(N'Checking sort order', 0, 1) WITH NOWAIT;
+IF @SortOrder NOT IN ('cpu', 'avg cpu', 'reads', 'avg reads', 'writes', 'avg writes',
+                       'duration', 'avg duration', 'executions', 'avg executions',
+                       'compiles', 'memory grant', 'avg memory grant', 'unused grant',
+					   'spills', 'avg spills', 'all', 'all avg', 'sp_BlitzIndex',
+					   'query hash', 'duplicate')
+  BEGIN
+  RAISERROR(N'Invalid sort order chosen, reverting to cpu', 16, 1) WITH NOWAIT;
+  SET @SortOrder = 'cpu';
+  END;
+
+SET @QueryFilter = LOWER(@QueryFilter);
+
+IF LEFT(@QueryFilter, 3) NOT IN ('all', 'sta', 'pro', 'fun')
+  BEGIN
+  RAISERROR(N'Invalid query filter chosen. Reverting to all.', 0, 1) WITH NOWAIT;
+  SET @QueryFilter = 'all';
+  END;
+
+/* Procedure and function DMVs do not expose statement memory-grant or duplicate data. */
+IF LEFT(@QueryFilter, 3) IN ('pro', 'fun')
+   AND @SortOrder IN ('memory grant', 'avg memory grant', 'unused grant', 'duplicate')
+BEGIN
+   RAISERROR('This sort order requires statement statistics. Use @QueryFilter = ''statements'' or choose another sort order.', 16, 1);
+   RETURN;
+END;
+
+/* Function statistics do not expose spill counters. */
+IF LEFT(@QueryFilter, 3) = 'fun' AND @SortOrder IN ('spills', 'avg spills')
+BEGIN
+   RAISERROR('Function statistics do not support sorting by spills. Use @QueryFilter = ''statements'' or choose another sort order.', 16, 1);
+   RETURN;
+END;
+
 DROP TABLE IF EXISTS #configuration;
 
 CREATE TABLE #configuration (
@@ -1086,7 +1150,7 @@ Return one self-contained Markdown response with prioritized findings, recommend
 
 
 /* If they want to sort by query hash, populate the @OnlyQueryHashes list for them */
-IF @SortOrder LIKE 'query hash%'
+IF @SortByQueryHash = 1
 	BEGIN
 	RAISERROR('Beginning query hash sort', 0, 1) WITH NOWAIT;
 
@@ -1110,11 +1174,6 @@ IF @SortOrder LIKE 'query hash%'
     FOR XML PATH(N''), TYPE).value(N'.[1]', N'NVARCHAR(MAX)'), 1, 1, N'')
 	OPTION(RECOMPILE);
 
-	/* When they ran it, @SortOrder probably looked like 'query hash, cpu', so strip the first sort order out: */
-    SELECT @SortOrder = LTRIM(REPLACE(REPLACE(@SortOrder,'query hash', ''), ',', ''));
-	
-	/* If they just called it with @SortOrder = 'query hash', set it to 'cpu' for backwards compatibility: */
-	IF @SortOrder = '' SET @SortOrder = 'cpu';
 
 	END
 
@@ -1227,43 +1286,6 @@ BEGIN
 END;
 
 SELECT @MinMemoryPerQuery = CONVERT(INT, c.value) FROM sys.configurations AS c WHERE c.name = 'min memory per query (KB)';
-
-SET @SortOrder = REPLACE(REPLACE(@SortOrder, 'average', 'avg'), '.', '');
-
-SET @SortOrder = CASE 
-                     WHEN @SortOrder IN ('executions per minute','execution per minute','executions / minute','execution / minute','xpm') THEN 'avg executions'
-                     WHEN @SortOrder IN ('recent compilations','recent compilation','compile') THEN 'compiles'
-                     WHEN @SortOrder IN ('read') THEN 'reads'
-                     WHEN @SortOrder IN ('avg read') THEN 'avg reads'
-                     WHEN @SortOrder IN ('write') THEN 'writes'
-                     WHEN @SortOrder IN ('avg write') THEN 'avg writes'
-                     WHEN @SortOrder IN ('memory grants') THEN 'memory grant'
-                     WHEN @SortOrder IN ('avg memory grants') THEN 'avg memory grant'
-                     WHEN @SortOrder IN ('unused grants','unused memory', 'unused memory grant', 'unused memory grants') THEN 'unused grant'
-                     WHEN @SortOrder IN ('spill') THEN 'spills'
-                     WHEN @SortOrder IN ('avg spill') THEN 'avg spills'
-                     WHEN @SortOrder IN ('execution') THEN 'executions'
-                     WHEN @SortOrder IN ('duplicates') THEN 'duplicate'
-                 ELSE @SortOrder END							  
-							  
-RAISERROR(N'Checking sort order', 0, 1) WITH NOWAIT;
-IF @SortOrder NOT IN ('cpu', 'avg cpu', 'reads', 'avg reads', 'writes', 'avg writes',
-                       'duration', 'avg duration', 'executions', 'avg executions',
-                       'compiles', 'memory grant', 'avg memory grant', 'unused grant',
-					   'spills', 'avg spills', 'all', 'all avg', 'sp_BlitzIndex',
-					   'query hash', 'duplicate')
-  BEGIN
-  RAISERROR(N'Invalid sort order chosen, reverting to cpu', 16, 1) WITH NOWAIT;
-  SET @SortOrder = 'cpu';
-  END; 
-
-SET @QueryFilter = LOWER(@QueryFilter);
-
-IF LEFT(@QueryFilter, 3) NOT IN ('all', 'sta', 'pro', 'fun')
-  BEGIN
-  RAISERROR(N'Invalid query filter chosen. Reverting to all.', 0, 1) WITH NOWAIT;
-  SET @QueryFilter = 'all';
-  END;
 
 IF @SkipAnalysis = 1
   BEGIN
@@ -2022,21 +2044,6 @@ BEGIN
    RETURN;
 END;
 
-
-/* Procedure and function DMVs do not expose statement memory-grant or duplicate data. */
-IF LEFT(@QueryFilter, 3) IN ('pro', 'fun')
-   AND @SortOrder IN ('memory grant', 'avg memory grant', 'unused grant', 'duplicate')
-BEGIN
-   RAISERROR('This sort order requires statement statistics. Use @QueryFilter = ''statements'' or choose another sort order.', 16, 1);
-   RETURN;
-END;
-
-/* Function statistics do not expose spill counters. */
-IF LEFT(@QueryFilter, 3) = 'fun' AND @SortOrder IN ('spills', 'avg spills')
-BEGIN
-   RAISERROR('Function statistics do not support sorting by spills. Use @QueryFilter = ''statements'' or choose another sort order.', 16, 1);
-   RETURN;
-END;
 
 RAISERROR (N'Creating dynamic SQL based on SQL Server version.',0,1) WITH NOWAIT;
 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -2023,6 +2023,21 @@ BEGIN
 END;
 
 
+/* Procedure and function DMVs do not expose statement memory-grant or duplicate data. */
+IF LEFT(@QueryFilter, 3) IN ('pro', 'fun')
+   AND @SortOrder IN ('memory grant', 'avg memory grant', 'unused grant', 'duplicate')
+BEGIN
+   RAISERROR('This sort order requires statement statistics. Use @QueryFilter = ''statements'' or choose another sort order.', 16, 1);
+   RETURN;
+END;
+
+/* Function statistics do not expose spill counters. */
+IF LEFT(@QueryFilter, 3) = 'fun' AND @SortOrder IN ('spills', 'avg spills')
+BEGIN
+   RAISERROR('Function statistics do not support sorting by spills. Use @QueryFilter = ''statements'' or choose another sort order.', 16, 1);
+   RETURN;
+END;
+
 RAISERROR (N'Creating dynamic SQL based on SQL Server version.',0,1) WITH NOWAIT;
 
 SET @insert_list += N'


### PR DESCRIPTION
Explicit procedure/function filters bypass the normal exclusions for sorts whose columns their DMVs do not expose. For example, procedure memory-grant sorting fails with `Invalid column name 'max_grant_kb'`, and function spill sorting fails with `Invalid column name 'max_spills'`.

Reject unsupported combinations with an actionable message directing the caller to statement statistics or another sort. Cover memory-grant/average/unused and duplicate sorts for procedures/functions, plus spills/average spills for functions. Preserve procedure spill sorting and supported statement/all filters.

Closes #4083.

Validation: SQL Server 2022 tests verified the intended error messages for ten unsupported combinations and successful execution for six supported controls: procedure CPU/spills, function CPU, statement memory grants/spills, and all with memory grants. No invalid-column errors occurred. `git diff --check` passed.