### PR TITLE
sp_BlitzIndex: allow local output tables on Azure SQL Database

### DIFF
--- a/.github/scripts/azure-index-output-regression.sql
+++ b/.github/scripts/azure-index-output-regression.sql
@@ -1,0 +1,58 @@
+/* Dedicated test schema belongs to this serialized Azure CI workflow. */
+SET NOCOUNT ON;
+IF SCHEMA_ID(N'FRKIndexSmoke') IS NULL
+    EXEC(N'CREATE SCHEMA FRKIndexSmoke AUTHORIZATION dbo');
+DROP TABLE IF EXISTS FRKIndexSmoke.Inventory;
+DROP TABLE IF EXISTS FRKIndexSmoke.SourceData;
+CREATE TABLE FRKIndexSmoke.SourceData (ID int NOT NULL PRIMARY KEY, Payload char(100));
+INSERT FRKIndexSmoke.SourceData VALUES (1, 'a'), (2, 'b');
+DECLARE @Database sysname = DB_NAME();
+BEGIN TRY
+    EXEC dbo.sp_BlitzIndex @Mode = 2, @DatabaseName = @Database,
+         @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
+         @OutputTableName = N'Inventory';
+    IF OBJECT_ID(N'FRKIndexSmoke.Inventory') IS NULL
+        THROW 51000, 'Azure index output table was not created.', 1;
+    IF NOT EXISTS (SELECT 1 FROM FRKIndexSmoke.Inventory)
+        THROW 51000, 'Azure index inventory is empty.', 1;
+    DECLARE @Before bigint = (SELECT COUNT_BIG(*) FROM FRKIndexSmoke.Inventory);
+    EXEC dbo.sp_BlitzIndex @Mode = 2, @DatabaseName = @Database,
+         @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
+         @OutputTableName = N'Inventory';
+    IF (SELECT COUNT_BIG(*) FROM FRKIndexSmoke.Inventory) <= @Before
+        THROW 51000, 'Azure index output did not append.', 1;
+
+    ALTER TABLE FRKIndexSmoke.Inventory DROP COLUMN total_forwarded_fetch_count;
+    SET @Before = (SELECT COUNT_BIG(*) FROM FRKIndexSmoke.Inventory);
+    EXEC dbo.sp_BlitzIndex @Mode = 2, @DatabaseName = @Database,
+         @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
+         @OutputTableName = N'Inventory';
+    IF COL_LENGTH(N'FRKIndexSmoke.Inventory', N'total_forwarded_fetch_count') IS NULL
+        THROW 51000, 'Azure legacy output table was not upgraded.', 1;
+    IF (SELECT COUNT_BIG(*) FROM FRKIndexSmoke.Inventory) <= @Before
+        THROW 51000, 'Azure index upgrade did not append rows.', 1;
+
+    IF CONVERT(int, SERVERPROPERTY('EngineEdition')) = 5
+    BEGIN
+        BEGIN TRY
+            EXEC dbo.sp_BlitzIndex @Mode = 2, @OutputServerName = N'FRKInvalidServer',
+                 @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
+                 @OutputTableName = N'Inventory';
+            THROW 51000, 'Azure remote output was accepted.', 1;
+        END TRY
+        BEGIN CATCH
+            IF ERROR_NUMBER() <> 50000 OR ERROR_MESSAGE() NOT LIKE 'Azure SQL Database does not support @OutputServerName.%'
+                THROW;
+        END CATCH;
+    END;
+    DROP TABLE FRKIndexSmoke.Inventory;
+    DROP TABLE FRKIndexSmoke.SourceData;
+    DROP SCHEMA FRKIndexSmoke;
+END TRY
+BEGIN CATCH
+    DROP TABLE IF EXISTS FRKIndexSmoke.Inventory;
+    DROP TABLE IF EXISTS FRKIndexSmoke.SourceData;
+    DROP SCHEMA FRKIndexSmoke;
+    THROW;
+END CATCH;
+PRINT 'Azure index create/append/upgrade/rejection assertions passed.';

--- a/.github/scripts/azure-index-output-regression.sql
+++ b/.github/scripts/azure-index-output-regression.sql
@@ -2,6 +2,10 @@
 SET NOCOUNT ON;
 IF SCHEMA_ID(N'FRKIndexSmoke') IS NULL
     EXEC(N'CREATE SCHEMA FRKIndexSmoke AUTHORIZATION dbo');
