### PR TITLE
sp_BlitzAnalysis: group Linux file statistics by directory

### DIFF
--- a/sp_BlitzAnalysis.sql
+++ b/sp_BlitzAnalysis.sql
@@ -375,7 +375,7 @@ CASE
 	WHEN MAX([io_stall_write_ms_average]) > @WriteLatencyThreshold THEN ''Yes''
 	ELSE ''No'' 
 END AS [io_stall_ms_breached],
-LEFT([PhysicalName],LEN([PhysicalName])-CHARINDEX(''\'',REVERSE([PhysicalName]))+1) AS [PhysicalPath],
+LEFT([PhysicalName],LEN([PhysicalName])-PATINDEX(''%[\/]%'',REVERSE([PhysicalName]))+1) AS [PhysicalPath],
 SUM([SizeOnDiskMB]) AS [SizeOnDiskMB], 
 SUM([SizeOnDiskMBgrowth]) AS [SizeOnDiskMBgrowth], 
 MAX([io_stall_read_ms]) AS [max_io_stall_read_ms], 
@@ -400,7 +400,7 @@ END
 +N'GROUP BY 
 [ServerName], 
 [CheckDate],
-LEFT([PhysicalName],LEN([PhysicalName])-CHARINDEX(''\'',REVERSE([PhysicalName]))+1)
+LEFT([PhysicalName],LEN([PhysicalName])-PATINDEX(''%[\/]%'',REVERSE([PhysicalName]))+1)
 ORDER BY 
 [CheckDate] ASC
 OPTION (RECOMPILE, MAXDOP '+CAST(@Maxdop AS NVARCHAR(2))+N');'


### PR DESCRIPTION
The file-statistics report finds directories using only backslashes. Linux paths therefore remain full filenames, splitting files from the same directory into separate groups. Recognize either slash when extracting PhysicalPath in both the SELECT and GROUP BY expressions.

Closes #4071.

Validation: executed the exact changed expression on SQL Server 2022 with seven fixture paths. Linux, Windows drive, and UNC pairs each formed one directory group with the correct summed size; a filename without separators retained its existing fallback. The changed procedure installed successfully and its Help path executed. `git diff --check` passed.