### PR TITLE
sp_BlitzFirst: isolate history deltas by server and upgrade existing views

### DIFF
--- a/.github/scripts/run-sql-server-smoke-tests.sh
+++ b/.github/scripts/run-sql-server-smoke-tests.sh
@@ -243,10 +243,25 @@ run_analysis_schema_step() {
   done
 }
 
+run_delta_step() {
+  local existing status=0
+  existing="$(run_scalar "SET NOCOUNT ON; SELECT COUNT(*) FROM sys.databases WHERE name=N'FRKDeltaSmoke';")" || return 1
+  if [[ "$existing" != "0" ]]; then
+    echo "Delta fixture already exists; refusing to overwrite it."
+    return 1
+  fi
+  run_file "$1" || status=$?
+  # The matrix continues after failures, so clean our database on both paths.
+  run_query "IF DB_ID(N'FRKDeltaSmoke') IS NOT NULL DROP DATABASE FRKDeltaSmoke;" || status=1
+  return "$status"
+}
+
 run_step() {
   if [[ "$2" == 'sp_BlitzLock parses a real system_health ring-buffer deadlock' ]]; then
     SQLCMDSERVER="$SQLCMDSERVER" SQLCMDUSER="$SQLCMDUSER" SQLCMD="$SQLCMD" \
       python3 "$SCRIPT_DIR/test-lock-ring-buffer.py"
+  elif [[ "$2" == 'sp_BlitzFirst multi-server deltas and in-place upgrades' ]]; then
+    run_delta_step "$1"
   elif [[ "$2" == 'sp_BlitzAnalysis defaults and isolates output schemas' ]]; then
     run_analysis_schema_step
   elif [[ "$2" == 'sp_kill kills a dedicated session' ]]; then

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -505,6 +505,24 @@ DELETE dbo.Files WHERE ServerName NOT IN(N'ServerA',N'ServerB');
 DELETE dbo.Perfmon WHERE ServerName NOT IN(N'ServerA',N'ServerB');
 DELETE dbo.Waits WHERE ServerName NOT IN(N'ServerA',N'ServerB');
 IF (SELECT COUNT(*) FROM dbo.Files_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Perfmon_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Waits_Deltas)<>4 THROW 51000,'Incorrect view row counts',1;
+IF EXISTS(
+    SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e
+    FULL OUTER JOIN (SELECT ServerName,CheckDate,COUNT(*) AS Copies FROM dbo.Files_Deltas GROUP BY ServerName,CheckDate) d
+    ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate
+    WHERE e.ServerName IS NULL OR d.ServerName IS NULL OR d.Copies<>1)
+    THROW 51000,'Missing, extra, or duplicate Files delta key.',1;
+IF EXISTS(
+    SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e
+    FULL OUTER JOIN (SELECT ServerName,CheckDate,COUNT(*) AS Copies FROM dbo.Perfmon_Deltas GROUP BY ServerName,CheckDate) d
+    ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate
+    WHERE e.ServerName IS NULL OR d.ServerName IS NULL OR d.Copies<>1)
+    THROW 51000,'Missing, extra, or duplicate Perfmon delta key.',1;
+IF EXISTS(
+    SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e
+    FULL OUTER JOIN (SELECT ServerName,CheckDate,COUNT(*) AS Copies FROM dbo.Waits_Deltas GROUP BY ServerName,CheckDate) d
+    ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate
+    WHERE e.ServerName IS NULL OR d.ServerName IS NULL OR d.Copies<>1)
+    THROW 51000,'Missing, extra, or duplicate Waits delta key.',1;
 IF EXISTS(SELECT 1 FROM dbo.Files_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.num_of_reads<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect file delta',1;
 IF EXISTS(SELECT 1 FROM dbo.Perfmon_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.cntr_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect perfmon delta',1;
 IF EXISTS(SELECT 1 FROM dbo.Waits_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.wait_time_ms_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect wait delta',1;
@@ -526,6 +544,24 @@ DELETE dbo.Files WHERE ServerName NOT IN(N'ServerA',N'ServerB');
 DELETE dbo.Perfmon WHERE ServerName NOT IN(N'ServerA',N'ServerB');
 DELETE dbo.Waits WHERE ServerName NOT IN(N'ServerA',N'ServerB');
 IF (SELECT COUNT(*) FROM dbo.Files_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Perfmon_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Waits_Deltas)<>4 THROW 51000,'Incorrect view row counts',1;
+IF EXISTS(
+    SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e
+    FULL OUTER JOIN (SELECT ServerName,CheckDate,COUNT(*) AS Copies FROM dbo.Files_Deltas GROUP BY ServerName,CheckDate) d
+    ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate
+    WHERE e.ServerName IS NULL OR d.ServerName IS NULL OR d.Copies<>1)
+    THROW 51000,'Missing, extra, or duplicate Files delta key.',1;
+IF EXISTS(
+    SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e
+    FULL OUTER JOIN (SELECT ServerName,CheckDate,COUNT(*) AS Copies FROM dbo.Perfmon_Deltas GROUP BY ServerName,CheckDate) d
+    ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate
+    WHERE e.ServerName IS NULL OR d.ServerName IS NULL OR d.Copies<>1)
+    THROW 51000,'Missing, extra, or duplicate Perfmon delta key.',1;
+IF EXISTS(
+    SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e
+    FULL OUTER JOIN (SELECT ServerName,CheckDate,COUNT(*) AS Copies FROM dbo.Waits_Deltas GROUP BY ServerName,CheckDate) d
+    ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate
+    WHERE e.ServerName IS NULL OR d.ServerName IS NULL OR d.Copies<>1)
+    THROW 51000,'Missing, extra, or duplicate Waits delta key.',1;
 IF EXISTS(SELECT 1 FROM dbo.Files_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.num_of_reads<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect file delta',1;
 IF EXISTS(SELECT 1 FROM dbo.Perfmon_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.cntr_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect perfmon delta',1;
 IF EXISTS(SELECT 1 FROM dbo.Waits_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.wait_time_ms_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect wait delta',1;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -353,3 +353,93 @@ IF @QueryPlanHash IS NULL
     RAISERROR('Seeded marker query was not found in the plan cache; sp_BlitzPlanCompare was not exercised.', 16, 1);
 
 EXEC dbo.sp_BlitzPlanCompare @QueryPlanHash = @QueryPlanHash, @DatabaseName = 'FRKSmokeTest';
+
+--#STEP: sp_BlitzFirst multi-server deltas and in-place upgrades
+IF DB_ID(N'FRKDeltaSmoke') IS NOT NULL THROW 51000,'Delta fixture already exists.',1;
+EXEC(N'CREATE DATABASE FRKDeltaSmoke;');
+GO
+EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=N'dbo',@OutputTableNameFileStats=N'Files',@OutputTableNamePerfmonStats=N'Perfmon',@OutputTableNameWaitStats=N'Waits';
+GO
+USE FRKDeltaSmoke;
+
+DELETE dbo.Files; DELETE dbo.Perfmon; DELETE dbo.Waits;
+CREATE TABLE dbo.Expected(ServerName nvarchar(128),CheckDate datetimeoffset,CounterValue bigint,ElapsedSeconds int);
+DECLARE @Base datetimeoffset=DATEADD(hour,-1,SYSDATETIMEOFFSET());
+INSERT dbo.Expected VALUES
+(N'ServerA',DATEADD(minute,0,@Base),1000,NULL),
+(N'ServerA',DATEADD(minute,5,@Base),2000,300),
+(N'ServerA',DATEADD(minute,10,@Base),3000,300),
+(N'ServerB',DATEADD(minute,0,@Base),4000,NULL),
+(N'ServerB',DATEADD(minute,5,@Base),5000,300),
+(N'ServerB',DATEADD(minute,12,@Base),6000,420);
+INSERT dbo.Files(ServerName,CheckDate,DatabaseID,FileID,num_of_reads,num_of_writes,io_stall_read_ms,io_stall_write_ms,bytes_read,bytes_written)
+SELECT ServerName,CheckDate,1,1,CounterValue,CounterValue,CounterValue,CounterValue,CounterValue,CounterValue FROM dbo.Expected;
+INSERT dbo.Perfmon(ServerName,CheckDate,object_name,counter_name,instance_name,cntr_type,cntr_value)
+SELECT ServerName,CheckDate,N'Object',N'Counter',N'Instance',272696576,CounterValue FROM dbo.Expected;
+INSERT dbo.Waits(ServerName,CheckDate,wait_type,wait_time_ms,signal_wait_time_ms,waiting_tasks_count)
+SELECT ServerName,CheckDate,N'LCK_M_X',CounterValue,0,CounterValue FROM dbo.Expected;
+CREATE USER CodexDeltaReader WITHOUT LOGIN;
+GRANT SELECT ON dbo.Files_Deltas TO CodexDeltaReader;
+GRANT SELECT ON dbo.Perfmon_Deltas TO CodexDeltaReader;
+GRANT SELECT ON dbo.Waits_Deltas TO CodexDeltaReader;
+SELECT object_id,name INTO dbo.OriginalViewIds FROM sys.views WHERE name IN('Files_Deltas','Perfmon_Deltas','Waits_Deltas');
+
+DELETE dbo.Files WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+DELETE dbo.Perfmon WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+DELETE dbo.Waits WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+IF (SELECT COUNT(*) FROM dbo.Files_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Perfmon_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Waits_Deltas)<>4 THROW 51000,'Incorrect view row counts',1;
+IF EXISTS(SELECT 1 FROM dbo.Files_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.num_of_reads<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect file delta',1;
+IF EXISTS(SELECT 1 FROM dbo.Perfmon_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.cntr_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect perfmon delta',1;
+IF EXISTS(SELECT 1 FROM dbo.Waits_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.wait_time_ms_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect wait delta',1;
+IF EXISTS(SELECT 1 FROM dbo.OriginalViewIds i LEFT JOIN sys.views v ON i.object_id=v.object_id AND i.name=v.name WHERE v.object_id IS NULL) THROW 51000,'View object ID changed',1;
+IF (SELECT COUNT(*) FROM sys.database_permissions WHERE grantee_principal_id=DATABASE_PRINCIPAL_ID('CodexDeltaReader') AND permission_name='SELECT')<>3 THROW 51000,'View permissions lost',1;
+PRINT 'SERVER DELTAS AND UPGRADE PASS';
+
+GO
+ALTER VIEW dbo.Files_Deltas AS SELECT CAST(1 AS int) AS Legacy;
+GO
+ALTER VIEW dbo.Perfmon_Deltas AS SELECT CAST(1 AS int) AS Legacy;
+GO
+ALTER VIEW dbo.Waits_Deltas AS SELECT CAST(1 AS int) AS Legacy;
+GO
+EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=N'dbo',@OutputTableNameFileStats=N'Files',@OutputTableNamePerfmonStats=N'Perfmon',@OutputTableNameWaitStats=N'Waits';
+GO
+
+DELETE dbo.Files WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+DELETE dbo.Perfmon WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+DELETE dbo.Waits WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+IF (SELECT COUNT(*) FROM dbo.Files_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Perfmon_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Waits_Deltas)<>4 THROW 51000,'Incorrect view row counts',1;
+IF EXISTS(SELECT 1 FROM dbo.Files_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.num_of_reads<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect file delta',1;
+IF EXISTS(SELECT 1 FROM dbo.Perfmon_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.cntr_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect perfmon delta',1;
+IF EXISTS(SELECT 1 FROM dbo.Waits_Deltas d JOIN dbo.Expected e ON e.ServerName=d.ServerName AND e.CheckDate=d.CheckDate WHERE d.wait_time_ms_delta<>1000 OR d.ElapsedSeconds<>e.ElapsedSeconds OR e.ElapsedSeconds IS NULL) THROW 51000,'Incorrect wait delta',1;
+IF EXISTS(SELECT 1 FROM dbo.OriginalViewIds i LEFT JOIN sys.views v ON i.object_id=v.object_id AND i.name=v.name WHERE v.object_id IS NULL) THROW 51000,'View object ID changed',1;
+IF (SELECT COUNT(*) FROM sys.database_permissions WHERE grantee_principal_id=DATABASE_PRINCIPAL_ID('CodexDeltaReader') AND permission_name='SELECT')<>3 THROW 51000,'View permissions lost',1;
+PRINT 'SERVER DELTAS AND UPGRADE PASS';
+
+GRANT VIEW DEFINITION ON dbo.Files_Deltas TO CodexDeltaReader;
+GRANT VIEW DEFINITION ON dbo.Perfmon_Deltas TO CodexDeltaReader;
+GRANT VIEW DEFINITION ON dbo.Waits_Deltas TO CodexDeltaReader;
+EXECUTE AS USER=N'CodexDeltaReader';
+BEGIN TRY
+    IF (SELECT COUNT(*) FROM sys.sql_modules WHERE definition LIKE '%FRK_ServerScopedDeltas_v1%') <> 3
+        THROW 51000,'Collector cannot recognize the migrated views.',1;
+    IF HAS_PERMS_BY_NAME(N'dbo.Files_Deltas', N'OBJECT', N'ALTER') <> 0
+        THROW 51000,'Metadata visibility test unexpectedly has ALTER permission.',1;
+    REVERT;
+END TRY
+BEGIN CATCH
+    REVERT;
+    THROW;
+END CATCH;
+SELECT object_id,modify_date INTO dbo.ViewModified FROM sys.views
+WHERE name IN(N'Files_Deltas',N'Perfmon_Deltas',N'Waits_Deltas');
+WAITFOR DELAY '00:00:01';
+GO
+EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=N'dbo',@OutputTableNameFileStats=N'Files',@OutputTableNamePerfmonStats=N'Perfmon',@OutputTableNameWaitStats=N'Waits';
+GO
+IF EXISTS(SELECT 1 FROM dbo.ViewModified m JOIN sys.views v ON v.object_id=m.object_id
+          WHERE v.modify_date<>m.modify_date)
+    THROW 51000,'Repeated collection unnecessarily altered a migrated view.',1;
+PRINT 'Multi-server delta values, upgrades, permissions, and repeat behavior passed.';
+USE master;
+DROP DATABASE FRKDeltaSmoke;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -591,11 +591,11 @@ IF (SELECT COUNT(*) FROM sys.database_permissions WHERE grantee_principal_id=DAT
 PRINT 'SERVER DELTAS AND UPGRADE PASS';
 
 GO
-ALTER VIEW dbo.Files_Deltas AS SELECT CAST(1 AS int) AS Legacy;
+ALTER VIEW dbo.Files_Deltas AS SELECT CAST(1 AS int) AS JoinKey, CAST(1 AS int) AS FRK_ServerScopedDeltas_v1;
 GO
-ALTER VIEW dbo.Perfmon_Deltas AS SELECT CAST(1 AS int) AS Legacy;
+ALTER VIEW dbo.Perfmon_Deltas AS SELECT CAST(1 AS int) AS JoinKey, CAST(1 AS int) AS FRK_ServerScopedDeltas_v1;
 GO
-ALTER VIEW dbo.Waits_Deltas AS SELECT CAST(1 AS int) AS Legacy;
+ALTER VIEW dbo.Waits_Deltas AS SELECT CAST(1 AS int) AS JoinKey, CAST(1 AS int) AS FRK_ServerScopedDeltas_v1;
 GO
 EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=N'dbo',@OutputTableNameFileStats=N'Files',@OutputTableNamePerfmonStats=N'Perfmon',@OutputTableNameWaitStats=N'Waits';
 GO
@@ -650,6 +650,8 @@ WAITFOR DELAY '00:00:01';
 GO
 EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=N'dbo',@OutputTableNameFileStats=N'Files',@OutputTableNamePerfmonStats=N'Perfmon',@OutputTableNameWaitStats=N'Waits';
 GO
+IF EXISTS(SELECT 1 FROM dbo.OriginalViewIds i LEFT JOIN sys.views v ON i.object_id=v.object_id AND i.name=v.name WHERE v.object_id IS NULL) THROW 51000,'Repeated collection changed a view object ID',1;
+IF (SELECT COUNT(*) FROM sys.database_permissions WHERE grantee_principal_id=DATABASE_PRINCIPAL_ID('CodexDeltaReader') AND permission_name='SELECT')<>3 THROW 51000,'Repeated collection lost view permissions',1;
 IF EXISTS(SELECT 1 FROM dbo.ViewModified m JOIN sys.views v ON v.object_id=m.object_id
           WHERE v.modify_date<>m.modify_date)
     THROW 51000,'Repeated collection unnecessarily altered a migrated view.',1;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -653,6 +653,14 @@ GO
 IF EXISTS(SELECT 1 FROM dbo.ViewModified m JOIN sys.views v ON v.object_id=m.object_id
           WHERE v.modify_date<>m.modify_date)
     THROW 51000,'Repeated collection unnecessarily altered a migrated view.',1;
+
+DECLARE @LongSchema sysname=REPLICATE(N'S',128), @LongTable sysname=REPLICATE(N'F',120), @LongSQL nvarchar(max);
+SET @LongSQL=N'CREATE SCHEMA '+QUOTENAME(@LongSchema)+N';';
+EXEC(@LongSQL);
+EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=@LongSchema,@OutputTableNameFileStats=@LongTable;
+IF NOT EXISTS(SELECT 1 FROM sys.views v JOIN sys.sql_modules m ON m.object_id=v.object_id
+ WHERE v.schema_id=SCHEMA_ID(@LongSchema) AND v.name=@LongTable+N'_Deltas' AND LEN(m.definition)>4000)
+ THROW 51000,'Long-identifier view was truncated or the fixture did not exceed 4000 characters.',1;
 PRINT 'Multi-server delta values, upgrades, permissions, and repeat behavior passed.';
 USE master;
 DROP DATABASE FRKDeltaSmoke;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -597,6 +597,13 @@ ALTER VIEW dbo.Perfmon_Deltas AS SELECT CAST(1 AS int) AS JoinKey, CAST(1 AS int
 GO
 ALTER VIEW dbo.Waits_Deltas AS SELECT CAST(1 AS int) AS JoinKey, CAST(1 AS int) AS FRK_ServerScopedDeltas_v1;
 GO
+/* A bare identifier is deliberately present to reproduce the old collision.
+   The complete comment marker must be absent before the migration call. */
+IF EXISTS(SELECT 1 FROM sys.sql_modules WHERE object_id IN
+    (OBJECT_ID(N'dbo.Files_Deltas'),OBJECT_ID(N'dbo.Perfmon_Deltas'),OBJECT_ID(N'dbo.Waits_Deltas'))
+    AND CHARINDEX(N'/* FRK_ServerScopedDeltas_v1 */',definition)>0)
+    THROW 51000,'Legacy fixture unexpectedly contains the complete migration marker.',1;
+GO
 EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=N'dbo',@OutputTableNameFileStats=N'Files',@OutputTableNamePerfmonStats=N'Perfmon',@OutputTableNameWaitStats=N'Waits';
 GO
 

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -539,14 +539,16 @@ USE FRKDeltaSmoke;
 
 DELETE dbo.Files; DELETE dbo.Perfmon; DELETE dbo.Waits;
 CREATE TABLE dbo.Expected(ServerName nvarchar(128),CheckDate datetimeoffset,CounterValue bigint,ElapsedSeconds int);
-DECLARE @Base datetimeoffset=DATEADD(hour,-1,SYSDATETIMEOFFSET());
+DECLARE @Base datetimeoffset=DATEADD(hour,-1,SYSDATETIMEOFFSET()),
+ @ServerA nvarchar(128)=N'FRKDeltaA_'+CONVERT(nvarchar(36),NEWID()),
+ @ServerB nvarchar(128)=N'FRKDeltaB_'+CONVERT(nvarchar(36),NEWID());
 INSERT dbo.Expected VALUES
-(N'ServerA',DATEADD(minute,0,@Base),1000,NULL),
-(N'ServerA',DATEADD(minute,5,@Base),2000,300),
-(N'ServerA',DATEADD(minute,10,@Base),3000,300),
-(N'ServerB',DATEADD(minute,0,@Base),4000,NULL),
-(N'ServerB',DATEADD(minute,5,@Base),5000,300),
-(N'ServerB',DATEADD(minute,12,@Base),6000,420);
+(@ServerA,DATEADD(minute,0,@Base),1000,NULL),
+(@ServerA,DATEADD(minute,5,@Base),2000,300),
+(@ServerA,DATEADD(minute,10,@Base),3000,300),
+(@ServerB,DATEADD(minute,0,@Base),4000,NULL),
+(@ServerB,DATEADD(minute,5,@Base),5000,300),
+(@ServerB,DATEADD(minute,12,@Base),6000,420);
 INSERT dbo.Files(ServerName,CheckDate,DatabaseID,FileID,num_of_reads,num_of_writes,io_stall_read_ms,io_stall_write_ms,bytes_read,bytes_written)
 SELECT ServerName,CheckDate,1,1,CounterValue,CounterValue,CounterValue,CounterValue,CounterValue,CounterValue FROM dbo.Expected;
 INSERT dbo.Perfmon(ServerName,CheckDate,object_name,counter_name,instance_name,cntr_type,cntr_value)
@@ -559,9 +561,9 @@ GRANT SELECT ON dbo.Perfmon_Deltas TO CodexDeltaReader;
 GRANT SELECT ON dbo.Waits_Deltas TO CodexDeltaReader;
 SELECT object_id,name INTO dbo.OriginalViewIds FROM sys.views WHERE name IN('Files_Deltas','Perfmon_Deltas','Waits_Deltas');
 
-DELETE dbo.Files WHERE ServerName NOT IN(N'ServerA',N'ServerB');
-DELETE dbo.Perfmon WHERE ServerName NOT IN(N'ServerA',N'ServerB');
-DELETE dbo.Waits WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+DELETE d FROM dbo.Files d WHERE NOT EXISTS(SELECT 1 FROM dbo.Expected e WHERE e.ServerName=d.ServerName);
+DELETE d FROM dbo.Perfmon d WHERE NOT EXISTS(SELECT 1 FROM dbo.Expected e WHERE e.ServerName=d.ServerName);
+DELETE d FROM dbo.Waits d WHERE NOT EXISTS(SELECT 1 FROM dbo.Expected e WHERE e.ServerName=d.ServerName);
 IF (SELECT COUNT(*) FROM dbo.Files_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Perfmon_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Waits_Deltas)<>4 THROW 51000,'Incorrect view row counts',1;
 IF EXISTS(
     SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e
@@ -598,9 +600,9 @@ GO
 EXEC master.dbo.sp_BlitzFirst @Seconds=1,@OutputDatabaseName=N'FRKDeltaSmoke',@OutputSchemaName=N'dbo',@OutputTableNameFileStats=N'Files',@OutputTableNamePerfmonStats=N'Perfmon',@OutputTableNameWaitStats=N'Waits';
 GO
 
-DELETE dbo.Files WHERE ServerName NOT IN(N'ServerA',N'ServerB');
-DELETE dbo.Perfmon WHERE ServerName NOT IN(N'ServerA',N'ServerB');
-DELETE dbo.Waits WHERE ServerName NOT IN(N'ServerA',N'ServerB');
+DELETE d FROM dbo.Files d WHERE NOT EXISTS(SELECT 1 FROM dbo.Expected e WHERE e.ServerName=d.ServerName);
+DELETE d FROM dbo.Perfmon d WHERE NOT EXISTS(SELECT 1 FROM dbo.Expected e WHERE e.ServerName=d.ServerName);
+DELETE d FROM dbo.Waits d WHERE NOT EXISTS(SELECT 1 FROM dbo.Expected e WHERE e.ServerName=d.ServerName);
 IF (SELECT COUNT(*) FROM dbo.Files_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Perfmon_Deltas)<>4 OR (SELECT COUNT(*) FROM dbo.Waits_Deltas)<>4 THROW 51000,'Incorrect view row counts',1;
 IF EXISTS(
     SELECT 1 FROM (SELECT ServerName,CheckDate FROM dbo.Expected WHERE ElapsedSeconds IS NOT NULL) e

--- a/Documentation/sp_BlitzFirst_History_View_Upgrade.md
+++ b/Documentation/sp_BlitzFirst_History_View_Upgrade.md
@@ -1,0 +1,43 @@
+# Upgrading sp_BlitzFirst history delta views
+
+The server-scoped history fix upgrades the file, Perfmon, and wait-stat `_Deltas`
+views in place. Existing object IDs and grants are preserved. A marker in each
+view definition prevents subsequent collections from altering it again.
+
+Before resuming a scheduled collection after this upgrade, have the history
+database owner run sp_BlitzFirst once with the same output database, schema,
+and file/Perfmon/wait table names used by the job. For example, replacing these
+names with the job's actual settings:
+
+```sql
+EXEC master.dbo.sp_BlitzFirst
+    @Seconds = 1,
+    @OutputDatabaseName = N'DBAHistory',
+    @OutputSchemaName = N'dbo',
+    @OutputTableNameFileStats = N'BlitzFirst_FileStats',
+    @OutputTableNamePerfmonStats = N'BlitzFirst_PerfmonStats',
+    @OutputTableNameWaitStats = N'BlitzFirst_WaitStats';
+```
+
+That first call needs permission to alter the existing views. A collector that
+can only insert history rows cannot perform this migration. Run it as the
+history database owner instead of permanently granting the scheduled collector
+DDL permissions.
+
+The scheduled collector must also be able to read the three view definitions
+to recognize that migration is complete. In the output database, grant this to
+the collector's database user if its existing permissions do not already allow
+it (substitute the actual names):
+
+```sql
+USE DBAHistory;
+GRANT VIEW DEFINITION ON dbo.BlitzFirst_FileStats_Deltas TO HistoryCollector;
+GRANT VIEW DEFINITION ON dbo.BlitzFirst_PerfmonStats_Deltas TO HistoryCollector;
+GRANT VIEW DEFINITION ON dbo.BlitzFirst_WaitStats_Deltas TO HistoryCollector;
+```
+
+These grants provide metadata visibility, not permission to alter the views.
+The collector still needs its existing procedure, DMV, and output-table
+permissions. Without metadata visibility, the procedure cannot recognize the
+marker and will attempt the migration again. Do not remove or change the
+`FRK_ServerScopedDeltas_v1` marker in migrated view definitions.

--- a/Documentation/sp_BlitzFirst_History_View_Upgrade.md
+++ b/Documentation/sp_BlitzFirst_History_View_Upgrade.md
@@ -24,10 +24,12 @@ can only insert history rows cannot perform this migration. Run it as the
 history database owner instead of permanently granting the scheduled collector
 DDL permissions.
 
-The scheduled collector must also be able to read the three view definitions
+The scheduled collector must also be able to read the definitions of the delta views its job creates
 to recognize that migration is complete. In the output database, grant this to
 the collector's database user if its existing permissions do not already allow
-it (substitute the actual names):
+it. Grant only on views created by the job: an output-table parameter set to
+NULL does not create its delta view. Omit the corresponding GRANT below and
+substitute the actual names:
 
 ```sql
 USE DBAHistory;

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -109,7 +109,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ';
-    PRINT 'History view upgrade: run the first collection as the output database owner, and give the collector VIEW DEFINITION on the three _Deltas views. See Documentation/sp_BlitzFirst_History_View_Upgrade.md.';
+    PRINT 'History view upgrade: run the first collection as the output database owner, and give the collector VIEW DEFINITION on each configured _Deltas view. See Documentation/sp_BlitzFirst_History_View_Upgrade.md.';
 
 RETURN;
 END;    /* @Help = 1 */

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -109,6 +109,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ';
+    PRINT 'History view upgrade: run the first collection as the output database owner, and give the collector VIEW DEFINITION on the three _Deltas views. See Documentation/sp_BlitzFirst_History_View_Upgrade.md.';
+
 RETURN;
 END;    /* @Help = 1 */
 

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -4345,7 +4345,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
                 + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
-                + ' EXEC (''CREATE OR ALTER VIEW '
+                + ' EXEC (N''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
                 + @OutputTableNameFileStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
                 + 'WITH RowDates as' + @LineFeed
@@ -4521,7 +4521,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
                 + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
-                + ' EXEC (''CREATE OR ALTER VIEW '
+                + ' EXEC (N''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
                 + @OutputTableNamePerfmonStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
                 + 'WITH RowDates as' + @LineFeed
@@ -4842,7 +4842,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
                 + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
-                + ' EXEC (''CREATE OR ALTER VIEW '
+                + ' EXEC (N''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
                 + @OutputTableNameWaitStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
                 + 'WITH RowDates as' + @LineFeed

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -4336,39 +4336,31 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 
         SET @ObjectFullName = @OutputDatabaseName + N'.' + @OutputSchemaName + N'.' +  @OutputTableNameFileStats_View;
 
-        /* If the view exists without the most recently added columns, drop it. See Github #2162. */
-        IF OBJECT_ID(@ObjectFullName) IS NOT NULL
-            BEGIN
-            SET @StringToExecute = N'USE ' + @OutputDatabaseName + N'; IF NOT EXISTS (SELECT * FROM ' + @OutputDatabaseName + N'.sys.all_columns 
-                WHERE object_id = (OBJECT_ID(''' + @ObjectFullName + N''')) AND name = ''JoinKey'')
-                DROP VIEW ' + @OutputSchemaName + N'.' + @OutputTableNameFileStats_View + N';';
-
-            EXEC(@StringToExecute);
-            END
-
-        /* Create the view */
-        IF OBJECT_ID(@ObjectFullName) IS NULL
-            BEGIN
+        /* Upgrade existing views in place to preserve permissions. */
+        BEGIN
             SET @StringToExecute = 'USE '
                 + @OutputDatabaseName
-                + '; EXEC (''CREATE VIEW '
+                + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
+                + ' WHERE object_id = OBJECT_ID(@ViewName)'
+                + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
+                + ' EXEC (''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
-                + @OutputTableNameFileStats_View + ' AS ' + @LineFeed
+                + @OutputTableNameFileStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
                 + 'WITH RowDates as' + @LineFeed
                 + '(' + @LineFeed
                 + '        SELECT ' + @LineFeed
-                + '                ROW_NUMBER() OVER (ORDER BY [ServerName], [CheckDate]) ID,' + @LineFeed
-                + '                [CheckDate]' + @LineFeed
+                + '                ROW_NUMBER() OVER (PARTITION BY [ServerName] ORDER BY [CheckDate]) ID,' + @LineFeed
+                + '                [ServerName], [CheckDate]' + @LineFeed
                 + '        FROM ' + @OutputSchemaName + '.' + @OutputTableNameFileStats + '' + @LineFeed
                 + '        GROUP BY [ServerName], [CheckDate]' + @LineFeed
                 + '),' + @LineFeed
                 + 'CheckDates as' + @LineFeed
                 + '(' + @LineFeed
-                + '        SELECT ThisDate.CheckDate,' + @LineFeed
+                + '        SELECT ThisDate.ServerName, ThisDate.CheckDate,' + @LineFeed
                 + '               LastDate.CheckDate as PreviousCheckDate' + @LineFeed
                 + '        FROM RowDates ThisDate' + @LineFeed
                 + '        JOIN RowDates LastDate' + @LineFeed
-                + '        ON ThisDate.ID = LastDate.ID + 1' + @LineFeed
+                + '        ON ThisDate.ID = LastDate.ID + 1 AND ThisDate.ServerName = LastDate.ServerName' + @LineFeed
                 + ')' + @LineFeed
                 + '     SELECT f.ServerName,' + @LineFeed
                 + '            f.CheckDate,' + @LineFeed
@@ -4399,7 +4391,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + '            (f.bytes_written - fPrior.bytes_written) / 1024.0 / 1024.0 AS megabytes_written, ' + @LineFeed
                 + '            f.ServerName + CAST(f.CheckDate AS NVARCHAR(50)) AS JoinKey' + @LineFeed
                 + '     FROM   ' + @OutputSchemaName + '.' + @OutputTableNameFileStats + ' f' + @LineFeed
-                + '            INNER HASH JOIN CheckDates DATES ON f.CheckDate = DATES.CheckDate' + @LineFeed
+                + '            INNER HASH JOIN CheckDates DATES ON f.CheckDate = DATES.CheckDate AND f.ServerName = DATES.ServerName' + @LineFeed
                 + '            INNER JOIN ' + @OutputSchemaName + '.' + @OutputTableNameFileStats + ' fPrior ON f.ServerName =                 fPrior.ServerName' + @LineFeed
                 + '                                                              AND f.DatabaseID = fPrior.DatabaseID' +     @LineFeed
                 + '                                                              AND f.FileID = fPrior.FileID' + @LineFeed
@@ -4409,7 +4401,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + '            AND f.num_of_writes >= fPrior.num_of_writes' + @LineFeed
                 + '            AND DATEDIFF(MI, fPrior.CheckDate, f.CheckDate) BETWEEN 1 AND 60;'')'
 
-			EXEC(@StringToExecute);
+			EXEC sys.sp_executesql @StringToExecute, N'@ViewName nvarchar(776)', @ViewName = @ObjectFullName;
             END;
 
 
@@ -4520,39 +4512,31 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 
         SET @ObjectFullName = @OutputDatabaseName + N'.' + @OutputSchemaName + N'.' +  @OutputTableNamePerfmonStats_View;
 
-        /* If the view exists without the most recently added columns, drop it. See Github #2162. */
-        IF OBJECT_ID(@ObjectFullName) IS NOT NULL
-            BEGIN
-            SET @StringToExecute = N'USE ' + @OutputDatabaseName + N'; IF NOT EXISTS (SELECT * FROM ' + @OutputDatabaseName + N'.sys.all_columns 
-                WHERE object_id = (OBJECT_ID(''' + @ObjectFullName + N''')) AND name = ''JoinKey'')
-                DROP VIEW ' + @OutputSchemaName + N'.' + @OutputTableNamePerfmonStats_View + N';';
-
-            EXEC(@StringToExecute);
-            END
-
-        /* Create the view */
-        IF OBJECT_ID(@ObjectFullName) IS NULL
-            BEGIN
+        /* Upgrade existing views in place to preserve permissions. */
+        BEGIN
             SET @StringToExecute = 'USE '
                 + @OutputDatabaseName
-                + '; EXEC (''CREATE VIEW '
+                + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
+                + ' WHERE object_id = OBJECT_ID(@ViewName)'
+                + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
+                + ' EXEC (''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
-                + @OutputTableNamePerfmonStats_View + ' AS ' + @LineFeed
+                + @OutputTableNamePerfmonStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
                 + 'WITH RowDates as' + @LineFeed
                 + '(' + @LineFeed
                 + '        SELECT ' + @LineFeed
-                + '                ROW_NUMBER() OVER (ORDER BY [ServerName], [CheckDate]) ID,' + @LineFeed
-                + '                [CheckDate]' + @LineFeed
+                + '                ROW_NUMBER() OVER (PARTITION BY [ServerName] ORDER BY [CheckDate]) ID,' + @LineFeed
+                + '                [ServerName], [CheckDate]' + @LineFeed
                 + '        FROM ' + @OutputSchemaName + '.' +@OutputTableNamePerfmonStats + '' + @LineFeed
                 + '        GROUP BY [ServerName], [CheckDate]' + @LineFeed
                 + '),' + @LineFeed
                 + 'CheckDates as' + @LineFeed
                 + '(' + @LineFeed
-                + '        SELECT ThisDate.CheckDate,' + @LineFeed
+                + '        SELECT ThisDate.ServerName, ThisDate.CheckDate,' + @LineFeed
                 + '               LastDate.CheckDate as PreviousCheckDate' + @LineFeed
                 + '        FROM RowDates ThisDate' + @LineFeed
                 + '        JOIN RowDates LastDate' + @LineFeed
-                + '        ON ThisDate.ID = LastDate.ID + 1' + @LineFeed
+                + '        ON ThisDate.ID = LastDate.ID + 1 AND ThisDate.ServerName = LastDate.ServerName' + @LineFeed
                 + ')' + @LineFeed
                 + 'SELECT' + @LineFeed
                 + '       pMon.[ServerName]' + @LineFeed
@@ -4568,7 +4552,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + '      ,pMon.ServerName + CAST(pMon.CheckDate AS NVARCHAR(50)) AS JoinKey' + @LineFeed
                 + '  FROM ' + @OutputSchemaName + '.' +@OutputTableNamePerfmonStats + ' pMon' + @LineFeed
                 + '  INNER HASH JOIN CheckDates Dates' + @LineFeed
-                + '  ON Dates.CheckDate = pMon.CheckDate' + @LineFeed
+                + '  ON Dates.CheckDate = pMon.CheckDate AND Dates.ServerName = pMon.ServerName' + @LineFeed
                 + '  JOIN ' + @OutputSchemaName + '.' +@OutputTableNamePerfmonStats + ' pMonPrior' + @LineFeed
                 + '  ON  Dates.PreviousCheckDate = pMonPrior.CheckDate' + @LineFeed
                 + '      AND pMon.[ServerName]    = pMonPrior.[ServerName]   ' + @LineFeed
@@ -4577,7 +4561,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + '      AND pMon.[instance_name] = pMonPrior.[instance_name]' + @LineFeed
                 + '    WHERE DATEDIFF(MI, pMonPrior.CheckDate, pMon.CheckDate) BETWEEN 1 AND 60;'')'
 
-			EXEC(@StringToExecute);
+			EXEC sys.sp_executesql @StringToExecute, N'@ViewName nvarchar(776)', @ViewName = @ObjectFullName;
             END
 
         SET @ObjectFullName = @OutputDatabaseName + N'.' + @OutputSchemaName + N'.' +  @OutputTableNamePerfmonStatsActuals_View;
@@ -4850,40 +4834,31 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 
         SET @ObjectFullName = @OutputDatabaseName + N'.' + @OutputSchemaName + N'.' +  @OutputTableNameWaitStats_View;
 
-        /* If the view exists without the most recently added columns, drop it. See Github #2162. */
-        IF OBJECT_ID(@ObjectFullName) IS NOT NULL
-            BEGIN
-            SET @StringToExecute = N'USE ' + @OutputDatabaseName + N'; IF NOT EXISTS (SELECT * FROM ' + @OutputDatabaseName + N'.sys.all_columns 
-                WHERE object_id = (OBJECT_ID(''' + @ObjectFullName + N''')) AND name = ''JoinKey'')
-                DROP VIEW ' + @OutputSchemaName + N'.' + @OutputTableNameWaitStats_View + N';';
-
-            EXEC(@StringToExecute);
-            END
-
-
-        /* Create the wait stats view */
-        IF OBJECT_ID(@ObjectFullName) IS NULL
-            BEGIN
+        /* Upgrade existing views in place to preserve permissions. */
+        BEGIN
             SET @StringToExecute = 'USE '
                 + @OutputDatabaseName
-                + '; EXEC (''CREATE VIEW '
+                + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
+                + ' WHERE object_id = OBJECT_ID(@ViewName)'
+                + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
+                + ' EXEC (''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
-                + @OutputTableNameWaitStats_View + ' AS ' + @LineFeed
+                + @OutputTableNameWaitStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
                 + 'WITH RowDates as' + @LineFeed
                 + '(' + @LineFeed
                 + '        SELECT ' + @LineFeed
-                + '                ROW_NUMBER() OVER (ORDER BY [ServerName], [CheckDate]) ID,' + @LineFeed
-                + '                [CheckDate]' + @LineFeed
+                + '                ROW_NUMBER() OVER (PARTITION BY [ServerName] ORDER BY [CheckDate]) ID,' + @LineFeed
+                + '                [ServerName], [CheckDate]' + @LineFeed
                 + '        FROM ' + @OutputSchemaName + '.' + @OutputTableNameWaitStats + @LineFeed
                 + '        GROUP BY [ServerName], [CheckDate]' + @LineFeed
                 + '),' + @LineFeed
                 + 'CheckDates as' + @LineFeed
                 + '(' + @LineFeed
-                + '        SELECT ThisDate.CheckDate,' + @LineFeed
+                + '        SELECT ThisDate.ServerName, ThisDate.CheckDate,' + @LineFeed
                 + '               LastDate.CheckDate as PreviousCheckDate' + @LineFeed
                 + '        FROM RowDates ThisDate' + @LineFeed
                 + '        JOIN RowDates LastDate' + @LineFeed
-                + '        ON ThisDate.ID = LastDate.ID + 1' + @LineFeed
+                + '        ON ThisDate.ID = LastDate.ID + 1 AND ThisDate.ServerName = LastDate.ServerName' + @LineFeed
                 + ')' + @LineFeed
                 + 'SELECT w.ServerName, w.CheckDate, w.wait_type, COALESCE(wc.WaitCategory, ''''Other'''') AS WaitCategory, COALESCE(wc.Ignorable,0) AS Ignorable' + @LineFeed
                 + ', DATEDIFF(ss, wPrior.CheckDate, w.CheckDate) AS ElapsedSeconds' + @LineFeed
@@ -4895,13 +4870,13 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + ', w.ServerName + CAST(w.CheckDate AS NVARCHAR(50)) AS JoinKey' + @LineFeed
                 + 'FROM ' + @OutputSchemaName + '.' + @OutputTableNameWaitStats + ' w' + @LineFeed
                 + 'INNER HASH JOIN CheckDates Dates' + @LineFeed
-                + 'ON Dates.CheckDate = w.CheckDate' + @LineFeed
+                + 'ON Dates.CheckDate = w.CheckDate AND Dates.ServerName = w.ServerName' + @LineFeed
                 + 'INNER JOIN ' + @OutputSchemaName + '.' + @OutputTableNameWaitStats + ' wPrior ON w.ServerName = wPrior.ServerName AND w.wait_type = wPrior.wait_type AND Dates.PreviousCheckDate = wPrior.CheckDate' + @LineFeed
 			 + 'LEFT OUTER JOIN ' + @OutputSchemaName + '.' + @OutputTableNameWaitStats_Categories + ' wc ON w.wait_type = wc.WaitType' + @LineFeed
                 + 'WHERE DATEDIFF(MI, wPrior.CheckDate, w.CheckDate) BETWEEN 1 AND 60' + @LineFeed
                 + 'AND [w].[wait_time_ms] >= [wPrior].[wait_time_ms];'')'
 
-			EXEC(@StringToExecute);
+			EXEC sys.sp_executesql @StringToExecute, N'@ViewName nvarchar(776)', @ViewName = @ObjectFullName;
             END;
 
 

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -4344,7 +4344,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + @OutputDatabaseName
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
-                + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
+                + ' AND CHARINDEX(''/* FRK_ServerScopedDeltas_v1 */'', definition) > 0)'
                 + ' EXEC (N''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
                 + @OutputTableNameFileStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
@@ -4520,7 +4520,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + @OutputDatabaseName
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
-                + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
+                + ' AND CHARINDEX(''/* FRK_ServerScopedDeltas_v1 */'', definition) > 0)'
                 + ' EXEC (N''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
                 + @OutputTableNamePerfmonStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed
@@ -4841,7 +4841,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
                 + @OutputDatabaseName
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
-                + ' AND CHARINDEX(''FRK_ServerScopedDeltas_v1'', definition) > 0)'
+                + ' AND CHARINDEX(''/* FRK_ServerScopedDeltas_v1 */'', definition) > 0)'
                 + ' EXEC (N''CREATE OR ALTER VIEW '
                 + @OutputSchemaName + '.'
                 + @OutputTableNameWaitStats_View + ' AS /* FRK_ServerScopedDeltas_v1 */ ' + @LineFeed

--- a/sp_BlitzFirst.sql
+++ b/sp_BlitzFirst.sql
@@ -4340,7 +4340,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 
         /* Upgrade existing views in place to preserve permissions. */
         BEGIN
-            SET @StringToExecute = 'USE '
+            SET @StringToExecute = CONVERT(nvarchar(max), N'USE ')
                 + @OutputDatabaseName
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
@@ -4516,7 +4516,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 
         /* Upgrade existing views in place to preserve permissions. */
         BEGIN
-            SET @StringToExecute = 'USE '
+            SET @StringToExecute = CONVERT(nvarchar(max), N'USE ')
                 + @OutputDatabaseName
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'
@@ -4837,7 +4837,7 @@ If one of them is a lead blocker, consider killing that query.'' AS HowToStopit,
 
         /* Upgrade existing views in place to preserve permissions. */
         BEGIN
-            SET @StringToExecute = 'USE '
+            SET @StringToExecute = CONVERT(nvarchar(max), N'USE ')
                 + @OutputDatabaseName
                 + '; IF NOT EXISTS (SELECT 1 FROM sys.sql_modules'
                 + ' WHERE object_id = OBJECT_ID(@ViewName)'


### PR DESCRIPTION
When multiple servers write to the same history tables, the file, perfmon, and wait delta views can duplicate rows or pair samples using another server's timeline. Partition sample numbering by ServerName and include ServerName in both date joins.

Existing views are upgraded with CREATE OR ALTER VIEW, preserving their object IDs and grants. A definition marker prevents repeating the alteration on subsequent collections.

Validation: reproduced incorrect row counts in all three original views on SQL Server 2022 and Windows SQL Server 2025. With the fix, two servers with shared and staggered sample times produced exactly four expected deltas per view, with correct values and elapsed times. Upgrade assertions confirmed unchanged object IDs and SELECT grants; repeat calls preserved modify_date. Fresh creation and a single-server control passed on SQL Server 2022. git diff --check passed.

Closes #4081.