### PR TITLE
sp_BlitzCache: keep analysis and export updates within their session

### DIFF
--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -353,3 +353,44 @@ IF @QueryPlanHash IS NULL
     RAISERROR('Seeded marker query was not found in the plan cache; sp_BlitzPlanCompare was not exercised.', 16, 1);
 
 EXEC dbo.sp_BlitzPlanCompare @QueryPlanHash = @QueryPlanHash, @DatabaseName = 'FRKSmokeTest';
+
+--#STEP: sp_BlitzCache isolates analysis and all Excel export paths
+EXEC FRKSmokeTest.sys.sp_executesql
+     N'SELECT COUNT_BIG(*) FROM dbo.Posts WHERE Id > 10 /* FRK isolation workload */';
+EXEC dbo.sp_BlitzCache @Top=100, @IgnoreSystemDBs=0, @SkipAnalysis=1, @HideSummary=1;
+IF NOT EXISTS(SELECT 1 FROM ##BlitzCacheProcs WHERE SPID=@@SPID AND QueryHash IS NOT NULL)
+    THROW 51000,'Isolation fixture has no cached statement.',1;
+DELETE ##BlitzCacheProcs WHERE SPID=-9876;
+INSERT ##BlitzCacheProcs(SPID,DatabaseName,QueryText,SqlHandle,QueryHash,QueryType,QueryPlanCost)
+SELECT -9876,DatabaseName,N'  SELECT   123 /* FRK other session */  ',SqlHandle,QueryHash,N'Statement',-987
+FROM ##BlitzCacheProcs WHERE SPID=@@SPID AND QueryHash IS NOT NULL;
+DECLARE @OtherCount int=(SELECT COUNT(*) FROM ##BlitzCacheProcs WHERE SPID=-9876);
+BEGIN TRY
+    EXEC dbo.sp_BlitzCache @Top=100, @IgnoreSystemDBs=0, @HideSummary=1;
+    IF NOT EXISTS(SELECT 1 FROM ##BlitzCacheProcs a JOIN ##BlitzCacheProcs b
+                  ON a.SqlHandle=b.SqlHandle AND a.QueryHash=b.QueryHash
+                  WHERE a.SPID=@@SPID AND b.SPID=-9876 AND a.QueryPlanCost>=0)
+        THROW 51000,'Analysis did not exercise the shared plan handles.',1;
+    IF EXISTS(SELECT 1 FROM ##BlitzCacheProcs WHERE SPID=-9876 AND QueryPlanCost<>-987)
+        THROW 51000,'Analysis changed another session.',1;
+    DECLARE @Modes TABLE(SortOrder varchar(20));
+    INSERT @Modes VALUES('cpu'),('all'),('all avg');
+    DECLARE @Sort varchar(20);
+    WHILE EXISTS(SELECT 1 FROM @Modes)
+    BEGIN
+        SELECT TOP(1) @Sort=SortOrder FROM @Modes;
+        EXEC dbo.sp_BlitzCache @Top=1, @DatabaseName=N'FRKSmokeTest',
+             @HideSummary=1, @ExportToExcel=1, @SortOrder=@Sort;
+        IF (SELECT COUNT(*) FROM ##BlitzCacheProcs WHERE SPID=-9876)<>@OtherCount
+           OR EXISTS(SELECT 1 FROM ##BlitzCacheProcs WHERE SPID=-9876
+                     AND (QueryText<>N'  SELECT   123 /* FRK other session */  ' OR QueryPlanCost<>-987))
+            THROW 51000,'Excel export changed another session.',1;
+        DELETE @Modes WHERE SortOrder=@Sort;
+    END;
+    DELETE ##BlitzCacheProcs WHERE SPID=-9876;
+END TRY
+BEGIN CATCH
+    DELETE ##BlitzCacheProcs WHERE SPID=-9876;
+    THROW;
+END CATCH;
+PRINT 'Analysis, direct export, all, and all avg preserved the other session.';

--- a/sp_BlitzCache.sql
+++ b/sp_BlitzCache.sql
@@ -3344,6 +3344,7 @@ JOIN    (   SELECT  r.SqlHandle
 WHERE   s.statement.exist('//p:StmtSimple[@StatementOptmLevel[.="TRIVIAL"]]/p:QueryPlan/p:ParameterList') = 1
 ) AS s
 ON b.SqlHandle = s.SqlHandle
+WHERE b.SPID = @@SPID
 OPTION (RECOMPILE);
 
 
@@ -3375,6 +3376,7 @@ WITH pc AS (
 		ON b.SqlHandle = pc.SqlHandle
 		AND b.QueryHash = pc.QueryHash
 		WHERE b.QueryType NOT LIKE '%Procedure%'
+        AND b.SPID = @@SPID
 	OPTION (RECOMPILE);
 
 IF EXISTS (
@@ -3839,6 +3841,7 @@ UPDATE b
 FROM ##BlitzCacheProcs b
 JOIN spools sp
 ON sp.QueryHash = b.QueryHash
+WHERE b.SPID = @@SPID
 OPTION (RECOMPILE);
 
 RAISERROR('Checking for wonky Table Spools', 0, 1) WITH NOWAIT;
@@ -3866,6 +3869,7 @@ UPDATE b
 FROM ##BlitzCacheProcs b
 JOIN spools sp
 ON sp.QueryHash = b.QueryHash
+WHERE b.SPID = @@SPID
 OPTION (RECOMPILE);
 
 
@@ -3880,7 +3884,8 @@ AS ( SELECT CONVERT(BINARY(8),
      FROM   #statements AS s
 	 JOIN ##BlitzCacheProcs b
 	 ON s.QueryHash = b.QueryHash
-	 WHERE b.index_spool_rows IS NULL
+	 WHERE b.SPID = @@SPID
+     AND   b.index_spool_rows IS NULL
 	 AND   b.index_spool_cost IS NULL
 	 AND   b.table_spool_cost IS NULL
 	 AND   b.table_spool_rows IS NULL
@@ -3893,7 +3898,8 @@ UPDATE b
 FROM ##BlitzCacheProcs b
 JOIN selects AS s
 ON s.QueryHash = b.QueryHash
-AND b.AverageWrites > 1024.;
+AND b.AverageWrites > 1024.
+WHERE b.SPID = @@SPID;
 
 	RAISERROR(N'Checking for forced serialization', 0, 1) WITH NOWAIT;
 	WITH XMLNAMESPACES('http://schemas.microsoft.com/sqlserver/2004/07/showplan' AS p)
@@ -4142,6 +4148,7 @@ FROM #relop AS r
 JOIN ##BlitzCacheProcs AS b
 ON b.SqlHandle = r.SqlHandle
 WHERE  r.relop.exist('/p:RelOp[(@EstimateRows="100" or @EstimateRows="1") and @LogicalOp="Table-valued function"]') = 1
+AND b.SPID = @@SPID
 OPTION (RECOMPILE);
 
 
@@ -4155,6 +4162,7 @@ FROM #relop AS r
 JOIN ##BlitzCacheProcs AS b
 ON b.SqlHandle = r.SqlHandle
 WHERE  r.relop.exist('/p:RelOp/p:Merge/@ManyToMany[.="1"]') = 1
+AND b.SPID = @@SPID
 OPTION (RECOMPILE);
 END ;
 
@@ -4462,6 +4470,7 @@ FROM ##BlitzCacheProcs AS b
 JOIN precheck pk
 ON pk.SqlHandle = b.SqlHandle
 AND pk.SPID = b.SPID
+WHERE b.SPID = @@SPID
 OPTION (RECOMPILE);
 
 
@@ -4505,6 +4514,7 @@ JOIN precheck pk
 ON pk.SqlHandle = b.SqlHandle
 AND pk.SPID = b.SPID
 WHERE b.QueryType <> N'Statement'
+AND b.SPID = @@SPID
 OPTION (RECOMPILE);
 
 
@@ -4549,6 +4559,7 @@ JOIN precheck pk
 ON pk.SqlHandle = b.SqlHandle
 AND pk.SPID = b.SPID
 WHERE b.QueryType = N'Statement'
+AND b.SPID = @@SPID
 OPTION (RECOMPILE);
 
 RAISERROR(N'Filling in implicit conversion and cached plan parameter info', 0, 1) WITH NOWAIT;
@@ -5952,6 +5963,7 @@ BEGIN
     /* excel output */
     UPDATE ##BlitzCacheProcs
     SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),' ','<>'),'><',''),'<>',' '), 1, 32000)
+	WHERE SPID = @@SPID
 	OPTION(RECOMPILE);
 
     SET @sql = N'
@@ -7794,7 +7806,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END; 
@@ -7824,7 +7836,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END; 
@@ -7843,7 +7855,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END; 
@@ -7873,7 +7885,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END; 
@@ -7971,7 +7983,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END;  
@@ -8001,7 +8013,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END; 
@@ -8020,7 +8032,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END;  
@@ -8050,7 +8062,7 @@ SET @AllSortSql += N'
 													missing_indexes = NULL
 												   OPTION (RECOMPILE);
 
-												   UPDATE ##BlitzCacheProcs
+												   UPDATE #bou_allsort
 												   SET QueryText = SUBSTRING(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(QueryText)),'' '',''<>''),''><'',''''),''<>'','' ''), 1, 32000)
 												   OPTION(RECOMPILE);';
 						END; 


### PR DESCRIPTION
sp_BlitzCache analysis and Excel formatting can update another invocation's rows in the shared global cache table. Scope analysis and direct-export updates to @@SPID, and format the local #bou_allsort result table in multi-sort exports.

Closes #4084.

Added an automated regression that shares real plan handles with sentinel rows for another SPID, verifies analysis covers those handles without changing the other rows, and runs complete direct, all, and all avg Excel exports while asserting the other rows' count, text, and cost remain unchanged. The complete regression passed with the Linux SQL client on SQL Server 2022, including after integrating current dev. The old procedure fails the cross-session analysis assertion.

An earlier macOS sqlcmd attempt stalled and was terminated; its exit status is not counted as validation. The subsequent complete Linux-client runs finished naturally with exit 0 and the final assertion marker. git diff --check passed.