### PR TITLE
sp_BlitzLock: read deadlocks from the system_health ring buffer

### DIFF
--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -221,7 +221,10 @@ THROW 51000, 'The dedicated victim timed out without being killed.', 1;" \
 )
 
 run_step() {
-  if [[ "$2" == 'sp_kill kills a dedicated session' ]]; then
+  if [[ "$2" == 'sp_BlitzLock parses a real system_health ring-buffer deadlock' ]]; then
+    SQLCMDSERVER="$SQLCMDSERVER" SQLCMDUSER="$SQLCMDUSER" SQLCMD="$SQLCMD" \
+      python3 "$SCRIPT_DIR/test-lock-ring-buffer.py"
+  elif [[ "$2" == 'sp_kill kills a dedicated session' ]]; then
     run_kill_step "$1"
   else
     "$SQLCMD" "${SQLCMD_ARGS[@]}" -d master -i "$1"

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -353,3 +353,6 @@ IF @QueryPlanHash IS NULL
     RAISERROR('Seeded marker query was not found in the plan cache; sp_BlitzPlanCompare was not exercised.', 16, 1);
 
 EXEC dbo.sp_BlitzPlanCompare @QueryPlanHash = @QueryPlanHash, @DatabaseName = 'FRKSmokeTest';
+
+--#STEP: sp_BlitzLock parses a real system_health ring-buffer deadlock
+/* The runner creates two concurrent workers and asserts the parsed participants. */

--- a/.github/scripts/test-lock-ring-buffer.py
+++ b/.github/scripts/test-lock-ring-buffer.py
@@ -1,0 +1,75 @@
+"""Generate a real deadlock and require both parsed participants in system_health.
+
+Runs only on the disposable boxed SQL Server smoke-test instance.
+"""
+from concurrent.futures import ThreadPoolExecutor
+import os
+import subprocess
+import uuid
+
+suffix = uuid.uuid4().hex[:12]
+schema = 'FRKRing_' + suffix
+table = 'Fixture_' + suffix
+args = [os.environ.get('SQLCMD', 'sqlcmd'), '-S', os.environ['SQLCMDSERVER'],
+        '-U', os.environ['SQLCMDUSER'], '-C', '-I', '-b', '-l', '60', '-t', '90']
+
+def run(sql, database='FRKSmokeTest', check=True):
+    result = subprocess.run(args + ['-d', database, '-Q', sql],
+                            capture_output=True, text=True, timeout=120)
+    if check and result.returncode:
+        raise RuntimeError(result.stdout + result.stderr)
+    return result
+
+run(f"CREATE SCHEMA [{schema}];")
+try:
+    run(f"CREATE TABLE [{schema}].[{table}](ID int PRIMARY KEY, V int); "
+        f"INSERT [{schema}].[{table}] VALUES(1,0),(2,0);")
+    def worker(own):
+        other = 3 - own
+        return run(f"""SET LOCK_TIMEOUT 30000;
+BEGIN TRAN;
+UPDATE [{schema}].[{table}] WITH (ROWLOCK) SET V = 1 WHERE ID = {own};
+DECLARE @Deadline datetime2 = DATEADD(second,30,SYSUTCDATETIME());
+WHILE NOT EXISTS(SELECT 1 FROM [{schema}].[{table}] WITH (READUNCOMMITTED) WHERE ID={other} AND V=1)
+BEGIN
+    IF SYSUTCDATETIME() > @Deadline THROW 51000,'Deadlock worker barrier timed out.',1;
+    WAITFOR DELAY '00:00:00.100';
+END;
+UPDATE [{schema}].[{table}] WITH (ROWLOCK) SET V = V + 1 WHERE ID={other};
+COMMIT;""", check=False)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(worker, [1, 2]))
+    failures = [r for r in results if r.returncode]
+    if len(failures) != 1 or '1205' not in failures[0].stdout + failures[0].stderr:
+        raise RuntimeError('Expected exactly one deadlock victim.\n' +
+                           '\n'.join(r.stdout + r.stderr for r in results))
+
+    # Wait for the actual fixture event to reach the ring buffer; old events
+    # from earlier tests cannot satisfy the unique table-name assertion.
+    run(f"""DECLARE @Deadline datetime2 = DATEADD(second,20,SYSUTCDATETIME());
+WHILE NOT EXISTS
+(SELECT 1 FROM sys.dm_xe_session_targets t JOIN sys.dm_xe_sessions s
+ ON s.address=t.event_session_address
+ WHERE s.name=N'system_health' AND t.target_name=N'ring_buffer'
+ AND CONVERT(nvarchar(max),t.target_data) LIKE N'%{table}%')
+BEGIN
+ IF SYSUTCDATETIME()>@Deadline THROW 51000,'Fixture deadlock did not reach system_health ring buffer.',1;
+ WAITFOR DELAY '00:00:00.100';
+END;
+EXEC master.dbo.sp_BlitzLock @EventSessionName=N'system_health', @TargetSessionType=N'ring_buffer',
+ @DatabaseName=N'FRKSmokeTest', @SkipExecutionPlans=1,
+ @OutputDatabaseName=N'FRKSmokeTest', @OutputSchemaName=N'{schema}', @OutputTableName=N'Deadlocks';
+IF (SELECT COUNT(DISTINCT spid) FROM [{schema}].Deadlocks
+ WHERE CONVERT(nvarchar(max),deadlock_graph) LIKE N'%{table}%') <> 2
+ THROW 51000,'sp_BlitzLock did not parse both fixture deadlock participants.',1;
+""")
+    print('PASS system_health ring buffer contains and parses both real deadlock participants')
+finally:
+    # The procedure normally removes its synonyms; clean owned leftovers if it
+    # returned early or a test failed. Never remove another target's synonym.
+    run(f"""IF EXISTS(SELECT 1 FROM sys.synonyms WHERE name=N'DeadLockTbl' AND base_object_name LIKE N'%{schema}%')
+ DROP SYNONYM dbo.DeadLockTbl;
+IF EXISTS(SELECT 1 FROM sys.synonyms WHERE name=N'DeadlockFindings' AND base_object_name LIKE N'%{schema}%')
+ DROP SYNONYM dbo.DeadlockFindings;""", database='master')
+    run(f"DROP TABLE IF EXISTS [{schema}].Deadlocks; DROP TABLE IF EXISTS [{schema}].BlitzLockFindings; "
+        f"DROP TABLE IF EXISTS [{schema}].[{table}]; DROP SCHEMA [{schema}];")

