### PR TITLE
sp_ineachdb: preserve full quoted database names

### DIFF
--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -97,12 +97,12 @@ BEGIN
 		RETURN -1;
 	END
 
-  DECLARE @exec   nvarchar(150),
+  DECLARE @exec   nvarchar(276),
           @sx     nvarchar(18) = N'.sys.sp_executesql',
           @db     sysname,
-          @dbq    sysname,
+          @dbq    nvarchar(258),
           @cmd    nvarchar(max),
-          @thisdb sysname,
+          @thisdb nvarchar(258),
           @cr     char(2) = CHAR(13) + CHAR(10),
 		  @SQLVersion	AS tinyint = (@@microsoftversion / 0x1000000) & 0xff,	     -- Stores the SQL Server Version Number(8(2000),9(2005),10(2008 & 2008R2),11(2012),12(2014),13(2016),14(2017),15(2019)
 		  @ServerName	AS sysname = CONVERT(sysname, SERVERPROPERTY('ServerName')), -- Stores the SQL Server Instance name.


### PR DESCRIPTION
Quoted database names can exceed 128 characters because of the surrounding brackets and escaped closing brackets. The helper stores them in sysname variables and builds the execution target in nvarchar(150), truncating valid names and preventing commands from running.

Widen the quoted-name and replacement variables to nvarchar(258), and the execution target to nvarchar(276) to include its suffix.

Closes #4068.

Validation: SQL Server 2022 tests created three disposable databases with 128-character names: plain, containing 123 closing brackets, and Unicode. Each was visited exactly once and returned the complete expected quoted placeholder replacement. All fixture databases were removed. `git diff --check` passed.