### PR TITLE
sp_BlitzIndex: require one index to cover a composite foreign key

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -2629,22 +2629,31 @@ OPTION (RECOMPILE);';
                 JOIN ' + QUOTENAME(@DatabaseName) + N'.sys.schemas AS s
                     ON s.schema_id = fk.schema_id
                 WHERE fk.is_disabled = 0
-                AND   EXISTS
-                      (
-                          SELECT  
-                              1/0
-                          FROM ' + QUOTENAME(@DatabaseName) + N'.sys.foreign_key_columns fkc
-                          WHERE fkc.constraint_object_id = fk.object_id
-                          AND NOT EXISTS
-                              (
-                                  SELECT  
-                                      1/0
-                                  FROM  ' + QUOTENAME(@DatabaseName) + N'.sys.index_columns ic
-                                  WHERE ic.object_id = fkc.parent_object_id
-                                  AND   ic.column_id = fkc.parent_column_id
-                                  AND   ic.index_column_id = fkc.constraint_column_id
-                              )
-                      )
+                AND NOT EXISTS
+                    (
+                        SELECT 1
+                        FROM ' + QUOTENAME(@DatabaseName) + N'.sys.indexes AS i
+                        WHERE i.object_id = fk.parent_object_id
+                        AND i.type IN (1, 2)
+                        AND i.is_disabled = 0
+                        AND i.is_hypothetical = 0
+                        AND i.has_filter = 0
+                        AND NOT EXISTS
+                            (
+                                SELECT 1
+                                FROM ' + QUOTENAME(@DatabaseName) + N'.sys.foreign_key_columns AS fkc
+                                WHERE fkc.constraint_object_id = fk.object_id
+                                AND NOT EXISTS
+                                    (
+                                        SELECT 1
+                                        FROM ' + QUOTENAME(@DatabaseName) + N'.sys.index_columns AS ic
+                                        WHERE ic.object_id = i.object_id
+                                        AND ic.index_id = i.index_id
+                                        AND ic.column_id = fkc.parent_column_id
+                                        AND ic.key_ordinal = fkc.constraint_column_id
+                                    )
+                            )
+                    )
 				OPTION (RECOMPILE);'
         IF @dsql IS NULL 
             RAISERROR('@dsql is null',16,1);


### PR DESCRIPTION
For a foreign key on (A,B), the current check accepts A from index (A,X) and B from a different index (X,B), suppressing the missing-index warning. Require all foreign-key columns to match the leading keys of one usable rowstore index. Use key_ordinal so included columns do not count, and exclude disabled, hypothetical, and filtered indexes. Preserve the existing foreign-key column-order policy and read-activity filtering.

Closes #4077.

Validation: seven full-procedure Mode 4 cases passed on SQL Server 2022 with persisted-output assertions: split indexes warn; (A,B) covers; (B,A), A INCLUDE(B), disabled (A,B), and filtered (A,B) warn; (A,B,X) covers. The disposable database was removed. `git diff --check` passed.