+DROP TABLE IF EXISTS FRKIndexSmoke.Mode0;
+DROP TABLE IF EXISTS FRKIndexSmoke.Mode1;
+DROP TABLE IF EXISTS FRKIndexSmoke.Mode3;
+DROP TABLE IF EXISTS FRKIndexSmoke.Mode4;
 DROP TABLE IF EXISTS FRKIndexSmoke.Inventory;
 DROP TABLE IF EXISTS FRKIndexSmoke.SourceData;
 CREATE TABLE FRKIndexSmoke.SourceData (ID int NOT NULL PRIMARY KEY, Payload char(100));
@@ -22,11 +26,37 @@ BEGIN TRY
     IF (SELECT COUNT_BIG(*) FROM FRKIndexSmoke.Inventory) <= @Before
         THROW 51000, 'Azure index output did not append.', 1;
 
+    DECLARE @Mode tinyint = 0, @Table sysname, @ObjectID int;
+    WHILE @Mode <= 4
+    BEGIN
+        IF @Mode <> 2
+        BEGIN
+            SET @Table = CONCAT(N'Mode', @Mode);
+            EXEC dbo.sp_BlitzIndex @Mode = @Mode, @DatabaseName = @Database,
+                 @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
+                 @OutputTableName = @Table;
+            SET @ObjectID = OBJECT_ID(N'FRKIndexSmoke.' + QUOTENAME(@Table));
+            IF @ObjectID IS NULL THROW 51000, 'Azure output mode did not create a table.', 1;
+            EXEC dbo.sp_BlitzIndex @Mode = @Mode, @DatabaseName = @Database,
+                 @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
+                 @OutputTableName = @Table;
+            IF OBJECT_ID(N'FRKIndexSmoke.' + QUOTENAME(@Table)) <> @ObjectID
+               OR OBJECT_ID(N'FRKIndexSmoke.' + QUOTENAME(@Table)) IS NULL
+                THROW 51000, 'Azure output mode did not reuse its table.', 1;
+        END;
+        SET @Mode += 1;
+    END;
+
     ALTER TABLE FRKIndexSmoke.Inventory DROP COLUMN total_forwarded_fetch_count;
     SET @Before = (SELECT COUNT_BIG(*) FROM FRKIndexSmoke.Inventory);
-    EXEC dbo.sp_BlitzIndex @Mode = 2, @DatabaseName = @Database,
-         @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
-         @OutputTableName = N'Inventory';
+    /* Omitted output database must default locally, including upgrades. */
+    IF CONVERT(int, SERVERPROPERTY('EngineEdition')) = 5
+        EXEC dbo.sp_BlitzIndex @Mode = 2, @DatabaseName = @Database,
+             @OutputTableName = N'FRKIndexSmoke.Inventory';
+    ELSE
+        EXEC dbo.sp_BlitzIndex @Mode = 2, @DatabaseName = @Database,
+             @OutputDatabaseName = @Database, @OutputSchemaName = N'FRKIndexSmoke',
+             @OutputTableName = N'Inventory';
     IF COL_LENGTH(N'FRKIndexSmoke.Inventory', N'total_forwarded_fetch_count') IS NULL
         THROW 51000, 'Azure legacy output table was not upgraded.', 1;
     IF (SELECT COUNT_BIG(*) FROM FRKIndexSmoke.Inventory) <= @Before
@@ -45,12 +75,20 @@ BEGIN TRY
                 THROW;
         END CATCH;
     END;
+    DROP TABLE IF EXISTS FRKIndexSmoke.Mode0;
+    DROP TABLE IF EXISTS FRKIndexSmoke.Mode1;
+    DROP TABLE IF EXISTS FRKIndexSmoke.Mode3;
+    DROP TABLE IF EXISTS FRKIndexSmoke.Mode4;
     DROP TABLE FRKIndexSmoke.Inventory;
     DROP TABLE FRKIndexSmoke.SourceData;
     DROP SCHEMA FRKIndexSmoke;
 END TRY
 BEGIN CATCH
