### PR TITLE
sp_BlitzLock: retain resource details for bare deadlock graphs

### DIFF
--- a/sp_BlitzLock.sql
+++ b/sp_BlitzLock.sql
@@ -1707,11 +1707,11 @@ To use sp_BlitzLock in Azure SQL DB, you have two options:
         FROM
         (
             SELECT
-                event_date = dd.deadlock_xml.value('(event/@timestamp)[1]', 'datetime2'),
-                victim_id = dd.deadlock_xml.value('(//deadlock/victim-list/victimProcess/@id)[1]', 'nvarchar(256)'),
+                event_date = dd.event_date,
+                victim_id = dd.victim_id,
                 resource_xml = ISNULL(ca.dp.query(N'.'), N'')
-            FROM #deadlock_data AS dd
-            CROSS APPLY dd.deadlock_xml.nodes('//deadlock/resource-list') AS ca(dp)
+            FROM #dd AS dd
+            CROSS APPLY dd.deadlock_graph.nodes('/deadlock/resource-list') AS ca(dp)
         ) AS dr
         OPTION(RECOMPILE);
 


### PR DESCRIPTION
For bare `<deadlock>` input, process parsing uses the transaction-start fallback timestamp, but resource parsing independently reads a nonexistent event timestamp. The resulting NULL prevents resources from joining to their processes, losing object names and lock details.

Read resource metadata from the already normalized deadlock rows and graph, keeping the same timestamp and victim ID used by process parsing.

Closes #4075.

Validation: full-procedure SQL Server 2022 tests read wrapped and bare versions of the same captured two-process deadlock. Both returned object names for both processes, with matching object XML, owner/waiter modes, and lock modes. Temporary output tables were removed. `git diff --check` passed.