### PR TITLE
sp_BlitzFirst: fix global temporary performance-counter output

### DIFF
--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -4771,7 +4771,6 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
             + ' INSERT '
             + @OutputTableNamePerfmonStats
             + ' (ServerName, CheckDate, object_name, counter_name, instance_name, cntr_value, cntr_type, value_delta, value_per_second) SELECT '
-            + CAST(SERVERPROPERTY('ServerName') AS NVARCHAR(128))
             + ' @SrvName, @CheckDate, object_name, counter_name, instance_name, cntr_value, cntr_type, value_delta, value_per_second FROM #PerfmonStats WHERE Pass = 2';
 
 		EXEC sp_executesql @StringToExecute,


### PR DESCRIPTION
The global temporary Perfmon output query inserts a raw server name immediately before the existing @SrvName parameter, producing invalid SQL. Remove that extra text and use the parameter already supplied to sp_executesql.

Closes #4080.

Validation: the complete changed procedure passed on SQL Server 2022 Linux and Windows SQL Server 2025. On each server, two samples wrote to the same global temporary table. Assertions verified nonempty counter output, the correct server name and non-NULL date, and an increased row count after the second sample. Test tables were removed. `git diff --check` passed.