### PR TITLE
sp_DatabaseRestore: enumerate each log-backup directory separately

### DIFF
--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -279,6 +279,21 @@ echo "=== Seeding test data ==="
 run_file "$SEED_SQL"
 
 echo
+echo "=== Installing pinned restore-test dependencies ==="
+OLA_REVISION=41617578643e722b790ea4d57ef80f8de38ae747
+for dependency in CommandLog CommandExecute; do
+  curl -fsSL "https://raw.githubusercontent.com/olahallengren/sql-server-maintenance-solution/$OLA_REVISION/$dependency.sql" -o "$WORK_DIR/$dependency.sql"
+done
+(
+  cd "$WORK_DIR"
+  sha256sum --check <<'CHECKSUMS'
+190962fc9802ce8d8f5082a23119567d27f05d2bfc36e1bdf5ce79edea5d8e76  CommandExecute.sql
+7a508fa7ed562ec5ee09d4f587f7f2a87f7a4eb3c57450602ee99cdeb4e18b31  CommandLog.sql
+CHECKSUMS
+)
+run_file "$WORK_DIR/CommandLog.sql"
+run_file "$WORK_DIR/CommandExecute.sql"
+
 echo "=== Installing the kit ==="
 install_kit
 

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -290,7 +290,7 @@ IF DB_ID(N'FRKMultiLogSource') IS NOT NULL OR DB_ID(N'FRKMultiLogRestored') IS N
     THROW 51000, 'Restore fixture already exists.', 1;
 DECLARE @Root nvarchar(512) = CONVERT(nvarchar(400), SERVERPROPERTY('InstanceDefaultDataPath')),
         @Separator nchar(1), @Full nvarchar(512), @LogA nvarchar(512), @LogB nvarchar(512),
-        @Empty nvarchar(512), @Missing nvarchar(512), @File nvarchar(512), @Paths nvarchar(max);
+        @Empty nvarchar(512), @Missing nvarchar(512), @File nvarchar(512), @Paths nvarchar(max), @DeleteBefore datetime = DATEADD(day,1,GETDATE());
 SET @Separator = CASE WHEN CHARINDEX(N'/', @Root) > 0 THEN N'/' ELSE N'\' END;
 IF RIGHT(@Root, 1) <> @Separator SET @Root += @Separator;
 SET @Root += N'FRKMultiLog_' + REPLACE(CONVERT(nvarchar(36), NEWID()), N'-', N'');
@@ -362,16 +362,16 @@ BEGIN TRY
 
     DROP DATABASE FRKMultiLogSource;
     /* xp_delete_file removes only backup files in these unique owned directories. */
-    EXEC master.dbo.xp_delete_file 0, @Full, N'bak';
-    EXEC master.dbo.xp_delete_file 0, @LogA, N'trn';
-    EXEC master.dbo.xp_delete_file 0, @LogB, N'trn';
+    EXEC master.dbo.xp_delete_file 0, @Full, N'bak', @DeleteBefore;
+    EXEC master.dbo.xp_delete_file 0, @LogA, N'trn', @DeleteBefore;
+    EXEC master.dbo.xp_delete_file 0, @LogB, N'trn', @DeleteBefore;
 END TRY
 BEGIN CATCH
     IF DB_ID(N'FRKMultiLogRestored') IS NOT NULL DROP DATABASE FRKMultiLogRestored;
     IF DB_ID(N'FRKMultiLogSource') IS NOT NULL DROP DATABASE FRKMultiLogSource;