-    DROP TABLE IF EXISTS FRKIndexSmoke.Inventory;
+    DROP TABLE IF EXISTS FRKIndexSmoke.Mode0;
+DROP TABLE IF EXISTS FRKIndexSmoke.Mode1;
+DROP TABLE IF EXISTS FRKIndexSmoke.Mode3;
+DROP TABLE IF EXISTS FRKIndexSmoke.Mode4;
+DROP TABLE IF EXISTS FRKIndexSmoke.Inventory;
     DROP TABLE IF EXISTS FRKIndexSmoke.SourceData;
     DROP SCHEMA FRKIndexSmoke;
     THROW;

--- a/.github/scripts/run-azure-smoke-test.sh
+++ b/.github/scripts/run-azure-smoke-test.sh
@@ -128,10 +128,11 @@ fi
 echo
 echo "=== Clearing procedures left by earlier runs ==="
 run_query "DROP PROCEDURE IF EXISTS dbo.sp_Blitz;
-           DROP PROCEDURE IF EXISTS dbo.sp_ineachdb;" > /dev/null
+           DROP PROCEDURE IF EXISTS dbo.sp_ineachdb;
+           DROP PROCEDURE IF EXISTS dbo.sp_BlitzIndex;" > /dev/null
 
 remaining="$(run_scalar_int "SET NOCOUNT ON;
-SELECT COUNT(*) FROM sys.procedures WHERE name IN ('sp_Blitz', 'sp_ineachdb');")"
+SELECT COUNT(*) FROM sys.procedures WHERE name IN ('sp_Blitz', 'sp_ineachdb', 'sp_BlitzIndex');")"
 
 # Anything but a definite zero -- including an empty result -- means we cannot
 # prove the database is clean, and a stale procedure could carry the run.
@@ -145,7 +146,7 @@ echo "  database is clean"
 echo
 echo "=== Installing ==="
 # sp_ineachdb first: sp_Blitz calls it to iterate databases.
-for script in sp_ineachdb sp_Blitz; do
+for script in sp_ineachdb sp_Blitz sp_BlitzIndex; do
   echo "  installing $script"
   if ! "$SQLCMD" "${SQLCMD_ARGS[@]}" -i "$REPO_ROOT/$script.sql" > "$WORK_DIR/$script.log" 2>&1; then
     echo "::error::$script failed to install on Azure SQL Database"
@@ -153,6 +154,9 @@ for script in sp_ineachdb sp_Blitz; do
     exit 1
   fi
 done
+
+echo "=== Verifying Azure index output ==="
+"$SQLCMD" "${SQLCMD_ARGS[@]}" -i "$REPO_ROOT/.github/scripts/azure-index-output-regression.sql"
 
 # The install "succeeding" is exactly what made #4040 invisible: the CREATE stub
 # is its own batch and always works, while only the ALTER carrying the real body

--- a/.github/scripts/run-azure-smoke-test.sh
+++ b/.github/scripts/run-azure-smoke-test.sh
@@ -132,7 +132,8 @@ run_query "DROP PROCEDURE IF EXISTS dbo.sp_Blitz;
            DROP PROCEDURE IF EXISTS dbo.sp_BlitzIndex;" > /dev/null
 
 remaining="$(run_scalar_int "SET NOCOUNT ON;
-SELECT COUNT(*) FROM sys.procedures WHERE name IN ('sp_Blitz', 'sp_ineachdb', 'sp_BlitzIndex');")"
+SELECT COUNT(*) FROM sys.procedures WHERE schema_id = SCHEMA_ID(N'dbo')
+AND name IN ('sp_Blitz', 'sp_ineachdb', 'sp_BlitzIndex');")"
 
 # Anything but a definite zero -- including an empty result -- means we cannot
 # prove the database is clean, and a stale procedure could carry the run.

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -321,6 +321,13 @@ BEGIN
     RETURN;
 END;
 
+/* Azure SQL DB cannot use linked-server output, including its own server name. */
+IF @AzureSQLDB = 1 AND @OutputServerName IS NOT NULL
+BEGIN
+    RAISERROR('Azure SQL Database does not support @OutputServerName. Output to a table in the current database instead.', 12, 1);
+    RETURN;
+END;
+
 /* Some prep-work for output object names before checking if they're ok or not */
 IF (@OutputTableName IS NOT NULL)
 BEGIN
@@ -4415,7 +4422,7 @@ BEGIN
 							EXEC @@@OutputServerName@@@.@@@OutputDatabaseName@@@.dbo.sp_executesql N''ALTER TABLE @@@OutputSchemaName@@@.@@@OutputTableName@@@ ADD [total_forwarded_fetch_count] BIGINT''
 					END';
 	
