### PR TITLE
sp_BlitzCache: validate reserved output names before quoting them

### DIFF
--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -146,7 +146,7 @@ EXEC dbo.sp_BlitzCache
    procedure's comparisons case-sensitive even when master/tempdb are not. */
 IF DB_ID(N'FRKReservedNameTest') IS NOT NULL
     THROW 51000, 'Reserved-name fixture database already exists.', 1;
-CREATE DATABASE FRKReservedNameTest COLLATE Latin1_General_100_CS_AS;
+EXEC(N'CREATE DATABASE FRKReservedNameTest COLLATE Latin1_General_100_CS_AS;');
 BEGIN TRY
     DECLARE @Definition nvarchar(max) = OBJECT_DEFINITION(OBJECT_ID(N'dbo.sp_BlitzCache'));
     SET @Definition = REPLACE(@Definition, N'ALTER PROCEDURE dbo.sp_BlitzCache', N'CREATE PROCEDURE dbo.sp_BlitzCache');

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -152,12 +152,14 @@ BEGIN TRY
     SET @Definition = REPLACE(@Definition, N'ALTER PROCEDURE dbo.sp_BlitzCache', N'CREATE PROCEDURE dbo.sp_BlitzCache');
     EXEC FRKReservedNameTest.sys.sp_executesql @Definition;
 
-    DECLARE @Names TABLE (Name sysname, SortOrder varchar(50), Qualified bit);
+    DECLARE @Names TABLE (Name sysname COLLATE Latin1_General_100_BIN2, SortOrder varchar(50), Qualified bit);
     INSERT @Names VALUES
         (N'##BlitzCacheProcs', 'cpu', 0),
         (N'##BlitzCacheResults', 'cpu', 0),
         (N'##blitzcacheprocs', 'duplicate', 0),
         (N'##BLITZCACHERESULTS', 'query hash', 0),
+        (N'##BlitzCachéProcs', 'cpu', 0),
+        (N'##ＢlitzCacheResults', 'cpu', 0),
         (N'##BlitzCacheProcs', 'cpu', 1),
         (N'##BlitzCacheResults', 'cpu', 1);
     DECLARE @Name sysname, @Sort varchar(50), @Qualified bit,

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -141,6 +141,70 @@ EXEC dbo.sp_BlitzCache
      @OutputSchemaName   = 'dbo',
      @OutputTableName    = 'BlitzCache';
 