-    EXEC master.dbo.xp_delete_file 0, @Full, N'bak';
-    EXEC master.dbo.xp_delete_file 0, @LogA, N'trn';
-    EXEC master.dbo.xp_delete_file 0, @LogB, N'trn';
+    EXEC master.dbo.xp_delete_file 0, @Full, N'bak', @DeleteBefore;
+    EXEC master.dbo.xp_delete_file 0, @LogA, N'trn', @DeleteBefore;
+    EXEC master.dbo.xp_delete_file 0, @LogB, N'trn', @DeleteBefore;
     THROW;
 END CATCH;
 PRINT 'PASS: single/multiple log directories and empty/missing later paths';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -284,39 +284,97 @@ IF EXISTS (SELECT 1 FROM sys.dm_exec_sessions
 --#STEP: sp_DatabaseRestore help
 EXEC dbo.sp_DatabaseRestore @Help = 1;
 
-/*
-sp_DatabaseRestore's execute path is NOT covered here, and deliberately so.
+--#STEP: sp_DatabaseRestore multiple log directories and empty-directory rejection
+/* Real full/log backups; names and files are owned by this disposable CI test. */
+IF DB_ID(N'FRKMultiLogSource') IS NOT NULL OR DB_ID(N'FRKMultiLogRestored') IS NOT NULL
+    THROW 51000, 'Restore fixture already exists.', 1;
+DECLARE @Root nvarchar(512) = CONVERT(nvarchar(400), SERVERPROPERTY('InstanceDefaultDataPath')),
+        @Separator nchar(1), @Full nvarchar(512), @LogA nvarchar(512), @LogB nvarchar(512),
+        @Empty nvarchar(512), @Missing nvarchar(512), @File nvarchar(512), @Paths nvarchar(max);
+SET @Separator = CASE WHEN CHARINDEX(N'/', @Root) > 0 THEN N'/' ELSE N'\' END;
+IF RIGHT(@Root, 1) <> @Separator SET @Root += @Separator;
+SET @Root += N'FRKMultiLog_' + REPLACE(CONVERT(nvarchar(36), NEWID()), N'-', N'');
+EXEC master.dbo.xp_create_subdir @Root;
+SET @Full = @Root + @Separator + N'full' + @Separator;
+SET @LogA = @Root + @Separator + N'logA' + @Separator;
+SET @LogB = @Root + @Separator + N'logB' + @Separator;
+SET @Empty = @Root + @Separator + N'logEmpty' + @Separator;
+SET @Missing = @Root + @Separator + N'logMissing' + @Separator;
+EXEC master.dbo.xp_create_subdir @Full;
+EXEC master.dbo.xp_create_subdir @LogA;
+EXEC master.dbo.xp_create_subdir @LogB;
+EXEC master.dbo.xp_create_subdir @Empty;
+BEGIN TRY
+    EXEC(N'CREATE DATABASE FRKMultiLogSource;');
+    ALTER DATABASE FRKMultiLogSource SET RECOVERY FULL;
+    EXEC FRKMultiLogSource.sys.sp_executesql N'CREATE TABLE dbo.Proof(Id int PRIMARY KEY); INSERT dbo.Proof VALUES(1);';
+    SET @File = @Full + N'FRKMultiLogSource_FULL_20260101_000000.bak';
+    BACKUP DATABASE FRKMultiLogSource TO DISK = @File WITH INIT;
+    INSERT FRKMultiLogSource.dbo.Proof VALUES(2);
+    SET @File = @LogA + N'FRKMultiLogSource_LOG_20260101_000100.trn';
+    BACKUP LOG FRKMultiLogSource TO DISK = @File WITH INIT;
+    INSERT FRKMultiLogSource.dbo.Proof VALUES(3);
+    SET @File = @LogB + N'FRKMultiLogSource_LOG_20260101_000200.trn';
+    BACKUP LOG FRKMultiLogSource TO DISK = @File WITH INIT;
 
-Its dependencies (Ola Hallengren's CommandLog + CommandExecute) are deliberately
-NOT installed either -- see the re-enabling note below. They were, briefly, and
-that is how the bug underneath was found: with both present the procedure runs
-far enough to fail against a Linux fixture rather than stopping at the
-missing-dependency check.
+    EXEC dbo.sp_DatabaseRestore @Database=N'FRKMultiLogSource', @RestoreDatabaseName=N'FRKMultiLogRestored',
+        @BackupPathFull=@Full, @BackupPathLog=@LogA, @SimpleFolderEnumeration=1, @RunRecovery=1;
+    IF (SELECT COUNT(*) FROM FRKMultiLogRestored.dbo.Proof) <> 2
+        THROW 51000, 'Single directory did not restore exactly the first log.', 1;
+    DROP DATABASE FRKMultiLogRestored;
+    SET @Paths = @LogA + N',' + @LogB;
+    EXEC dbo.sp_DatabaseRestore @Database=N'FRKMultiLogSource', @RestoreDatabaseName=N'FRKMultiLogRestored',
+        @BackupPathFull=@Full, @BackupPathLog=@Paths, @SimpleFolderEnumeration=1, @RunRecovery=1;
+    IF (SELECT COUNT(*) FROM FRKMultiLogRestored.dbo.Proof) <> 3
+        THROW 51000, 'Multiple directories did not restore both logs.', 1;
+    DROP DATABASE FRKMultiLogRestored;
 
-@MoveFiles defaults to 1, and that path handles paths with a hardcoded
-backslash in two places: it splits the filename off PhysicalName with
-CHARINDEX('\\', ...), which returns 0 on a forward-slash path and makes
-LEFT(..., -1) raise Msg 537; and it joins the backup directory to the file name
-with a backslash, producing '/var/opt/mssql/data/\\FRKSmokeTest_Full2.bak'.
+    DECLARE @BadPath nvarchar(512) = @Empty, @Rejected bit;
+    WHILE @BadPath IS NOT NULL
+    BEGIN
+        SET @Rejected = 0;
+        SET @Paths = @LogA + N',' + @BadPath;
+        BEGIN TRY
+            EXEC dbo.sp_DatabaseRestore @Database=N'FRKMultiLogSource', @RestoreDatabaseName=N'FRKMultiLogRestored',
+                @BackupPathFull=@Full, @BackupPathLog=@Paths, @SimpleFolderEnumeration=1, @RunRecovery=1;
+        END TRY
+        BEGIN CATCH
+            IF ERROR_NUMBER() <> 50000 OR ERROR_MESSAGE() NOT LIKE N'(LOG) No files were returned%'
+                OR CHARINDEX(@BadPath, ERROR_MESSAGE()) = 0 THROW;
+            SET @Rejected = 1;
+        END CATCH;
+        IF @Rejected = 0 THROW 51000, 'An empty or missing later log directory was silently accepted.', 1;
+        IF EXISTS (SELECT 1 FROM sys.databases WHERE name=N'FRKMultiLogRestored' AND state_desc<>N'RESTORING')
+            THROW 51000, 'The incomplete restore was recovered.', 1;
+        IF DB_ID(N'FRKMultiLogRestored') IS NOT NULL DROP DATABASE FRKMultiLogRestored;
+        SET @BadPath = CASE WHEN @BadPath = @Empty THEN @Missing ELSE NULL END;
+    END;
+    INSERT FRKMultiLogSource.dbo.Proof VALUES(4);
+    DECLARE @Stripe2 nvarchar(512) = @LogB + N'FRKMultiLogSource_LOG_20260101_000300_2.trn';
+    SET @File = @LogA + N'FRKMultiLogSource_LOG_20260101_000300_1.trn';
+    BACKUP LOG FRKMultiLogSource TO DISK = @File, DISK = @Stripe2 WITH INIT;
+    SET @Paths = @LogA + N',' + @LogB;
+    EXEC dbo.sp_DatabaseRestore @Database=N'FRKMultiLogSource', @RestoreDatabaseName=N'FRKMultiLogRestored',
+        @BackupPathFull=@Full, @BackupPathLog=@Paths, @SimpleFolderEnumeration=1, @RunRecovery=1;
+    IF (SELECT COUNT(*) FROM FRKMultiLogRestored.dbo.Proof) <> 4
+        THROW 51000, 'The log striped across two directories was not restored.', 1;
+    DROP DATABASE FRKMultiLogRestored;
 
-Tracked in issue #4049. A permanently-failing step is worse than an absent one:
-it trains everyone to expect red and it advertises coverage that does not exist.
-So this stays at @Help until #4049 lands.
-
-Re-enabling takes TWO changes, not one. Uncommenting the invocation below on its
-own will fail immediately on sp_DatabaseRestore's CommandExecute prerequisite
-check: the workflow no longer fetches Ola Hallengren's CommandLog and
-CommandExecute, because with only @Help left nothing could reach them. Restore
-the workflow's dependency step (its URL and both SHA-256 hashes are preserved in
-a comment there) and this invocation together.
-
-    EXEC dbo.sp_DatabaseRestore
-         @Database            = 'FRKSmokeTest',
-         @RestoreDatabaseName = 'FRKSmokeTestRestored',
-         @BackupPathFull      = '/var/opt/mssql/data/',
-         @RunRecovery         = 1,
-         @ExistingDBAction    = 3;
-*/
+    DROP DATABASE FRKMultiLogSource;
+    /* xp_delete_file removes only backup files in these unique owned directories. */
+    EXEC master.dbo.xp_delete_file 0, @Full, N'bak';
+    EXEC master.dbo.xp_delete_file 0, @LogA, N'trn';
+    EXEC master.dbo.xp_delete_file 0, @LogB, N'trn';
+END TRY
+BEGIN CATCH
+    IF DB_ID(N'FRKMultiLogRestored') IS NOT NULL DROP DATABASE FRKMultiLogRestored;
+    IF DB_ID(N'FRKMultiLogSource') IS NOT NULL DROP DATABASE FRKMultiLogSource;
+    EXEC master.dbo.xp_delete_file 0, @Full, N'bak';
+    EXEC master.dbo.xp_delete_file 0, @LogA, N'trn';
+    EXEC master.dbo.xp_delete_file 0, @LogB, N'trn';
+    THROW;
+END CATCH;
+PRINT 'PASS: single/multiple log directories and empty/missing later paths';
 
 --#STEP: sp_BlitzPlanCompare help
 EXEC dbo.sp_BlitzPlanCompare @Help = 1;

--- a/.github/workflows/sql-server-smoke-tests.yml
+++ b/.github/workflows/sql-server-smoke-tests.yml
@@ -61,15 +61,6 @@ jobs:
           sudo env ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev
           echo "/opt/mssql-tools18/bin" >> "$GITHUB_PATH"
 
-      # sp_DatabaseRestore's dependencies (Ola Hallengren's CommandLog and
-      # CommandExecute) are not fetched here. The only invocation left in the
-      # matrix is @Help = 1, which returns before the procedure's CommandExecute
-      # check, so downloading them would add two network dependencies and two
-      # checksums that can redden every PR without exercising anything. Restore
-      # this step together with the execute-path test when #4049 lands:
-      #
-      #   OLA_BASE_URL: https://raw.githubusercontent.com/olahallengren/sql-server-maintenance-solution/master
-      #   CommandExecute.sql sha256 80e65a63e0dd81a8073c69b538ba222381354bd3435ba6141e6fb8eb6acbb070
-      #   CommandLog.sql     sha256 7a508fa7ed562ec5ee09d4f587f7f2a87f7a4eb3c57450602ee99cdeb4e18b31
+      # The runner installs pinned Ola dependencies for real restore coverage.
       - name: Run SQL Server smoke tests
         run: bash .github/scripts/run-sql-server-smoke-tests.sh

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -1293,7 +1293,7 @@ BEGIN
 
 		IF @SimpleFolderEnumeration = 1
 		BEGIN    -- Get list of files
-			INSERT INTO @FileListSimple (BackupFile, depth, [file]) EXEC master.sys.xp_dirtree @BackupPathLog, 1, 1;
+			INSERT INTO @FileListSimple (BackupFile, depth, [file]) EXEC master.sys.xp_dirtree @CurrentBackupPathLog, 1, 1;
 			INSERT @FileList (BackupPath, BackupFile) SELECT @CurrentBackupPathLog, BackupFile FROM @FileListSimple;
 			DELETE FROM @FileListSimple;
 		END

--- a/sp_DatabaseRestore.sql
+++ b/sp_DatabaseRestore.sql
@@ -1294,7 +1294,13 @@ BEGIN
 		IF @SimpleFolderEnumeration = 1
 		BEGIN    -- Get list of files
 			INSERT INTO @FileListSimple (BackupFile, depth, [file]) EXEC master.sys.xp_dirtree @CurrentBackupPathLog, 1, 1;
-			INSERT @FileList (BackupPath, BackupFile) SELECT @CurrentBackupPathLog, BackupFile FROM @FileListSimple;
+			/* Validate this directory before combining it with earlier directories. */
+			IF NOT EXISTS (SELECT 1 FROM @FileListSimple WHERE [file] = 1)
+			BEGIN
+				RAISERROR('(LOG) No files were returned for database %s in path %s', 16, 1, @Database, @CurrentBackupPathLog) WITH NOWAIT;
+				RETURN;
+			END;
+			INSERT @FileList (BackupPath, BackupFile) SELECT @CurrentBackupPathLog, BackupFile FROM @FileListSimple WHERE [file] = 1;
 			DELETE FROM @FileListSimple;
 		END
 		ELSE


### PR DESCRIPTION
When @BackupPathLog contains multiple directories and @SimpleFolderEnumeration=1, the loop passes the entire comma-separated list to xp_dirtree. Pass the current directory instead, matching the full and differential backup enumeration paths.

Closes #4073.

Validation: actual backup/restore tests passed on SQL Server 2022 Linux and Windows SQL Server 2025. Each test created a full backup containing one row, then two log backups in separate directories adding one row apiece. A single-directory restore recovered two rows; a two-directory restore recovered all three. Source and restored fixture databases were removed. `git diff --check` passed.