--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -1041,14 +1041,13 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
     END;
 
 
-    /*The system health stuff gets handled different from user extended events.*/
-    /*These next sections deal with user events, dependent on target.*/
+    /*Event files use separate paths for system_health and user sessions.*/
+    /*Ring buffers share collection and parsing for system and user sessions.*/
 
     /*If ring buffers*/
     IF
     (
            LOWER(@TargetSessionType) LIKE N'ring%'
-       AND @EventSessionName NOT LIKE N'system_health%'
     )
     BEGIN
         IF @Azure = 0
@@ -1204,7 +1203,6 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
     IF
     (
            LOWER(@TargetSessionType) LIKE N'ring%'
-       AND @EventSessionName NOT LIKE N'system_health%'
     )
     BEGIN
         SET @d = CONVERT(varchar(40), GETDATE(), 109);


### PR DESCRIPTION
The ring-buffer collection and parsing branches both exclude system_health, but its special handling only supports event files. Consequently, an explicit system_health ring-buffer request returns no deadlocks even when the target contains them. Use the shared ring-buffer path for both system and custom sessions.

Closes #4074.

Validation: generated a deadlock between two sessions updating only a disposable fixture on SQL Server 2022. Verified the system_health ring buffer contained the event and that persisted sp_BlitzLock output was nonempty for system_health ring_buffer, a custom ring_buffer, and system_health event_file. Temporary output tables were removed. `git diff --check` passed.