+--#STEP: sp_BlitzCache reserved global names in a case-sensitive database
+/* This runner owns a disposable SQL Server. A separate database makes the
+   procedure's comparisons case-sensitive even when master/tempdb are not. */
+IF DB_ID(N'FRKReservedNameTest') IS NOT NULL
+    THROW 51000, 'Reserved-name fixture database already exists.', 1;
+CREATE DATABASE FRKReservedNameTest COLLATE Latin1_General_100_CS_AS;
+BEGIN TRY
+    DECLARE @Definition nvarchar(max) = OBJECT_DEFINITION(OBJECT_ID(N'dbo.sp_BlitzCache'));
+    SET @Definition = REPLACE(@Definition, N'ALTER PROCEDURE dbo.sp_BlitzCache', N'CREATE PROCEDURE dbo.sp_BlitzCache');
+    EXEC FRKReservedNameTest.sys.sp_executesql @Definition;
+
+    DECLARE @Names TABLE (Name sysname, SortOrder varchar(50), Qualified bit);
+    INSERT @Names VALUES
+        (N'##BlitzCacheProcs', 'cpu', 0),
+        (N'##BlitzCacheResults', 'cpu', 0),
+        (N'##blitzcacheprocs', 'duplicate', 0),
+        (N'##BLITZCACHERESULTS', 'query hash', 0),
+        (N'##BlitzCacheProcs', 'cpu', 1),
+        (N'##BlitzCacheResults', 'cpu', 1);
+    DECLARE @Name sysname, @Sort varchar(50), @Qualified bit,
+            @OutputDB sysname, @OutputSchema sysname;
+    WHILE EXISTS (SELECT 1 FROM @Names)
+    BEGIN
+        SELECT TOP (1) @Name = Name, @Sort = SortOrder, @Qualified = Qualified FROM @Names;
+        SELECT @OutputDB = CASE WHEN @Qualified = 1 THEN N'FRKReservedNameTest' END,
+               @OutputSchema = CASE WHEN @Qualified = 1 THEN N'dbo' END;
+        BEGIN TRY
+            EXEC FRKReservedNameTest.dbo.sp_BlitzCache
+                 @Top = 1, @SortOrder = @Sort, @OutputTableName = @Name,
+                 @OutputDatabaseName = @OutputDB, @OutputSchemaName = @OutputSchema;
+            THROW 51000, 'Reserved global name was accepted.', 1;
+        END TRY
+        BEGIN CATCH
+            IF ERROR_NUMBER() <> 50000 OR ERROR_MESSAGE() NOT LIKE 'OutputTableName is a reserved name%'
+                THROW;
+        END CATCH;
+        DELETE @Names WHERE Name = @Name AND SortOrder = @Sort AND Qualified = @Qualified;
+    END;
+    DROP DATABASE FRKReservedNameTest;
+END TRY
+BEGIN CATCH
+    DROP DATABASE FRKReservedNameTest;
+    THROW;
+END CATCH;
+
+--#STEP: sp_BlitzCache ordinary global output still works
+IF OBJECT_ID(N'tempdb..##FRKCacheOutput') IS NOT NULL
+    THROW 51000, 'Global-output fixture already exists.', 1;
+BEGIN TRY
+    EXEC FRKSmokeTest.sys.sp_executesql N'SELECT SUM(CONVERT(bigint, a.Id)) FROM dbo.Users a CROSS JOIN dbo.Users b;';
+    EXEC dbo.sp_BlitzCache @Top = 5, @DatabaseName = N'FRKSmokeTest',
+         @MinimumExecutionCount = 0, @OutputTableName = N'##FRKCacheOutput';
+    IF OBJECT_ID(N'tempdb..##FRKCacheOutput') IS NULL
+       OR COL_LENGTH(N'tempdb..##FRKCacheOutput', N'QueryText') IS NULL
+        THROW 51000, 'Global cache output is missing or has the wrong schema.', 1;
+    IF (SELECT COUNT(*) FROM ##FRKCacheOutput) < 1
+        THROW 51000, 'Global cache output is unexpectedly empty.', 1;
+    DROP TABLE ##FRKCacheOutput;
+END TRY
+BEGIN CATCH
+    DROP TABLE IF EXISTS ##FRKCacheOutput;
+    THROW;
+END CATCH;
+
 --#STEP: sp_BlitzCache filtered to database
 EXEC dbo.sp_BlitzCache @DatabaseName = 'FRKSmokeTest';
 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -1156,6 +1156,12 @@ BEGIN
     RETURN;
 END;
 
+IF @OutputTableName IN ('##BlitzCacheProcs', '##BlitzCacheResults')
+BEGIN
+    RAISERROR('OutputTableName is a reserved name for this procedure. We only use ##BlitzCacheProcs and ##BlitzCacheResults, please choose another table name.', 16, 1);
+    RETURN;
+END;
+
 IF @MinutesBack IS NOT NULL
     BEGIN
         RAISERROR(N'Checking @MinutesBack validity.', 0, 1) WITH NOWAIT;
@@ -8590,10 +8596,6 @@ END ';
 			IF @ValidOutputServer = 1
 				BEGIN
 					RAISERROR('Due to the nature of temporary tables, outputting to a linked server requires a permanent table.', 16, 0);
-				END;
-			ELSE IF @OutputTableName IN ('##BlitzCacheProcs','##BlitzCacheResults')
-				BEGIN
-					RAISERROR('OutputTableName is a reserved name for this procedure. We only use ##BlitzCacheProcs and ##BlitzCacheResults, please choose another table name.', 16, 0);
 				END;
 			ELSE
 				BEGIN				

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -847,6 +847,13 @@ BEGIN
     SET @HideSummary = 1;
 END;
 
+/* Reject internal global-table names before any plan-cache preprocessing. */
+IF @OutputTableName COLLATE Latin1_General_100_CI_AS IN ('##BlitzCacheProcs', '##BlitzCacheResults')
+BEGIN
+    RAISERROR('OutputTableName is a reserved name for this procedure. We only use ##BlitzCacheProcs and ##BlitzCacheResults, please choose another table name.', 16, 1);
+    RETURN;
+END;
+
 /* Lets get @SortOrder set to lower case here for comparisons later */
 SET @SortOrder = LOWER(@SortOrder);
 
@@ -1153,12 +1160,6 @@ IF @Top IS NULL
     OR @Reanalyze IS NULL
 BEGIN
     RAISERROR(N'Several parameters (@Top, @SortOrder, @QueryFilter, @Reanalyze) are required. Do not set them to NULL. Please try again.', 16, 1) WITH NOWAIT;
-    RETURN;
-END;
-
-IF @OutputTableName IN ('##BlitzCacheProcs', '##BlitzCacheResults')
-BEGIN
-    RAISERROR('OutputTableName is a reserved name for this procedure. We only use ##BlitzCacheProcs and ##BlitzCacheResults, please choose another table name.', 16, 1);
     RETURN;
 END;
 

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -847,8 +847,8 @@ BEGIN
     SET @HideSummary = 1;
 END;
 
-/* Reject internal global-table names before any plan-cache preprocessing. */
-IF @OutputTableName COLLATE Latin1_General_100_CI_AS IN ('##BlitzCacheProcs', '##BlitzCacheResults')
+/* Reserve case/accent/kana/width-equivalent internal names before preprocessing. */
+IF @OutputTableName COLLATE Latin1_General_100_CI_AI IN ('##BlitzCacheProcs', '##BlitzCacheResults')
 BEGIN
     RAISERROR('OutputTableName is a reserved name for this procedure. We only use ##BlitzCacheProcs and ##BlitzCacheResults, please choose another table name.', 16, 1);
     RETURN;


### PR DESCRIPTION
Output directed to the internal ##BlitzCacheProcs or ##BlitzCacheResults tables can bypass the reserved-name check because the old comparison runs after QUOTENAME. Validate raw names with an explicit case-insensitive collation before plan-cache preprocessing and return the explanatory error immediately, including when the procedure is installed in a case-sensitive database.

Schema qualification does not make a ## name permanent on SQL Server, so qualified reserved names remain rejected.

Closes #4088.

Validation: added two automated SQL smoke matrix steps. A case-sensitive database hosts the procedure and tests both reserved names, case variants, duplicate/query-hash sorts, and qualified destinations. A real cached workload verifies an ordinary global output table contains rows and the expected schema. These regressions passed on SQL Server 2022 Linux; the previous PR head fails the new regression with an invalid-column error after a lowercase name bypasses validation. git diff --check passed. Generated installers are unchanged per CONTRIBUTING.md.