### PR TITLE
sp_BlitzFirst: safely serialize history Details as XML text

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -263,7 +263,7 @@ BEGIN
         SET @StringToExecute = N' IF EXISTS(SELECT * FROM '
             + @OutputDatabaseName
             + '.INFORMATION_SCHEMA.SCHEMATA WHERE QUOTENAME(SCHEMA_NAME) = '''
-            + @OutputSchemaName + ''') SELECT CheckDate, [Priority], [FindingsGroup], [Finding], [URL], CAST([Details] AS [XML]) AS Details,'
+            + @OutputSchemaName + ''') SELECT CheckDate, [Priority], [FindingsGroup], [Finding], [URL], CASE WHEN [Details] IS NULL THEN NULL ELSE (SELECT [Details] AS [text()] FOR XML PATH(''''), TYPE) END AS Details,'
             + '[HowToStopIt], [CheckID], [StartTime], [LoginName], [NTUserName], [OriginalLoginName], [ProgramName], [HostName], [DatabaseID],'
             + '[DatabaseName], [OpenTransactionCount], [QueryPlan], [QueryText] FROM '
             + @OutputDatabaseName + '.'


### PR DESCRIPTION
The @AsOf reader directly casts stored Details text to XML. A normal logged message such as `Review A & B` therefore saves successfully but fails when read back. Serialize Details as an XML text node instead, preserving the XML result type and NULL values without interpreting message content as markup.

Closes #4079.

Validation: complete-procedure SQL Server 2022 tests logged and read back ampersands, angle brackets, quotes, Unicode, `?>`, and literal XML markup. Assertions compared the decoded XML text to the original messages and verified NULL remains NULL. Test history rows were removed. `git diff --check` passed.