### PR TITLE
sp_ineachdb: honor include and exclude lists on Azure SQL Database

### DIFF
--- a/.github/scripts/azure-ineachdb-regression.sql
+++ b/.github/scripts/azure-ineachdb-regression.sql
@@ -1,0 +1,32 @@
+/* Uses only local temporary state; the Azure runner already verifies edition 5. */
+SET NOCOUNT ON;
+DECLARE @Current sysname = DB_NAME(), @Quoted nvarchar(258) = QUOTENAME(DB_NAME()),
+        @Other sysname = N'FRKMissing_' + CONVERT(nvarchar(36), NEWID());
+CREATE TABLE #Visited (DatabaseName sysname);
+DECLARE @Cases TABLE (CaseID int IDENTITY, Included nvarchar(max), Excluded nvarchar(max), Expected int);
+INSERT @Cases VALUES
+    (NULL, NULL, 1),
+    (@Quoted, NULL, 1),
+    (NULL, @Quoted, 0),
+    (@Quoted, @Quoted, 0),
+    (QUOTENAME(@Other), NULL, 0),
+    (NULL, QUOTENAME(@Other), 1),
+    (QUOTENAME(@Other) + N',' + @Quoted, NULL, 1),
+    (N'  ' + @Current + N'  ', NULL, 1);
+DECLARE @ID int, @In nvarchar(max), @Out nvarchar(max), @Expected int;
+WHILE EXISTS (SELECT 1 FROM @Cases)
+BEGIN
+    SELECT TOP (1) @ID = CaseID, @In = Included, @Out = Excluded, @Expected = Expected
+    FROM @Cases ORDER BY CaseID;
+    TRUNCATE TABLE #Visited;
+    EXEC dbo.sp_ineachdb @command = N'INSERT #Visited VALUES(DB_NAME());',
+         @database_list = @In, @exclude_list = @Out, @name_pattern = @Current;
+    IF (SELECT COUNT(*) FROM #Visited) <> @Expected
+       OR EXISTS (SELECT 1 FROM #Visited WHERE DatabaseName <> @Current)
+    BEGIN
+        DECLARE @Error nvarchar(2048) = CONCAT(N'Azure include/exclude regression failed, case ', @ID);
+        THROW 51000, @Error, 1;
+    END;
+    DELETE @Cases WHERE CaseID = @ID;
+END;
+PRINT 'All eight Azure include/exclude assertions passed.';

--- a/.github/scripts/run-azure-smoke-test.sh
+++ b/.github/scripts/run-azure-smoke-test.sh
@@ -154,6 +154,9 @@ for script in sp_ineachdb sp_Blitz; do
   fi
 done
 
+echo "=== Verifying Azure database include/exclude lists ==="
+"$SQLCMD" "${SQLCMD_ARGS[@]}" -i "$REPO_ROOT/.github/scripts/azure-ineachdb-regression.sql"
+
 # The install "succeeding" is exactly what made #4040 invisible: the CREATE stub
 # is its own batch and always works, while only the ALTER carrying the real body
 # fails. So confirm the procedure has a body, not merely a name.

--- a/sp_ineachdb.sql
+++ b/sp_ineachdb.sql
@@ -183,15 +183,6 @@ BEGIN
 3)If we find a [, we begin to accumulate the result until we reach closing ], (jumping over escaped ]]).
 4)Finally, tabs, line breaks and spaces are removed from unquoted names
 */
-IF @IsAzureSqlDb = 1
-BEGIN
-  /* Azure SQL DB: the session is bound to one user database. Seed with it and
-     let the downstream filter DELETEs decide whether it survives. */
-  INSERT #ineachdb(id, name, is_distributor)
-  SELECT DB_ID(), DB_NAME(), 0;
-END
-ELSE
-BEGIN
 ;WITH C
 AS (SELECT V.SrcList
          , CAST('' AS nvarchar(MAX)) AS Name
@@ -238,13 +229,21 @@ INSERT #ineachdb(id,name,is_distributor)
 SELECT d.database_id
      , d.name
      , d.is_distributor
-FROM sys.databases AS d
+FROM
+(
+  SELECT database_id, name, is_distributor
+  FROM sys.databases
+  WHERE @IsAzureSqlDb = 0
+  UNION ALL
+  /* Azure SQL DB can only execute commands in the current database. */
+  SELECT DB_ID(), DB_NAME(), 0
+  WHERE @IsAzureSqlDb = 1
+) AS d
 WHERE (   EXISTS (SELECT NULL FROM F WHERE F.name = d.name AND F.SrcList = 'In')
           OR @database_list IS NULL)
       AND NOT EXISTS (SELECT NULL FROM F WHERE F.name = d.name AND F.SrcList = 'Out')
 OPTION (MAXRECURSION 0);
-END
-;
+
   -- next, let's delete any that *don't* match various criteria passed in
   DELETE dbs FROM #ineachdb AS dbs
   WHERE (@system_only = 1 AND (id NOT IN (1,2,3,4) AND is_distributor <> 1))


### PR DESCRIPTION
Azure's current-database shortcut bypasses the shared list parser, so @database_list and @exclude_list are ignored. Feed the current Azure database through the same parser and selection logic as SQL Server. Azure still offers only the current database as a candidate; SQL Server continues to use sys.databases.

Closes #4065.

Validation: eight cases passed on both SQL Server 2022 and Azure SQL Database: default selection, quoted inclusion, mixed inclusion, a different database only, current-database exclusion, simultaneous inclusion/exclusion, excluding a different database, and whitespace in an unquoted name. Assertions checked exact visit counts and database context. Temporary schemas were removed and existing dbo procedure hashes were unchanged. `git diff --check` passed.