-				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@', @OutputServerName);
+				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@.', CASE WHEN @AzureSQLDB = 1 THEN N'' ELSE @OutputServerName + N'.' END);
 				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputDatabaseName@@@', @OutputDatabaseName);
 				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputSchemaName@@@', @OutputSchemaName); 
 				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputTableName@@@', @OutputTableName);
@@ -4430,7 +4437,7 @@ BEGIN
 					ELSE
 						SET @TableExists = 1';
 				
-				SET @TableExistsSql = REPLACE(@TableExistsSql, '@@@OutputServerName@@@', @OutputServerName);
+				SET @TableExistsSql = REPLACE(@TableExistsSql, '@@@OutputServerName@@@.', CASE WHEN @AzureSQLDB = 1 THEN N'' ELSE @OutputServerName + N'.' END);
 				SET @TableExistsSql = REPLACE(@TableExistsSql, '@@@OutputDatabaseName@@@', @OutputDatabaseName);
 				SET @TableExistsSql = REPLACE(@TableExistsSql, '@@@OutputSchemaName@@@', @OutputSchemaName); 
 				SET @TableExistsSql = REPLACE(@TableExistsSql, '@@@OutputTableName@@@', @OutputTableName); 
@@ -6812,7 +6819,7 @@ BEGIN
 					ORDER BY br.Priority ASC, br.check_id ASC, br.blitz_result_id ASC, br.findings_group ASC
 					OPTION (RECOMPILE);';
 	
-				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@', @OutputServerName);
+				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@.', CASE WHEN @AzureSQLDB = 1 THEN N'' ELSE @OutputServerName + N'.' END);
 				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputDatabaseName@@@', @OutputDatabaseName);
 				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputSchemaName@@@', @OutputSchemaName); 
 				SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputTableName@@@', @OutputTableName); 
@@ -7032,7 +7039,7 @@ BEGIN
 							ORDER BY [Display Order] ASC
 							OPTION (RECOMPILE);';
 	
-					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@', @OutputServerName);
+					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@.', CASE WHEN @AzureSQLDB = 1 THEN N'' ELSE @OutputServerName + N'.' END);
 					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputDatabaseName@@@', @OutputDatabaseName);
 					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputSchemaName@@@', @OutputSchemaName); 
 					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputTableName@@@', @OutputTableName); 
@@ -7409,7 +7416,7 @@ BEGIN
 									ORDER BY [Database Name], [Schema Name], [Object Name], [Index ID]
 									OPTION (RECOMPILE);';
 	
-								SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@', @OutputServerName);
+								SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@.', CASE WHEN @AzureSQLDB = 1 THEN N'' ELSE @OutputServerName + N'.' END);
 								SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputDatabaseName@@@', @OutputDatabaseName);
 								SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputSchemaName@@@', @OutputSchemaName); 
 								SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputTableName@@@', @OutputTableName); 
@@ -7733,7 +7740,7 @@ BEGIN
 						ORDER BY [Display Order] ASC, [Magic Benefit Number] DESC
 						OPTION (RECOMPILE);';
 	
-					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@', @OutputServerName);
+					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputServerName@@@.', CASE WHEN @AzureSQLDB = 1 THEN N'' ELSE @OutputServerName + N'.' END);
 					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputDatabaseName@@@', @OutputDatabaseName);
 					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputSchemaName@@@', @OutputSchemaName); 
 					SET @StringToExecute = REPLACE(@StringToExecute, '@@@OutputTableName@@@', @OutputTableName); 


### PR DESCRIPTION
Azure SQL DB output fails because the local output path adds the server name to metadata lookups and INSERT targets. Omit that server prefix on Azure while retaining database qualification, including the command that upgrades older output tables. Reject an explicit @OutputServerName on Azure with an actionable message.

Validation on Azure SQL DB: Modes 0–4 each created and reused an output table; Mode 2 also restored a deliberately removed total_forwarded_fetch_count column and appended rows with the output database omitted. Explicit remote output raised the expected message. Temporary objects were removed and all 21 existing dbo procedure definition hashes were unchanged. SQL Server 2022 local create/append control and git diff --check passed.

Closes #4112.