### PR TITLE
sp_BlitzAnalysis: apply the schema default before building history names

### DIFF
--- a/.github/scripts/analysis-schema-regression.sql
+++ b/.github/scripts/analysis-schema-regression.sql
@@ -1,0 +1,29 @@
+USE FRKSmokeTest;
+SET NOCOUNT ON;
+IF SCHEMA_ID(N'FRKAnalysisSmoke') IS NULL EXEC(N'CREATE SCHEMA FRKAnalysisSmoke');
+DROP TABLE IF EXISTS dbo.FRKSchemaHistory;
+DROP TABLE IF EXISTS FRKAnalysisSmoke.FRKSchemaHistory;
+CREATE TABLE dbo.FRKSchemaHistory
+(ServerName nvarchar(128), CheckDate datetimeoffset, CheckID int, Priority int,
+ FindingsGroup nvarchar(128), Finding nvarchar(128), URL nvarchar(256),
+ Details nvarchar(max), HowToStopIt nvarchar(max), QueryPlan xml, QueryText nvarchar(max));
+INSERT dbo.FRKSchemaHistory VALUES
+(@@SERVERNAME, SYSDATETIMEOFFSET(), 1, 10, N'Test', N'FRK_DBO_SCHEMA_SENTINEL', NULL, NULL, NULL, NULL, NULL);
+SELECT * INTO FRKAnalysisSmoke.FRKSchemaHistory FROM dbo.FRKSchemaHistory;
+UPDATE FRKAnalysisSmoke.FRKSchemaHistory SET Finding = N'FRK_CUSTOM_SCHEMA_SENTINEL';
+BEGIN TRY
+    EXEC master.dbo.sp_BlitzAnalysis @OutputDatabaseName = N'FRKSmokeTest',
+         @OutputSchemaName = $(SchemaArgument), @OutputTableNameBlitzFirst = N'FRKSchemaHistory',
+         @OutputTableNameFileStats = NULL, @OutputTableNamePerfmonStats = NULL,
+         @OutputTableNameWaitStats = NULL, @OutputTableNameBlitzCache = NULL,
+         @OutputTableNameBlitzWho = NULL;
+    DROP TABLE dbo.FRKSchemaHistory;
+    DROP TABLE FRKAnalysisSmoke.FRKSchemaHistory;
+    DROP SCHEMA FRKAnalysisSmoke;
+END TRY
+BEGIN CATCH
+    DROP TABLE IF EXISTS dbo.FRKSchemaHistory;
+    DROP TABLE IF EXISTS FRKAnalysisSmoke.FRKSchemaHistory;
+    DROP SCHEMA FRKAnalysisSmoke;
+    THROW;
+END CATCH;

--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -220,8 +220,33 @@ THROW 51000, 'The dedicated victim timed out without being killed.', 1;" \
   return "$status"
 )
 
+run_analysis_schema_step() {
+  local schema expected absent log="$WORK_DIR/analysis-schema.log"
+  for schema in "NULL" "N'dbo'" "N'FRKAnalysisSmoke'"; do
+    expected='FRK_DBO_SCHEMA_SENTINEL'
+    absent='FRK_CUSTOM_SCHEMA_SENTINEL'
+    if [[ "$schema" == "N'FRKAnalysisSmoke'" ]]; then
+      expected='FRK_CUSTOM_SCHEMA_SENTINEL'
+      absent='FRK_DBO_SCHEMA_SENTINEL'
+    fi
+    if ! "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -v SchemaArgument="$schema" \
+         -i "$SCRIPT_DIR/analysis-schema-regression.sql" > "$log" 2>&1; then
+      cat "$log"
+      return 1
+    fi
+    if ! grep -Fq "$expected" "$log" || grep -Fq "$absent" "$log"; then
+      echo "Analysis schema $schema returned missing or cross-schema findings."
+      cat "$log"
+      return 1
+    fi
+    echo "PASS Analysis schema $schema returned only $expected"
+  done
+}
+
 run_step() {
-  if [[ "$2" == 'sp_kill kills a dedicated session' ]]; then
+  if [[ "$2" == 'sp_BlitzAnalysis defaults and isolates output schemas' ]]; then
+    run_analysis_schema_step
+  elif [[ "$2" == 'sp_kill kills a dedicated session' ]]; then
     run_kill_step "$1"
   else
     "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$1"

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -353,3 +353,6 @@ IF @QueryPlanHash IS NULL
     RAISERROR('Seeded marker query was not found in the plan cache; sp_BlitzPlanCompare was not exercised.', 16, 1);
 
 EXEC dbo.sp_BlitzPlanCompare @QueryPlanHash = @QueryPlanHash, @DatabaseName = 'FRKSmokeTest';
+
+--#STEP: sp_BlitzAnalysis defaults and isolates output schemas
+/* The runner checks three result sets using analysis-schema-regression.sql. */

--- a/sp_BlitzAnalysis.sql
+++ b/sp_BlitzAnalysis.sql
@@ -93,6 +93,12 @@ BEGIN
 	RETURN;
 END
 
+/* Default to dbo schema if NULL is passed in */
+IF (@OutputSchemaName IS NULL) 
+BEGIN 
+	SET @OutputSchemaName = 'dbo';
+END
+
 /* Set fully qualified table names */
 SET @FullOutputTableNameBlitzFirst = QUOTENAME(@OutputDatabaseName)+N'.'+QUOTENAME(@OutputSchemaName)+N'.'+QUOTENAME(@OutputTableNameBlitzFirst);
 SET @FullOutputTableNameFileStats = QUOTENAME(@OutputDatabaseName)+N'.'+QUOTENAME(@OutputSchemaName)+N'.'+QUOTENAME(@OutputTableNameFileStats+N'_Deltas');
@@ -183,12 +189,6 @@ BEGIN
 		SET @EndDate = SYSDATETIMEOFFSET();
 	END
 END 
-
-/* Default to dbo schema if NULL is passed in */
-IF (@OutputSchemaName IS NULL) 
-BEGIN 
-	SET @OutputSchemaName = 'dbo';
-END
 
 /* Prompt the user for @BringThePain = 1 if they are searching a timeframe greater than 4 hours and they are using BlitzCacheSortorder = 'all' */
 IF(@BlitzCacheSortorder = 'all' AND DATEDIFF(HOUR,@StartDate,@EndDate) > 4 AND @BringThePain = 0)

--- a/sp_BlitzAnalysis.sql
+++ b/sp_BlitzAnalysis.sql
@@ -94,8 +94,8 @@ BEGIN
 END
 
 /* Default to dbo schema if NULL is passed in */
-IF (@OutputSchemaName IS NULL) 
-BEGIN 
+IF (@OutputSchemaName IS NULL)
+BEGIN
 	SET @OutputSchemaName = 'dbo';
 END
 


### PR DESCRIPTION
Passing @OutputSchemaName=NULL currently builds NULL fully qualified history-table names before applying the intended dbo fallback, then reports that existing history cannot be found. Apply the fallback before constructing those names.

Closes #4067.

Validation: complete-procedure SQL Server 2022 tests with separate dbo and custom history fixtures verified NULL and explicit dbo both return the default history, while an explicit custom schema returns only its own history. Fixture database removed; `git diff --check` passed.