### PR TITLE
sp_BlitzBackups: count logs overlapping the full or differential endpoint

### DIFF
--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -1039,6 +1039,28 @@ BEGIN TRY
     IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
        OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Damaged regular log received a restore estimate.',1;
+    /* A real striped full requires metadata for both media families. */
+    DECLARE @SecondFile nvarchar(512)=@Root+N'striped2.bak';
+    SET @File=@Root+N'striped1.bak';
+    BACKUP DATABASE FRKLogSource TO DISK=@File,DISK=@SecondFile WITH COPY_ONLY,INIT;
+    DECLARE @StripedFull int=(SELECT MAX(backup_set_id) FROM msdb.dbo.backupset WHERE database_name=N'FRKLogSource');
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset WHERE backup_set_id=@StripedFull;
+    DROP TABLE FRKLogHistory.dbo.backupmediafamily;
+    SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
+      WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
+    IF (SELECT COUNT(*) FROM FRKLogHistory.dbo.backupmediafamily)<>2
+        THROW 51000,'Striped fixture did not produce two families.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+        THROW 51000,'Complete striped metadata did not permit an estimate.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE FRKLogHistory.dbo.backupmediafamily WHERE family_sequence_number=2;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Missing stripe family received a restore estimate.',1;
     /* Exercise the unmodified push path with four-part local-server names.
        Precreate the destination so this tests insertion/mapping without remote DDL. */
     DROP TABLE FRKLogHistory.dbo.backupset;
@@ -1049,11 +1071,11 @@ BEGIN TRY
     IF NOT EXISTS(SELECT 1 FROM FRKLogHistory.dbo.backupset WHERE database_name=N'FRKLogSource')
         THROW 51000,'History push did not insert fixture backups.',1;
     IF EXISTS(
-      SELECT backup_set_uuid,first_recovery_fork_guid,last_recovery_fork_guid,fork_point_lsn,
+      SELECT backup_set_uuid,first_family_number,last_family_number,first_recovery_fork_guid,last_recovery_fork_guid,fork_point_lsn,
         differential_base_lsn,differential_base_guid,is_copy_only FROM msdb.dbo.backupset
       WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'))
       EXCEPT
-      SELECT backup_set_uuid,first_recovery_fork_guid,last_recovery_fork_guid,fork_point_lsn,
+      SELECT backup_set_uuid,first_family_number,last_family_number,first_recovery_fork_guid,last_recovery_fork_guid,fork_point_lsn,
         differential_base_lsn,differential_base_guid,is_copy_only FROM FRKLogHistory.dbo.backupset)
         THROW 51000,'History push lost or mis-mapped recovery metadata.',1;
     DROP DATABASE FRKLogHistory;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -577,16 +577,23 @@ PRINT 'Analysis, direct export, all, and all avg preserved the other session.';
 --#STEP: sp_BlitzBackups excludes redundant copy-only logs
 IF DB_ID(N'FRKLogSource') IS NOT NULL OR DB_ID(N'FRKLogHistory') IS NOT NULL
     THROW 51000, 'Backup overlap fixture already exists.', 1;
-EXEC(N'CREATE DATABASE FRKLogSource;');
-EXEC(N'CREATE DATABASE FRKLogHistory;');
+BEGIN TRY
+    EXEC(N'CREATE DATABASE FRKLogSource;');
+    EXEC(N'CREATE DATABASE FRKLogHistory;');
+END TRY
+BEGIN CATCH
+    IF DB_ID(N'FRKLogHistory') IS NOT NULL DROP DATABASE FRKLogHistory;
+    IF DB_ID(N'FRKLogSource') IS NOT NULL DROP DATABASE FRKLogSource;
+    THROW;
+END CATCH;
 GO
 DECLARE @Root nvarchar(512) = CONVERT(nvarchar(400), SERVERPROPERTY('InstanceDefaultDataPath')),
         @Separator nchar(1), @File nvarchar(512), @Definition nvarchar(max), @DeleteBefore datetime=DATEADD(day,1,GETDATE());
 SET @Separator = CASE WHEN CHARINDEX(N'/', @Root)>0 THEN N'/' ELSE N'\' END;
 IF RIGHT(@Root,1)<>@Separator SET @Root += @Separator;
 SET @Root += N'FRKLog_' + REPLACE(CONVERT(nvarchar(36),NEWID()),N'-',N'') + @Separator;
-EXEC master.dbo.xp_create_subdir @Root;
 BEGIN TRY
+    EXEC master.dbo.xp_create_subdir @Root;
     ALTER DATABASE FRKLogSource SET RECOVERY FULL;
     EXEC FRKLogSource.sys.sp_executesql N'CREATE TABLE dbo.Proof(Id int PRIMARY KEY); INSERT dbo.Proof VALUES(1);';
     SET @File=@Root+N'full.bak';
@@ -633,7 +640,7 @@ BEGIN TRY
     SET @Definition=REPLACE(@Definition,N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',
         N'INSERT #FRKRecoveryProof SELECT full_backup_set_id,log_backup_set_id,log_backups,log_file_size_mb,log_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NOT NULL;
           INSERT #FRKBackupProof SELECT RTOWorstCaseMinutes FROM #Backups;
-          INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE Finding=N''RTO estimate unavailable'';
+          INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE CheckId IN(15,16);
           DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
     EXEC FRKLogHistory.sys.sp_executesql @Definition;
     DECLARE @Case int=1, @ExpectedCount int, @ExpectedSeconds int, @ExpectedRTO decimal(18,2), @ExpectedMB decimal(18,2);
@@ -680,12 +687,26 @@ BEGIN TRY
         IF @Case IN(6,8) AND (EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR
             (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL))
             THROW 51000,'Ambiguous or discarded backup history reported an RTO estimate.',1;
-        IF @Case IN(6,8) AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof) THROW 51000,'Unavailable RTO did not explain the limitation.',1;
+        IF @Case=5 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Recovery fork metadata missing') THROW 51000,'Missing fork metadata warning absent.',1;
+        IF @Case IN(6,8) AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable') THROW 51000,'Unavailable RTO did not explain the limitation.',1;
         DELETE #FRKWarningProof;
         DELETE #FRKRecoveryProof;
         DELETE #FRKBackupProof;
         SET @Case+=1;
     END;
+    /* Equal intervals prefer the regular backup's duration and endpoint ID. */
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE backup_set_id<>@Endpoint;
+    UPDATE c SET first_lsn=r.first_lsn,last_lsn=r.last_lsn
+      FROM FRKLogHistory.dbo.backupset c CROSS JOIN FRKLogHistory.dbo.backupset r
+      WHERE c.backup_set_id=@Copy AND r.backup_set_id=@Regular;
+    UPDATE m SET physical_device_name=n.physical_device_name FROM FRKLogHistory.dbo.backupmediafamily m
+      JOIN msdb.dbo.backupmediafamily n ON n.media_set_id=m.media_set_id AND n.family_sequence_number=m.family_sequence_number;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
+        THROW 51000,'Equal intervals did not prefer the regular backup.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     /* A later full must not erase the overlapping endpoint of the earlier full. */
     INSERT FRKLogSource.dbo.Proof VALUES(6);
     SET @File=@Root+N'full2.bak';
@@ -718,8 +739,10 @@ BEGIN TRY
     UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(day,-10,GETDATE()),
        backup_finish_date=DATEADD(second,10,DATEADD(day,-10,GETDATE())),first_recovery_fork_guid=@ForkB,last_recovery_fork_guid=@ForkB
        WHERE backup_set_id<@CurrentFull;
-    UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(hour,-2,GETDATE()),
-       backup_finish_date=DATEADD(second,10,DATEADD(hour,-2,GETDATE())),first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA
+    /* A .007 datetime boundary exposed datetime2 promotion losing the anchor itself. */
+    DECLARE @AnchorTime datetime=DATEADD(millisecond,7,DATEADD(hour,DATEDIFF(hour,0,GETDATE())-2,0));
+    UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=@AnchorTime,
+       backup_finish_date=DATEADD(second,10,@AnchorTime),first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA
        WHERE backup_set_id=@CurrentFull;
     UPDATE FRKLogHistory.dbo.backupset SET first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA WHERE backup_set_id=@CurrentLog;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
@@ -727,7 +750,54 @@ BEGIN TRY
     IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
       (SELECT 1 FROM #FRKRecoveryProof WHERE full_backup_set_id=@CurrentFull AND log_backup_set_id=@CurrentLog AND log_backups=1)
       OR EXISTS(SELECT 1 FROM #FRKWarningProof)
+      OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'An ancient fork suppressed or contaminated the current recovery chain.',1;
+    /* Missing media metadata must produce an explained NULL estimate, not an error. */
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DROP TABLE FRKLogHistory.dbo.backupmediafamily;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR (SELECT COUNT(*) FROM #FRKBackupProof)<>1
+       OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Missing media metadata was not handled explicitly.',1;
+    SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
+      WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
+
+    /* No usable preceding full: do not silently lose the database or invent an RTO. */
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id<@CurrentFull;
+    UPDATE m SET physical_device_name=N'NUL' FROM FRKLogHistory.dbo.backupmediafamily m
+      JOIN FRKLogHistory.dbo.backupset b ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@CurrentFull;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR (SELECT COUNT(*) FROM #FRKBackupProof)<>1
+       OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Unusable preceding full did not produce an explained NULL RTO.',1;
+
+    /* A discarded full/diff alternative must not suppress the older usable chain. */
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
+      WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
+    UPDATE m SET physical_device_name=N'NUL' FROM FRKLogHistory.dbo.backupmediafamily m
+      JOIN FRKLogHistory.dbo.backupset b ON b.media_set_id=m.media_set_id WHERE b.type='I';
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+       OR NOT EXISTS(SELECT 1 FROM #FRKRecoveryProof WHERE full_backup_set_id<@CurrentFull)
+       OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+        THROW 51000,'Discarded full/diff alternatives suppressed a usable chain.',1;
+
+    /* A regular discard log before the window still breaks the selected chain. */
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@CurrentFull;
+    UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(hour,-2,GETDATE()),
+      backup_finish_date=DATEADD(second,10,DATEADD(hour,-2,GETDATE())) WHERE backup_set_id<>@CurrentLog;
+    UPDATE m SET physical_device_name=N'NUL' FROM FRKLogHistory.dbo.backupmediafamily m
+      JOIN FRKLogHistory.dbo.backupset b ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@Regular;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Pre-window discard log did not suppress the broken chain.',1;
     DROP DATABASE FRKLogHistory;
     DROP DATABASE FRKLogSource;
     EXEC master.dbo.xp_delete_file 0,@Root,N'bak',@DeleteBefore;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -513,3 +513,101 @@ END CATCH;
 PRINT 'Analysis, direct export, all, and all avg preserved the other session.';
 --#STEP: sp_BlitzAnalysis defaults and isolates output schemas
 /* The runner checks three result sets using analysis-schema-regression.sql. */
+
+--#STEP: sp_BlitzBackups excludes redundant copy-only logs
+IF DB_ID(N'FRKLogSource') IS NOT NULL OR DB_ID(N'FRKLogHistory') IS NOT NULL
+    THROW 51000, 'Backup overlap fixture already exists.', 1;
+EXEC(N'CREATE DATABASE FRKLogSource;');
+EXEC(N'CREATE DATABASE FRKLogHistory;');
+GO
+DECLARE @Root nvarchar(512) = CONVERT(nvarchar(400), SERVERPROPERTY('InstanceDefaultDataPath')),
+        @Separator nchar(1), @File nvarchar(512), @Definition nvarchar(max);
+SET @Separator = CASE WHEN CHARINDEX(N'/', @Root)>0 THEN N'/' ELSE N'\' END;
+IF RIGHT(@Root,1)<>@Separator SET @Root += @Separator;
+SET @Root += N'FRKLog_' + REPLACE(CONVERT(nvarchar(36),NEWID()),N'-',N'') + @Separator;
+EXEC master.dbo.xp_create_subdir @Root;
+BEGIN TRY
+    ALTER DATABASE FRKLogSource SET RECOVERY FULL;
+    EXEC FRKLogSource.sys.sp_executesql N'CREATE TABLE dbo.Proof(Id int PRIMARY KEY); INSERT dbo.Proof VALUES(1);';
+    SET @File=@Root+N'full.bak';
+    BACKUP DATABASE FRKLogSource TO DISK=@File WITH INIT;
+    INSERT FRKLogSource.dbo.Proof VALUES(2);
+    SET @File=@Root+N'diff.bak';
+    BACKUP DATABASE FRKLogSource TO DISK=@File WITH DIFFERENTIAL, INIT;
+    INSERT FRKLogSource.dbo.Proof VALUES(3);
+    SET @File=@Root+N'copy.trn';
+    BACKUP LOG FRKLogSource TO DISK=@File WITH COPY_ONLY, INIT;
+    INSERT FRKLogSource.dbo.Proof VALUES(4);
+    SET @File=@Root+N'regular.trn';
+    BACKUP LOG FRKLogSource TO DISK=@File WITH INIT;
+    INSERT FRKLogSource.dbo.Proof VALUES(5);
+    SET @File=@Root+N'endpoint.trn';
+    BACKUP LOG FRKLogSource TO DISK=@File WITH COPY_ONLY, INIT;
+
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
+    SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
+        WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
+    DECLARE @Copy int=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='L'),
+            @Regular int=(SELECT backup_set_id FROM FRKLogHistory.dbo.backupset WHERE type='L' AND is_copy_only=0),
+            @Endpoint int=(SELECT MAX(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='L');
+    IF (SELECT COUNT(*) FROM FRKLogHistory.dbo.backupset)<>5 OR @Copy IS NULL OR @Regular IS NULL OR @Endpoint=@Copy
+        THROW 51000, 'Native backup history fixture is incomplete.', 1;
+    IF NOT EXISTS(SELECT 1 FROM FRKLogHistory.dbo.backupset c JOIN FRKLogHistory.dbo.backupset r
+        ON r.backup_set_id=@Regular AND r.first_lsn<=c.first_lsn AND r.last_lsn>=c.last_lsn
+        WHERE c.backup_set_id=@Copy)
+        THROW 51000, 'The regular backup does not cover the copy-only interval.', 1;
+    /* Deterministic durations in the private history copy; native LSNs/sizes remain intact. */
+    UPDATE FRKLogHistory.dbo.backupset SET backup_finish_date=DATEADD(second,
+        CASE WHEN type='D' THEN 10 WHEN type='I' THEN 20 WHEN backup_set_id=@Copy THEN 30
+             WHEN backup_set_id=@Regular THEN 40 ELSE 50 END,backup_start_date);
+    CREATE TABLE #FRKRecoveryProof(log_backups int, log_file_size_mb decimal(18,2), log_time_seconds int);
+    CREATE TABLE #FRKBackupProof(RTOWorstCaseMinutes decimal(18,2));
+    /* Copy the installed procedure into the isolated fixture database. Only add result
+       capture before teardown; all production queries and calculations run unchanged. */
+    SELECT @Definition=definition FROM sys.sql_modules WHERE object_id=OBJECT_ID(N'dbo.sp_BlitzBackups');
+    SET @Definition=REPLACE(@Definition,N'ALTER PROCEDURE',N'CREATE PROCEDURE');
+    IF CHARINDEX(N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',@Definition)=0
+        THROW 51000, 'Cannot locate the production result-capture point.', 1;
+    SET @Definition=REPLACE(@Definition,N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',
+        N'INSERT #FRKRecoveryProof SELECT log_backups,log_file_size_mb,log_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NOT NULL;
+          INSERT #FRKBackupProof SELECT RTOWorstCaseMinutes FROM #Backups;
+          DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
+    EXEC FRKLogHistory.sys.sp_executesql @Definition;
+    DECLARE @Case int=1, @ExpectedCount int, @ExpectedSeconds int, @ExpectedRTO decimal(18,2), @ExpectedMB decimal(18,2);
+    WHILE @Case<=4
+    BEGIN
+        IF @Case=2 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Endpoint;
+        IF @Case=3 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Regular;
+        IF @Case=4 DELETE FRKLogHistory.dbo.backupset WHERE type='I';
+        SET @ExpectedCount=CASE WHEN @Case=1 THEN 2 ELSE 1 END;
+        SET @ExpectedSeconds=CASE @Case WHEN 1 THEN 90 WHEN 2 THEN 40 ELSE 30 END;
+        SET @ExpectedRTO=CASE @Case WHEN 1 THEN 2.00 WHEN 2 THEN 1.20 WHEN 3 THEN 1.00 ELSE 0.70 END;
+        SELECT @ExpectedMB=CONVERT(decimal(18,2),SUM(backup_size)/1048576.0)
+          FROM FRKLogHistory.dbo.backupset WHERE backup_set_id IN
+            (CASE WHEN @Case<=2 THEN @Regular ELSE @Copy END,CASE WHEN @Case=1 THEN @Endpoint ELSE NULL END);
+        EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+        IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+            (SELECT 1 FROM #FRKRecoveryProof WHERE log_backups=@ExpectedCount
+             AND log_time_seconds=@ExpectedSeconds AND log_file_size_mb=@ExpectedMB)
+            THROW 51000, 'Incorrect log count, size, or duration for the actual backup chain.', 1;
+        SELECT @Case AS TestCase, @ExpectedRTO AS ExpectedRTO, * FROM #FRKBackupProof;
+        IF (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR NOT EXISTS
+            (SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=@ExpectedRTO)
+            THROW 51000, 'Incorrect user-visible RTO for the actual backup chain.', 1;
+        DELETE #FRKRecoveryProof;
+        DELETE #FRKBackupProof;
+        SET @Case+=1;
+    END;
+    DROP DATABASE FRKLogHistory;
+    DROP DATABASE FRKLogSource;
+    EXEC master.dbo.xp_delete_file 0,@Root,N'bak';
+    EXEC master.dbo.xp_delete_file 0,@Root,N'trn';
+END TRY
+BEGIN CATCH
+    IF DB_ID(N'FRKLogHistory') IS NOT NULL DROP DATABASE FRKLogHistory;
+    IF DB_ID(N'FRKLogSource') IS NOT NULL DROP DATABASE FRKLogSource;
+    EXEC master.dbo.xp_delete_file 0,@Root,N'bak';
+    EXEC master.dbo.xp_delete_file 0,@Root,N'trn';
+    THROW;
+END CATCH;
+PRINT 'PASS: overlapping copy-only logs, copy-only endpoint, and full/diff boundaries';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -1116,6 +1116,13 @@ BEGIN TRY
       SELECT backup_set_uuid,first_family_number,last_family_number,first_recovery_fork_guid,last_recovery_fork_guid,fork_point_lsn,
         differential_base_lsn,differential_base_guid,is_copy_only FROM FRKLogHistory.dbo.backupset)
         THROW 51000,'History push lost or mis-mapped recovery metadata.',1;
+    EXEC FRKLogHistory.sys.sp_executesql N'IF EXISTS(SELECT 1 FROM dbo.backupset WHERE frk_media_is_usable IS NULL OR frk_media_has_discard IS NULL) THROW 51000,''Push omitted media facts.'',1;';
+    DROP TABLE FRKLogHistory.dbo.backupmediafamily;
+    DELETE FRKLogHistory.dbo.backupset WHERE database_guid<>(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+        THROW 51000,'Built-in pushed history cannot produce RTO without a media table.',1;
     DROP DATABASE FRKLogHistory;
     DROP DATABASE FRKLogSource;
     EXEC master.dbo.xp_delete_file 0,@Root,N'bak',@DeleteBefore;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -969,6 +969,15 @@ BEGIN TRY
         THROW 51000,'An ancient fork suppressed or contaminated the current recovery chain.',1;
     IF NOT EXISTS(SELECT 1 FROM #FRKRPOProof WHERE Minutes IS NOT NULL AND Endpoint=@CurrentLog AND PriorBackup=@CurrentFull)
         THROW 51000,'Newly visible old-full history omitted its RPO fields.',1;
+    SELECT * INTO #FRKEndpointSave FROM FRKLogHistory.dbo.backupset WHERE backup_set_id=@CurrentLog;
+    UPDATE FRKLogHistory.dbo.backupset SET type='I',is_damaged=1 WHERE backup_set_id=@CurrentLog;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Old full became an out-of-window standalone endpoint.',1;
+    UPDATE b SET type=s.type,is_damaged=s.is_damaged FROM FRKLogHistory.dbo.backupset b JOIN #FRKEndpointSave s ON b.backup_set_id=s.backup_set_id;
+    DROP TABLE #FRKEndpointSave;
     /* Merged sources cannot share an unqualified media_set_id mapping safely. */
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     UPDATE FRKLogHistory.dbo.backupset SET server_name=N'OtherSource' WHERE backup_set_id=@CurrentLog;
@@ -1117,6 +1126,11 @@ BEGIN TRY
         differential_base_lsn,differential_base_guid,is_copy_only FROM FRKLogHistory.dbo.backupset)
         THROW 51000,'History push lost or mis-mapped recovery metadata.',1;
     EXEC FRKLogHistory.sys.sp_executesql N'IF EXISTS(SELECT 1 FROM dbo.backupset WHERE frk_media_is_usable IS NULL OR frk_media_has_discard IS NULL) THROW 51000,''Push omitted media facts.'',1;';
+    /* No current push rows: retained full facts must still be backfilled. */
+    EXEC FRKLogHistory.sys.sp_executesql N'UPDATE dbo.backupset SET frk_media_is_usable=NULL,frk_media_has_discard=NULL WHERE type=''D'';';
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @PushBackupHistoryToListener=1,
+      @WriteBackupsToListenerName=@LocalServer,@WriteBackupsToDatabaseName=N'FRKLogHistory',@WriteBackupsLastHours=0;
+    EXEC FRKLogHistory.sys.sp_executesql N'IF EXISTS(SELECT 1 FROM dbo.backupset WHERE type=''D'' AND (frk_media_is_usable IS NULL OR frk_media_has_discard IS NULL)) THROW 51000,''Retained full media facts were not refreshed.'',1;';
     DROP TABLE FRKLogHistory.dbo.backupmediafamily;
     DELETE FRKLogHistory.dbo.backupset WHERE database_guid<>(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -1040,21 +1040,39 @@ BEGIN TRY
        OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Damaged regular log received a restore estimate.',1;
     /* A real striped full requires metadata for both media families. */
-    DECLARE @SecondFile nvarchar(512)=@Root+N'striped2.bak';
+    DECLARE @SecondFile nvarchar(512)=@Root+N'striped2.bak',
+      @MirrorFirst nvarchar(512)=@Root+N'mirror1.bak',@MirrorSecond nvarchar(512)=@Root+N'mirror2.bak';
     SET @File=@Root+N'striped1.bak';
-    BACKUP DATABASE FRKLogSource TO DISK=@File,DISK=@SecondFile WITH COPY_ONLY,INIT;
+    BACKUP DATABASE FRKLogSource TO DISK=@File,DISK=@SecondFile
+      MIRROR TO DISK=@MirrorFirst,DISK=@MirrorSecond WITH COPY_ONLY,INIT,FORMAT;
     DECLARE @StripedFull int=(SELECT MAX(backup_set_id) FROM msdb.dbo.backupset WHERE database_name=N'FRKLogSource');
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset WHERE backup_set_id=@StripedFull;
     DROP TABLE FRKLogHistory.dbo.backupmediafamily;
     SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
       WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
-    IF (SELECT COUNT(*) FROM FRKLogHistory.dbo.backupmediafamily)<>2
-        THROW 51000,'Striped fixture did not produce two families.',1;
+    IF (SELECT COUNT(*) FROM FRKLogHistory.dbo.backupmediafamily)<>4
+        THROW 51000,'Mirrored fixture did not produce two copies of two families.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'Complete striped metadata did not permit an estimate.',1;
+    /* SQL Server can restore one family from each different mirror. */
+    DELETE FRKLogHistory.dbo.backupmediafamily WHERE (mirror=0 AND family_sequence_number=2)
+      OR (mirror=1 AND family_sequence_number=1);
+    RESTORE VERIFYONLY FROM DISK=@File,DISK=@MirrorSecond;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+        THROW 51000,'Interchangeable families from different mirrors were rejected.',1;
+    DROP TABLE FRKLogHistory.dbo.backupmediafamily;
+    SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
+      WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
+    UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'NUL' WHERE mirror=0;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+        THROW 51000,'A discard mirror suppressed another usable mirror.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     DELETE FRKLogHistory.dbo.backupmediafamily WHERE family_sequence_number=2;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -786,6 +786,15 @@ BEGIN TRY
       OR EXISTS(SELECT 1 FROM #FRKWarningProof)
       OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'An ancient fork suppressed or contaminated the current recovery chain.',1;
+    /* A media table with missing candidate rows is also incomplete metadata. */
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE m FROM FRKLogHistory.dbo.backupmediafamily m JOIN FRKLogHistory.dbo.backupset b
+      ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@CurrentLog;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR (SELECT COUNT(*) FROM #FRKBackupProof)<>1
+       OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Missing candidate media rows were treated as usable backups.',1;
     /* Missing media metadata must produce an explained NULL estimate, not an error. */
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     DROP TABLE FRKLogHistory.dbo.backupmediafamily;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -707,6 +707,16 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
         THROW 51000,'Equal intervals did not prefer the regular backup.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    /* Old NULL metadata and newly pushed known metadata still share one estimate. */
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE backup_set_id<>@Endpoint;
+    UPDATE FRKLogHistory.dbo.backupset SET first_recovery_fork_guid=NULL,last_recovery_fork_guid=NULL WHERE backup_set_id=@Copy;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
+      OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Recovery fork metadata missing')
+        THROW 51000,'Mixed unknown and known fork metadata double-counted covered logs.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     /* A later full must not erase the overlapping endpoint of the earlier full. */
     INSERT FRKLogSource.dbo.Proof VALUES(6);
     SET @File=@Root+N'full2.bak';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -690,6 +690,10 @@ BEGIN TRY
     INSERT FRKLogSource.dbo.Proof VALUES(6);
     SET @File=@Root+N'full2.bak';
     BACKUP DATABASE FRKLogSource TO DISK=@File WITH INIT;
+    INSERT FRKLogSource.dbo.Proof VALUES(7);
+    EXEC FRKLogSource.sys.sp_executesql N'CHECKPOINT;';
+    SET @File=@Root+N'current.trn';
+    BACKUP LOG FRKLogSource TO DISK=@File WITH INIT;
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
       WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
@@ -699,16 +703,13 @@ BEGIN TRY
     UPDATE FRKLogHistory.dbo.backupset SET backup_finish_date=DATEADD(second,
         CASE WHEN type='D' THEN 10 WHEN type='I' THEN 20 WHEN backup_set_id=@Copy THEN 30
              WHEN backup_set_id=@Regular THEN 40 ELSE 50 END,backup_start_date);
+    DECLARE @BoundaryLog int=(SELECT MAX(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='L');
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
-    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
-      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Endpoint AND log_backups=2 AND log_time_seconds=90
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>2 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@BoundaryLog AND log_backups=2 AND log_time_seconds=90
        AND full_backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'))
         THROW 51000,'Older full lost its overlapping log endpoint or selected a different database.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
-    INSERT FRKLogSource.dbo.Proof VALUES(7);
-    EXEC FRKLogSource.sys.sp_executesql N'CHECKPOINT;';
-    SET @File=@Root+N'current.trn';
-    BACKUP LOG FRKLogSource TO DISK=@File WITH INIT;
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
       WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -521,7 +521,7 @@ EXEC(N'CREATE DATABASE FRKLogSource;');
 EXEC(N'CREATE DATABASE FRKLogHistory;');
 GO
 DECLARE @Root nvarchar(512) = CONVERT(nvarchar(400), SERVERPROPERTY('InstanceDefaultDataPath')),
-        @Separator nchar(1), @File nvarchar(512), @Definition nvarchar(max);
+        @Separator nchar(1), @File nvarchar(512), @Definition nvarchar(max), @DeleteBefore datetime=DATEADD(day,1,GETDATE());
 SET @Separator = CASE WHEN CHARINDEX(N'/', @Root)>0 THEN N'/' ELSE N'\' END;
 IF RIGHT(@Root,1)<>@Separator SET @Root += @Separator;
 SET @Root += N'FRKLog_' + REPLACE(CONVERT(nvarchar(36),NEWID()),N'-',N'') + @Separator;
@@ -560,8 +560,10 @@ BEGIN TRY
     UPDATE FRKLogHistory.dbo.backupset SET backup_finish_date=DATEADD(second,
         CASE WHEN type='D' THEN 10 WHEN type='I' THEN 20 WHEN backup_set_id=@Copy THEN 30
              WHEN backup_set_id=@Regular THEN 40 ELSE 50 END,backup_start_date);
-    CREATE TABLE #FRKRecoveryProof(log_backups int, log_file_size_mb decimal(18,2), log_time_seconds int);
+    SELECT * INTO FRKLogHistory.dbo.AllBackupSets FROM FRKLogHistory.dbo.backupset;
+    CREATE TABLE #FRKRecoveryProof(full_backup_set_id int,log_backup_set_id int, log_backups int, log_file_size_mb decimal(18,2), log_time_seconds int);
     CREATE TABLE #FRKBackupProof(RTOWorstCaseMinutes decimal(18,2));
+    CREATE TABLE #FRKWarningProof(Finding nvarchar(200));
     /* Copy the installed procedure into the isolated fixture database. Only add result
        capture before teardown; all production queries and calculations run unchanged. */
     SELECT @Definition=definition FROM sys.sql_modules WHERE object_id=OBJECT_ID(N'dbo.sp_BlitzBackups');
@@ -569,45 +571,87 @@ BEGIN TRY
     IF CHARINDEX(N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',@Definition)=0
         THROW 51000, 'Cannot locate the production result-capture point.', 1;
     SET @Definition=REPLACE(@Definition,N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',
-        N'INSERT #FRKRecoveryProof SELECT log_backups,log_file_size_mb,log_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NOT NULL;
+        N'INSERT #FRKRecoveryProof SELECT full_backup_set_id,log_backup_set_id,log_backups,log_file_size_mb,log_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NOT NULL;
           INSERT #FRKBackupProof SELECT RTOWorstCaseMinutes FROM #Backups;
+          INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE Finding=N''RTO estimate unavailable'';
           DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
     EXEC FRKLogHistory.sys.sp_executesql @Definition;
     DECLARE @Case int=1, @ExpectedCount int, @ExpectedSeconds int, @ExpectedRTO decimal(18,2), @ExpectedMB decimal(18,2);
-    WHILE @Case<=4
+    WHILE @Case<=7
     BEGIN
         IF @Case=2 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Endpoint;
         IF @Case=3 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Regular;
         IF @Case=4 DELETE FRKLogHistory.dbo.backupset WHERE type='I';
+        IF @Case=5
+        BEGIN
+            DROP TABLE FRKLogHistory.dbo.backupset;
+            SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE backup_set_id<>@Endpoint;
+            UPDATE FRKLogHistory.dbo.backupset SET first_recovery_fork_guid=NULL,last_recovery_fork_guid=NULL;
+        END;
+        IF @Case=6
+        BEGIN
+            DECLARE @ForkA uniqueidentifier=NEWID(), @ForkB uniqueidentifier=NEWID();
+            UPDATE FRKLogHistory.dbo.backupset SET first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA;
+            UPDATE FRKLogHistory.dbo.backupset SET last_recovery_fork_guid=@ForkB WHERE backup_set_id=@Copy;
+        END;
+        IF @Case=7
+        BEGIN
+            UPDATE FRKLogHistory.dbo.backupset SET first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA;
+            UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'NUL'
+              WHERE media_set_id=(SELECT media_set_id FROM FRKLogHistory.dbo.backupset WHERE backup_set_id=@Copy);
+        END;
         SET @ExpectedCount=CASE WHEN @Case=1 THEN 2 ELSE 1 END;
-        SET @ExpectedSeconds=CASE @Case WHEN 1 THEN 90 WHEN 2 THEN 40 ELSE 30 END;
-        SET @ExpectedRTO=CASE @Case WHEN 1 THEN 2.00 WHEN 2 THEN 1.20 WHEN 3 THEN 1.00 ELSE 0.70 END;
+        SET @ExpectedSeconds=CASE @Case WHEN 1 THEN 90 WHEN 2 THEN 40 WHEN 5 THEN 40 ELSE 30 END;
+        SET @ExpectedRTO=CASE @Case WHEN 1 THEN 2.00 WHEN 2 THEN 1.20 WHEN 3 THEN 1.00 WHEN 5 THEN 1.20 ELSE 0.70 END;
         SELECT @ExpectedMB=CONVERT(decimal(18,2),SUM(backup_size)/1048576.0)
           FROM FRKLogHistory.dbo.backupset WHERE backup_set_id IN
-            (CASE WHEN @Case<=2 THEN @Regular ELSE @Copy END,CASE WHEN @Case=1 THEN @Endpoint ELSE NULL END);
+            (CASE WHEN @Case<=2 OR @Case=5 THEN @Regular ELSE @Copy END,CASE WHEN @Case=1 THEN @Endpoint ELSE NULL END);
         EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
-        IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
-            (SELECT 1 FROM #FRKRecoveryProof WHERE log_backups=@ExpectedCount
-             AND log_time_seconds=@ExpectedSeconds AND log_file_size_mb=@ExpectedMB)
+        IF @Case<=5 AND ((SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+            (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=CASE WHEN @Case=1 THEN @Endpoint WHEN @Case IN(2,5) THEN @Regular ELSE @Copy END AND full_backup_set_id<>log_backup_set_id AND log_backups=@ExpectedCount
+             AND log_time_seconds=@ExpectedSeconds AND log_file_size_mb=@ExpectedMB))
             THROW 51000, 'Incorrect log count, size, or duration for the actual backup chain.', 1;
         SELECT @Case AS TestCase, @ExpectedRTO AS ExpectedRTO, * FROM #FRKBackupProof;
-        IF (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR NOT EXISTS
-            (SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=@ExpectedRTO)
+        IF @Case<=5 AND ((SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR NOT EXISTS
+            (SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=@ExpectedRTO))
             THROW 51000, 'Incorrect user-visible RTO for the actual backup chain.', 1;
+        IF @Case>=6 AND (EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR
+            (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL))
+            THROW 51000,'Ambiguous or discarded backup history reported an RTO estimate.',1;
+        IF @Case>=6 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof) THROW 51000,'Unavailable RTO did not explain the limitation.',1;
+        DELETE #FRKWarningProof;
         DELETE #FRKRecoveryProof;
         DELETE #FRKBackupProof;
         SET @Case+=1;
     END;
+    /* A later full must not erase the overlapping endpoint of the earlier full. */
+    INSERT FRKLogSource.dbo.Proof VALUES(6);
+    SET @File=@Root+N'full2.bak';
+    BACKUP DATABASE FRKLogSource TO DISK=@File WITH INIT;
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
+      WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
+    DROP TABLE FRKLogHistory.dbo.backupmediafamily;
+    SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
+      WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
+    UPDATE FRKLogHistory.dbo.backupset SET backup_finish_date=DATEADD(second,
+        CASE WHEN type='D' THEN 10 WHEN type='I' THEN 20 WHEN backup_set_id=@Copy THEN 30
+             WHEN backup_set_id=@Regular THEN 40 ELSE 50 END,backup_start_date);
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Endpoint AND log_backups=2 AND log_time_seconds=90
+       AND full_backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'))
+        THROW 51000,'Older full lost its overlapping log endpoint or selected a different database.',1;
     DROP DATABASE FRKLogHistory;
     DROP DATABASE FRKLogSource;
-    EXEC master.dbo.xp_delete_file 0,@Root,N'bak';
-    EXEC master.dbo.xp_delete_file 0,@Root,N'trn';
+    EXEC master.dbo.xp_delete_file 0,@Root,N'bak',@DeleteBefore;
+    EXEC master.dbo.xp_delete_file 0,@Root,N'trn',@DeleteBefore;
 END TRY
 BEGIN CATCH
     IF DB_ID(N'FRKLogHistory') IS NOT NULL DROP DATABASE FRKLogHistory;
     IF DB_ID(N'FRKLogSource') IS NOT NULL DROP DATABASE FRKLogSource;
-    EXEC master.dbo.xp_delete_file 0,@Root,N'bak';
-    EXEC master.dbo.xp_delete_file 0,@Root,N'trn';
+    EXEC master.dbo.xp_delete_file 0,@Root,N'bak',@DeleteBefore;
+    EXEC master.dbo.xp_delete_file 0,@Root,N'trn',@DeleteBefore;
     THROW;
 END CATCH;
 PRINT 'PASS: overlapping copy-only logs, copy-only endpoint, and full/diff boundaries';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -640,14 +640,19 @@ BEGIN TRY
     SET @Definition=REPLACE(@Definition,N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',
         N'INSERT #FRKRecoveryProof SELECT full_backup_set_id,log_backup_set_id,log_backups,log_file_size_mb,log_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NOT NULL;
           INSERT #FRKBackupProof SELECT RTOWorstCaseMinutes FROM #Backups;
-          INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE CheckId IN(15,16);
+          INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE CheckId IN(14,15,16);
           DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
     EXEC FRKLogHistory.sys.sp_executesql @Definition;
     DECLARE @Case int=1, @ExpectedCount int, @ExpectedSeconds int, @ExpectedRTO decimal(18,2), @ExpectedMB decimal(18,2);
     WHILE @Case<=8
     BEGIN
         IF @Case=2 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Endpoint;
-        IF @Case=3 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Regular;
+        IF @Case=3
+        BEGIN
+            IF EXISTS(SELECT 1 FROM FRKLogHistory.dbo.backupset WHERE backup_set_id=@Endpoint)
+                THROW 51000,'Case 2 failed to remove the endpoint before case 3.',1;
+            DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Regular;
+        END;
         IF @Case=4 DELETE FRKLogHistory.dbo.backupset WHERE type='I';
         IF @Case=5
         BEGIN
@@ -664,7 +669,7 @@ BEGIN TRY
         IF @Case=7
         BEGIN
             UPDATE FRKLogHistory.dbo.backupset SET first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA;
-            UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'NUL'
+            UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'/dev/null'
               WHERE media_set_id=(SELECT media_set_id FROM FRKLogHistory.dbo.backupset WHERE backup_set_id=@Copy);
         END;
         IF @Case=8 UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'NUL'
@@ -687,6 +692,7 @@ BEGIN TRY
         IF @Case IN(6,8) AND (EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR
             (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL))
             THROW 51000,'Ambiguous or discarded backup history reported an RTO estimate.',1;
+        IF @Case=7 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Backup to NUL device') THROW 51000,'Linux discard-device warning absent.',1;
         IF @Case=5 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Recovery fork metadata missing') THROW 51000,'Missing fork metadata warning absent.',1;
         IF @Case IN(6,8) AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable') THROW 51000,'Unavailable RTO did not explain the limitation.',1;
         DELETE #FRKWarningProof;
@@ -716,6 +722,24 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Recovery fork metadata missing')
         THROW 51000,'Mixed unknown and known fork metadata double-counted covered logs.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    /* A differential with an unknown base is optional; full plus logs remains valid. */
+    UPDATE FRKLogHistory.dbo.backupset SET differential_base_guid=NULL WHERE type='I';
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
+      OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=CAST(50.0/60 AS decimal(18,1)))
+        THROW 51000,'Unknown differential base did not use the complete full-plus-log path.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    /* Unknown copy-only metadata on discard media must not produce a numeric RTO. */
+    ALTER TABLE FRKLogHistory.dbo.backupset ALTER COLUMN is_copy_only bit NULL;
+    UPDATE FRKLogHistory.dbo.backupset SET is_copy_only=NULL WHERE backup_set_id=@Regular;
+    UPDATE m SET physical_device_name=N'/dev/null' FROM FRKLogHistory.dbo.backupmediafamily m
+      JOIN FRKLogHistory.dbo.backupset b ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@Regular;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+      OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Unknown copy-only metadata allowed a discard log into RTO.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     /* A later full must not erase the overlapping endpoint of the earlier full. */
     INSERT FRKLogSource.dbo.Proof VALUES(6);

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -916,6 +916,15 @@ BEGIN TRY
        AND full_backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'))
         THROW 51000,'Older full lost its overlapping log endpoint or selected a different database.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(hour,-2,GETDATE()),
+      backup_finish_date=DATEADD(second,10,DATEADD(hour,-2,GETDATE()))
+      WHERE backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D');
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>2 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@BoundaryLog AND log_backups=2 AND log_time_seconds=90
+       AND full_backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'))
+        THROW 51000,'Pre-window anchor was omitted when a newer full existed.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
       WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
@@ -992,6 +1001,25 @@ BEGIN TRY
     IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
        OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Pre-window discard log did not suppress the broken chain.',1;
+    /* Damaged full/diff alternatives are optional; a damaged regular log breaks the chain. */
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
+      WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
+    DROP TABLE FRKLogHistory.dbo.backupmediafamily;
+    SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
+      WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
+    UPDATE FRKLogHistory.dbo.backupset SET is_damaged=1 WHERE type='I' OR backup_set_id=@CurrentFull;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF EXISTS(SELECT 1 FROM #FRKRecoveryProof WHERE full_backup_set_id=@CurrentFull)
+       OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+        THROW 51000,'Damaged full/diff alternatives displaced the usable chain.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    UPDATE FRKLogHistory.dbo.backupset SET is_damaged=1 WHERE backup_set_id=@Regular;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Damaged regular log received a restore estimate.',1;
     /* Exercise the unmodified push path with four-part local-server names.
        Precreate the destination so this tests insertion/mapping without remote DDL. */
     DROP TABLE FRKLogHistory.dbo.backupset;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -577,7 +577,7 @@ BEGIN TRY
           DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
     EXEC FRKLogHistory.sys.sp_executesql @Definition;
     DECLARE @Case int=1, @ExpectedCount int, @ExpectedSeconds int, @ExpectedRTO decimal(18,2), @ExpectedMB decimal(18,2);
-    WHILE @Case<=7
+    WHILE @Case<=8
     BEGIN
         IF @Case=2 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Endpoint;
         IF @Case=3 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Regular;
@@ -600,25 +600,27 @@ BEGIN TRY
             UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'NUL'
               WHERE media_set_id=(SELECT media_set_id FROM FRKLogHistory.dbo.backupset WHERE backup_set_id=@Copy);
         END;
+        IF @Case=8 UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'NUL'
+          WHERE media_set_id=(SELECT media_set_id FROM FRKLogHistory.dbo.backupset WHERE backup_set_id=@Regular);
         SET @ExpectedCount=CASE WHEN @Case=1 THEN 2 ELSE 1 END;
-        SET @ExpectedSeconds=CASE @Case WHEN 1 THEN 90 WHEN 2 THEN 40 WHEN 5 THEN 40 ELSE 30 END;
-        SET @ExpectedRTO=CASE @Case WHEN 1 THEN 2.00 WHEN 2 THEN 1.20 WHEN 3 THEN 1.00 WHEN 5 THEN 1.20 ELSE 0.70 END;
+        SET @ExpectedSeconds=CASE @Case WHEN 1 THEN 90 WHEN 2 THEN 40 WHEN 5 THEN 40 WHEN 7 THEN 40 ELSE 30 END;
+        SET @ExpectedRTO=CASE @Case WHEN 1 THEN 2.00 WHEN 2 THEN 1.20 WHEN 3 THEN 1.00 WHEN 5 THEN 1.20 WHEN 7 THEN 1.20 ELSE 0.70 END;
         SELECT @ExpectedMB=CONVERT(decimal(18,2),SUM(backup_size)/1048576.0)
           FROM FRKLogHistory.dbo.backupset WHERE backup_set_id IN
-            (CASE WHEN @Case<=2 OR @Case=5 THEN @Regular ELSE @Copy END,CASE WHEN @Case=1 THEN @Endpoint ELSE NULL END);
+            (CASE WHEN @Case<=2 OR @Case IN(5,7) THEN @Regular ELSE @Copy END,CASE WHEN @Case=1 THEN @Endpoint ELSE NULL END);
         EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
-        IF @Case<=5 AND ((SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
-            (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=CASE WHEN @Case=1 THEN @Endpoint WHEN @Case IN(2,5) THEN @Regular ELSE @Copy END AND full_backup_set_id<>log_backup_set_id AND log_backups=@ExpectedCount
+        IF (@Case<=5 OR @Case=7) AND ((SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+            (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=CASE WHEN @Case=1 THEN @Endpoint WHEN @Case IN(2,5,7) THEN @Regular ELSE @Copy END AND full_backup_set_id<>log_backup_set_id AND log_backups=@ExpectedCount
              AND log_time_seconds=@ExpectedSeconds AND log_file_size_mb=@ExpectedMB))
             THROW 51000, 'Incorrect log count, size, or duration for the actual backup chain.', 1;
         SELECT @Case AS TestCase, @ExpectedRTO AS ExpectedRTO, * FROM #FRKBackupProof;
-        IF @Case<=5 AND ((SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR NOT EXISTS
+        IF (@Case<=5 OR @Case=7) AND ((SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR NOT EXISTS
             (SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=@ExpectedRTO))
             THROW 51000, 'Incorrect user-visible RTO for the actual backup chain.', 1;
-        IF @Case>=6 AND (EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR
+        IF @Case IN(6,8) AND (EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR
             (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL))
             THROW 51000,'Ambiguous or discarded backup history reported an RTO estimate.',1;
-        IF @Case>=6 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof) THROW 51000,'Unavailable RTO did not explain the limitation.',1;
+        IF @Case IN(6,8) AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof) THROW 51000,'Unavailable RTO did not explain the limitation.',1;
         DELETE #FRKWarningProof;
         DELETE #FRKRecoveryProof;
         DELETE #FRKBackupProof;
@@ -642,6 +644,29 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Endpoint AND log_backups=2 AND log_time_seconds=90
        AND full_backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'))
         THROW 51000,'Older full lost its overlapping log endpoint or selected a different database.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    INSERT FRKLogSource.dbo.Proof VALUES(7);
+    EXEC FRKLogSource.sys.sp_executesql N'CHECKPOINT;';
+    SET @File=@Root+N'current.trn';
+    BACKUP LOG FRKLogSource TO DISK=@File WITH INIT;
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
+      WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
+    DECLARE @CurrentFull int=(SELECT MAX(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'),
+            @CurrentLog int=(SELECT MAX(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='L');
+    UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(day,-10,GETDATE()),
+       backup_finish_date=DATEADD(second,10,DATEADD(day,-10,GETDATE())),first_recovery_fork_guid=@ForkB,last_recovery_fork_guid=@ForkB
+       WHERE backup_set_id<@CurrentFull;
+    UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(hour,-2,GETDATE()),
+       backup_finish_date=DATEADD(second,10,DATEADD(hour,-2,GETDATE())),first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA
+       WHERE backup_set_id=@CurrentFull;
+    UPDATE FRKLogHistory.dbo.backupset SET first_recovery_fork_guid=@ForkA,last_recovery_fork_guid=@ForkA WHERE backup_set_id=@CurrentLog;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    SELECT @CurrentFull AS CurrentFull,@CurrentLog AS CurrentLog; SELECT * FROM #FRKRecoveryProof; SELECT * FROM #FRKWarningProof;
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE full_backup_set_id=@CurrentFull AND log_backup_set_id=@CurrentLog AND log_backups=1)
+      OR EXISTS(SELECT 1 FROM #FRKWarningProof)
+        THROW 51000,'An ancient fork suppressed or contaminated the current recovery chain.',1;
     DROP DATABASE FRKLogHistory;
     DROP DATABASE FRKLogSource;
     EXEC master.dbo.xp_delete_file 0,@Root,N'bak',@DeleteBefore;

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -775,6 +775,7 @@ BEGIN TRY
     CREATE TABLE #FRKRecoveryProof(full_backup_set_id int,log_backup_set_id int, log_backups int, log_file_size_mb decimal(18,2), log_time_seconds int);
     CREATE TABLE #FRKBackupProof(RTOWorstCaseMinutes decimal(18,2));
     CREATE TABLE #FRKDiffProof(diff_backup_set_id int,diff_time_seconds int);
+    CREATE TABLE #FRKRPOProof(Minutes decimal(18,1),Endpoint int,PriorBackup int);
     CREATE TABLE #FRKWarningProof(Finding nvarchar(200));
     /* Copy the installed procedure into the isolated fixture database. Only add result
        capture before teardown; all production queries and calculations run unchanged. */
@@ -785,6 +786,7 @@ BEGIN TRY
     SET @Definition=REPLACE(@Definition,N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',
         N'INSERT #FRKRecoveryProof SELECT full_backup_set_id,log_backup_set_id,log_backups,log_file_size_mb,log_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NOT NULL;
           INSERT #FRKBackupProof SELECT RTOWorstCaseMinutes FROM #Backups;
+          INSERT #FRKRPOProof SELECT RPOWorstCaseMinutes,RPOWorstCaseBackupSetID,RPOWorstCaseBackupSetIDPrior FROM #Backups;
           INSERT #FRKDiffProof SELECT diff_backup_set_id,diff_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NULL AND diff_backup_set_id IS NOT NULL;
           INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE CheckId IN(14,15,16);
           DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
@@ -838,12 +840,12 @@ BEGIN TRY
         IF @Case IN(6,8) AND (EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR
             (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL))
             THROW 51000,'Ambiguous or discarded backup history reported an RTO estimate.',1;
-        IF @Case=7 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Backup to NUL device') THROW 51000,'Linux discard-device warning absent.',1;
+        IF @Case=7 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Backup to discard device') THROW 51000,'Linux discard-device warning absent.',1;
         IF @Case=5 AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Recovery fork metadata missing') THROW 51000,'Missing fork metadata warning absent.',1;
         IF @Case IN(6,8) AND NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable') THROW 51000,'Unavailable RTO did not explain the limitation.',1;
         DELETE #FRKWarningProof;
         DELETE #FRKRecoveryProof;
-        DELETE #FRKBackupProof;
+        DELETE #FRKBackupProof; DELETE #FRKRPOProof;
         SET @Case+=1;
     END;
     /* SIMPLE-style full/differential history has a differential endpoint without logs. */
@@ -855,7 +857,7 @@ BEGIN TRY
     IF (SELECT COUNT(*) FROM #FRKDiffProof)<>1 OR NOT EXISTS(SELECT 1 FROM #FRKDiffProof WHERE diff_time_seconds=20)
        OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=0.50)
         THROW 51000,'Differential-only recovery point omitted its differential.',1;
-    DELETE #FRKDiffProof; DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKDiffProof; DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     /* Equal intervals prefer the regular backup's duration and endpoint ID. */
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE backup_set_id<>@Endpoint;
@@ -868,14 +870,14 @@ BEGIN TRY
     IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
         THROW 51000,'Equal intervals did not prefer the regular backup.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     ALTER TABLE FRKLogHistory.dbo.backupset ALTER COLUMN is_copy_only bit NULL;
     UPDATE FRKLogHistory.dbo.backupset SET is_copy_only=NULL WHERE backup_set_id=@Copy;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
         THROW 51000,'Unknown copy-only metadata sorted before a known regular backup.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     /* Old NULL metadata and newly pushed known metadata still share one estimate. */
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE backup_set_id<>@Endpoint;
@@ -885,14 +887,14 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Recovery fork metadata missing')
         THROW 51000,'Mixed unknown and known fork metadata double-counted covered logs.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DELETE m FROM FRKLogHistory.dbo.backupmediafamily m JOIN FRKLogHistory.dbo.backupset b
       ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@Copy;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=1.20)
        OR EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Optional copy-only media gap suppressed the healthy regular chain.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     /* A differential with an unknown base is optional; full plus logs remains valid. */
     UPDATE FRKLogHistory.dbo.backupset SET differential_base_guid=NULL WHERE type='I';
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
@@ -900,7 +902,7 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
       OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=CAST(50.0/60 AS decimal(18,1)))
         THROW 51000,'Unknown differential base did not use the complete full-plus-log path.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     /* Unknown copy-only metadata on discard media must not produce a numeric RTO. */
     ALTER TABLE FRKLogHistory.dbo.backupset ALTER COLUMN is_copy_only bit NULL;
     UPDATE FRKLogHistory.dbo.backupset SET is_copy_only=NULL WHERE backup_set_id=@Regular;
@@ -910,7 +912,7 @@ BEGIN TRY
     IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Unknown copy-only metadata allowed a discard log into RTO.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     /* A later full must not erase the overlapping endpoint of the earlier full. */
     INSERT FRKLogSource.dbo.Proof VALUES(6);
     SET @File=@Root+N'full2.bak';
@@ -934,7 +936,7 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@BoundaryLog AND log_backups=2 AND log_time_seconds=90
        AND full_backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'))
         THROW 51000,'Older full lost its overlapping log endpoint or selected a different database.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(hour,-2,GETDATE()),
       backup_finish_date=DATEADD(second,10,DATEADD(hour,-2,GETDATE()))
       WHERE backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D');
@@ -943,7 +945,7 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@BoundaryLog AND log_backups=2 AND log_time_seconds=90
        AND full_backup_set_id=(SELECT MIN(backup_set_id) FROM FRKLogHistory.dbo.backupset WHERE type='D'))
         THROW 51000,'Pre-window anchor was omitted when a newer full existed.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
       WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
@@ -965,8 +967,19 @@ BEGIN TRY
       OR EXISTS(SELECT 1 FROM #FRKWarningProof)
       OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'An ancient fork suppressed or contaminated the current recovery chain.',1;
+    IF NOT EXISTS(SELECT 1 FROM #FRKRPOProof WHERE Minutes IS NOT NULL AND Endpoint=@CurrentLog AND PriorBackup=@CurrentFull)
+        THROW 51000,'Newly visible old-full history omitted its RPO fields.',1;
+    /* Merged sources cannot share an unqualified media_set_id mapping safely. */
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
+    UPDATE FRKLogHistory.dbo.backupset SET server_name=N'OtherSource' WHERE backup_set_id=@CurrentLog;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Merged source media IDs were treated as unambiguous.',1;
+    UPDATE b SET server_name=n.server_name FROM FRKLogHistory.dbo.backupset b
+      JOIN msdb.dbo.backupset n ON b.backup_set_id=n.backup_set_id;
     /* A media table with missing candidate rows is also incomplete metadata. */
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DELETE m FROM FRKLogHistory.dbo.backupmediafamily m JOIN FRKLogHistory.dbo.backupset b
       ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@CurrentLog;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
@@ -975,7 +988,7 @@ BEGIN TRY
        OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Missing candidate media rows were treated as usable backups.',1;
     /* Missing media metadata must produce an explained NULL estimate, not an error. */
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DROP TABLE FRKLogHistory.dbo.backupmediafamily;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
     IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR (SELECT COUNT(*) FROM #FRKBackupProof)<>1
@@ -986,7 +999,7 @@ BEGIN TRY
       WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
 
     /* No usable preceding full: do not silently lose the database or invent an RTO. */
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id<@CurrentFull;
     UPDATE m SET physical_device_name=N'NUL' FROM FRKLogHistory.dbo.backupmediafamily m
       JOIN FRKLogHistory.dbo.backupset b ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@CurrentFull;
@@ -997,7 +1010,7 @@ BEGIN TRY
         THROW 51000,'Unusable preceding full did not produce an explained NULL RTO.',1;
 
     /* A discarded full/diff alternative must not suppress the older usable chain. */
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
       WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
@@ -1010,7 +1023,7 @@ BEGIN TRY
         THROW 51000,'Discarded full/diff alternatives suppressed a usable chain.',1;
 
     /* A regular discard log before the window still breaks the selected chain. */
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@CurrentFull;
     UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(hour,-2,GETDATE()),
       backup_finish_date=DATEADD(second,10,DATEADD(hour,-2,GETDATE())) WHERE backup_set_id<>@CurrentLog;
@@ -1021,7 +1034,7 @@ BEGIN TRY
        OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Pre-window discard log did not suppress the broken chain.',1;
     /* Damaged full/diff alternatives are optional; a damaged regular log breaks the chain. */
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset
       WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'));
@@ -1033,12 +1046,19 @@ BEGIN TRY
     IF EXISTS(SELECT 1 FROM #FRKRecoveryProof WHERE full_backup_set_id=@CurrentFull)
        OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'Damaged full/diff alternatives displaced the usable chain.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     UPDATE FRKLogHistory.dbo.backupset SET is_damaged=1 WHERE backup_set_id=@Regular;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
        OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Damaged regular log received a restore estimate.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
+    DELETE FRKLogHistory.dbo.backupset WHERE type<>'D';
+    UPDATE FRKLogHistory.dbo.backupset SET is_damaged=1;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF (SELECT COUNT(*) FROM #FRKBackupProof)<>1 OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Entirely damaged full history disappeared instead of explaining NULL RTO.',1;
     /* A real striped full requires metadata for both media families. */
     DECLARE @SecondFile nvarchar(512)=@Root+N'striped2.bak',
       @MirrorFirst nvarchar(512)=@Root+N'mirror1.bak',@MirrorSecond nvarchar(512)=@Root+N'mirror2.bak';
@@ -1053,7 +1073,7 @@ BEGIN TRY
       WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
     IF (SELECT COUNT(*) FROM FRKLogHistory.dbo.backupmediafamily)<>4
         THROW 51000,'Mirrored fixture did not produce two copies of two families.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'Complete striped metadata did not permit an estimate.',1;
@@ -1061,7 +1081,7 @@ BEGIN TRY
     DELETE FRKLogHistory.dbo.backupmediafamily WHERE (mirror=0 AND family_sequence_number=2)
       OR (mirror=1 AND family_sequence_number=1);
     RESTORE VERIFYONLY FROM DISK=@File,DISK=@MirrorSecond;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'Interchangeable families from different mirrors were rejected.',1;
@@ -1069,11 +1089,11 @@ BEGIN TRY
     SELECT * INTO FRKLogHistory.dbo.backupmediafamily FROM msdb.dbo.backupmediafamily
       WHERE media_set_id IN(SELECT media_set_id FROM FRKLogHistory.dbo.backupset);
     UPDATE FRKLogHistory.dbo.backupmediafamily SET physical_device_name=N'NUL' WHERE mirror=0;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
         THROW 51000,'A discard mirror suppressed another usable mirror.',1;
-    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
     DELETE FRKLogHistory.dbo.backupmediafamily WHERE family_sequence_number=2;
     EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
     IF EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -774,6 +774,7 @@ BEGIN TRY
     SELECT * INTO FRKLogHistory.dbo.AllBackupSets FROM FRKLogHistory.dbo.backupset;
     CREATE TABLE #FRKRecoveryProof(full_backup_set_id int,log_backup_set_id int, log_backups int, log_file_size_mb decimal(18,2), log_time_seconds int);
     CREATE TABLE #FRKBackupProof(RTOWorstCaseMinutes decimal(18,2));
+    CREATE TABLE #FRKDiffProof(diff_backup_set_id int,diff_time_seconds int);
     CREATE TABLE #FRKWarningProof(Finding nvarchar(200));
     /* Copy the installed procedure into the isolated fixture database. Only add result
        capture before teardown; all production queries and calculations run unchanged. */
@@ -784,6 +785,7 @@ BEGIN TRY
     SET @Definition=REPLACE(@Definition,N'DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints',
         N'INSERT #FRKRecoveryProof SELECT full_backup_set_id,log_backup_set_id,log_backups,log_file_size_mb,log_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NOT NULL;
           INSERT #FRKBackupProof SELECT RTOWorstCaseMinutes FROM #Backups;
+          INSERT #FRKDiffProof SELECT diff_backup_set_id,diff_time_seconds FROM #RTORecoveryPoints WHERE log_last_lsn IS NULL AND diff_backup_set_id IS NOT NULL;
           INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE CheckId IN(14,15,16);
           DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
     EXEC FRKLogHistory.sys.sp_executesql @Definition;
@@ -844,6 +846,16 @@ BEGIN TRY
         DELETE #FRKBackupProof;
         SET @Case+=1;
     END;
+    /* SIMPLE-style full/differential history has a differential endpoint without logs. */
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE type IN('D','I');
+    UPDATE FRKLogHistory.dbo.backupset SET backup_start_date=DATEADD(hour,-2,GETDATE()),
+      backup_finish_date=DATEADD(second,10,DATEADD(hour,-2,GETDATE())) WHERE type='D';
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory',@HoursBack=1;
+    IF (SELECT COUNT(*) FROM #FRKDiffProof)<>1 OR NOT EXISTS(SELECT 1 FROM #FRKDiffProof WHERE diff_time_seconds=20)
+       OR NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=0.50)
+        THROW 51000,'Differential-only recovery point omitted its differential.',1;
+    DELETE #FRKDiffProof; DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     /* Equal intervals prefer the regular backup's duration and endpoint ID. */
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE backup_set_id<>@Endpoint;
@@ -873,6 +885,13 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
       OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'Recovery fork metadata missing')
         THROW 51000,'Mixed unknown and known fork metadata double-counted covered logs.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    DELETE m FROM FRKLogHistory.dbo.backupmediafamily m JOIN FRKLogHistory.dbo.backupset b
+      ON b.media_set_id=m.media_set_id WHERE b.backup_set_id=@Copy;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes=1.20)
+       OR EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
+        THROW 51000,'Optional copy-only media gap suppressed the healthy regular chain.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     /* A differential with an unknown base is optional; full plus logs remains valid. */
     UPDATE FRKLogHistory.dbo.backupset SET differential_base_guid=NULL WHERE type='I';

--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -857,6 +857,13 @@ BEGIN TRY
       (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
         THROW 51000,'Equal intervals did not prefer the regular backup.',1;
     DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
+    ALTER TABLE FRKLogHistory.dbo.backupset ALTER COLUMN is_copy_only bit NULL;
+    UPDATE FRKLogHistory.dbo.backupset SET is_copy_only=NULL WHERE backup_set_id=@Copy;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+    IF (SELECT COUNT(*) FROM #FRKRecoveryProof)<>1 OR NOT EXISTS
+      (SELECT 1 FROM #FRKRecoveryProof WHERE log_backup_set_id=@Regular AND log_backups=1 AND log_time_seconds=40)
+        THROW 51000,'Unknown copy-only metadata sorted before a known regular backup.',1;
+    DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKWarningProof;
     /* Old NULL metadata and newly pushed known metadata still share one estimate. */
     DROP TABLE FRKLogHistory.dbo.backupset;
     SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets WHERE backup_set_id<>@Endpoint;
@@ -985,6 +992,23 @@ BEGIN TRY
     IF EXISTS(SELECT 1 FROM #FRKRecoveryProof) OR EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
        OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable')
         THROW 51000,'Pre-window discard log did not suppress the broken chain.',1;
+    /* Exercise the unmodified push path with four-part local-server names.
+       Precreate the destination so this tests insertion/mapping without remote DDL. */
+    DROP TABLE FRKLogHistory.dbo.backupset;
+    SELECT TOP(0) * INTO FRKLogHistory.dbo.backupset FROM msdb.dbo.backupset;
+    DECLARE @LocalServer sysname=@@SERVERNAME;
+    EXEC FRKLogHistory.dbo.sp_BlitzBackups @PushBackupHistoryToListener=1,
+      @WriteBackupsToListenerName=@LocalServer,@WriteBackupsToDatabaseName=N'FRKLogHistory',@WriteBackupsLastHours=1;
+    IF NOT EXISTS(SELECT 1 FROM FRKLogHistory.dbo.backupset WHERE database_name=N'FRKLogSource')
+        THROW 51000,'History push did not insert fixture backups.',1;
+    IF EXISTS(
+      SELECT backup_set_uuid,first_recovery_fork_guid,last_recovery_fork_guid,fork_point_lsn,
+        differential_base_lsn,differential_base_guid,is_copy_only FROM msdb.dbo.backupset
+      WHERE database_name=N'FRKLogSource' AND database_guid=(SELECT database_guid FROM sys.database_recovery_status WHERE database_id=DB_ID(N'FRKLogSource'))
+      EXCEPT
+      SELECT backup_set_uuid,first_recovery_fork_guid,last_recovery_fork_guid,fork_point_lsn,
+        differential_base_lsn,differential_base_guid,is_copy_only FROM FRKLogHistory.dbo.backupset)
+        THROW 51000,'History push lost or mis-mapped recovery metadata.',1;
     DROP DATABASE FRKLogHistory;
     DROP DATABASE FRKLogSource;
     EXEC master.dbo.xp_delete_file 0,@Root,N'bak',@DeleteBefore;

--- a/Documentation/sp_BlitzBackups_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzBackups_Checks_by_Priority.md
@@ -6,8 +6,8 @@ Before adding a new check, make sure to add a Github issue for it first, and hav
 
 If you want to change anything about a check - the priority, finding, or ID - open a Github issue first. The relevant scripts have to be updated too.
 
-CURRENT HIGH CHECKID: 14.
-If you want to add a new one, start at 15.
+CURRENT HIGH CHECKID: 16.
+If you want to add a new one, start at 17.
 
 | Priority | Finding                                | CheckID |
 | -------: | :------------------------------------- | ------: |
@@ -16,9 +16,11 @@ If you want to add a new one, start at 15.
 |       10 | Damaged backups                        |       8 |
 |       20 | No CHECKSUMS                           |       7 |
 |       20 | Backup to NUL device                   |      14 |
+|       50 | RTO estimate unavailable              |      15 |
 |       50 | Single user mode backups               |       6 |
 |       50 | Big Diffs/Logs                         |      13 |
 |       80 | Uncompressed backups                   |      12 |
+|      100 | Recovery fork metadata missing        |      16 |
 |      100 | Non-Agent backups taken                |       1 |
 |      100 | Compatibility level changing           |       2 |
 |      100 | Password backups                       |       3 |
@@ -26,3 +28,7 @@ If you want to add a new one, start at 15.
 |      100 | Bulk logged backups                    |      10 |
 |      150 | Read only state backups                |       5 |
 |      200 | Snapshot backups                       |       4 |
+
+Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks or a regular backup written to a discard device. Candidate history includes the reporting window and its preceding usable full backup; discarded copy-only backups are ignored.
+
+Check 16 warns that legacy history lacks fork identifiers. LSN-based estimates remain available, but fork compatibility cannot be verified. New centralized-history pushes preserve the required metadata. See issue #4115.

--- a/Documentation/sp_BlitzBackups_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzBackups_Checks_by_Priority.md
@@ -29,6 +29,6 @@ If you want to add a new one, start at 17.
 |      150 | Read only state backups                |       5 |
 |      200 | Snapshot backups                       |       4 |
 
-Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks or a regular backup written to a discard device. Candidate history includes the reporting window and its preceding usable full backup; discarded copy-only backups are ignored.
+Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks a regular log written to a discard device, missing media metadata, or no usable full for its log endpoint. Candidate history includes the reporting window and its preceding usable full backup; discarded copy-only, full, and differential alternatives are ignored. Centralized history without backupmediafamily remains readable, but cannot receive a verified RTO estimate until media metadata is available.
 
 Check 16 warns that legacy history lacks fork identifiers. LSN-based estimates remain available, but fork compatibility cannot be verified. New centralized-history pushes preserve the required metadata. See issue #4115.

--- a/Documentation/sp_BlitzBackups_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzBackups_Checks_by_Priority.md
@@ -31,4 +31,6 @@ If you want to add a new one, start at 17.
 
 Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks a regular log written to a discard device, missing media metadata, or no usable full for its log endpoint. Candidate history includes the reporting window and its preceding usable full backup; discarded copy-only, full, and differential alternatives are ignored. Centralized history without backupmediafamily remains readable, but cannot receive a verified RTO estimate until media metadata is available.
 
+RTO is a worst-case estimate for the requested interval, not only the latest restore point. A later full within that interval does not make an earlier discard-log gap restorable, so the interval remains unavailable rather than reporting only its later healthy portion.
+
 Check 16 warns that legacy history lacks fork identifiers. LSN-based estimates remain available, but fork compatibility cannot be verified. New centralized-history pushes preserve the required metadata. See issue #4115.

--- a/Documentation/sp_BlitzBackups_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzBackups_Checks_by_Priority.md
@@ -29,7 +29,7 @@ If you want to add a new one, start at 17.
 |      150 | Read only state backups                |       5 |
 |      200 | Snapshot backups                       |       4 |
 
-Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks a regular log written to a discard device, missing media metadata, or no usable full for its log endpoint. Candidate history includes the reporting window and its preceding usable full backup; discarded copy-only, full, and differential alternatives are ignored. Centralized history without backupmediafamily remains readable, but cannot receive a verified RTO estimate until media metadata is available.
+Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks a regular log written to a discard device or marked damaged, missing media or integrity metadata, or no usable full for its log endpoint. Candidate history includes the reporting window and its preceding usable full backup; discarded or damaged copy-only, full, and differential alternatives are ignored. Centralized history without backupmediafamily remains readable, but cannot receive a verified RTO estimate until media metadata is available.
 
 RTO is a worst-case estimate for the requested interval, not only the latest restore point. A later full within that interval does not make an earlier discard-log gap restorable, so the interval remains unavailable rather than reporting only its later healthy portion.
 

--- a/Documentation/sp_BlitzBackups_Checks_by_Priority.md
+++ b/Documentation/sp_BlitzBackups_Checks_by_Priority.md
@@ -12,10 +12,10 @@ If you want to add a new one, start at 17.
 | Priority | Finding                                | CheckID |
 | -------: | :------------------------------------- | ------: |
 |       10 | Recovery model switched                |      11 |
-|       10 | Backup to NUL device without COPY_ONLY |      14 |
+|       10 | Backup to discard device without COPY_ONLY |      14 |
 |       10 | Damaged backups                        |       8 |
 |       20 | No CHECKSUMS                           |       7 |
-|       20 | Backup to NUL device                   |      14 |
+|       20 | Backup to discard device                   |      14 |
 |       50 | RTO estimate unavailable              |      15 |
 |       50 | Single user mode backups               |       6 |
 |       50 | Big Diffs/Logs                         |      13 |
@@ -29,8 +29,10 @@ If you want to add a new one, start at 17.
 |      150 | Read only state backups                |       5 |
 |      200 | Snapshot backups                       |       4 |
 
-Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks a regular log written to a discard device or marked damaged, missing media or integrity metadata, or no usable full for its log endpoint. Candidate history includes the reporting window and its preceding usable full backup; discarded or damaged copy-only, full, and differential alternatives are ignored. Centralized history without backupmediafamily remains readable, but cannot receive a verified RTO estimate until media metadata is available.
+Check 15 leaves RTO unknown when the candidate history contains multiple known recovery forks, a regular log written to a discard device or marked damaged, missing media or integrity metadata, or no usable full for its log endpoint. Candidate history includes the reporting window and its preceding usable full backup; discarded or damaged copy-only, full, and differential alternatives are ignored. Centralized history without backupmediafamily remains readable, but cannot receive a verified RTO estimate until media metadata is available.
 
 RTO is a worst-case estimate for the requested interval, not only the latest restore point. A later full within that interval does not make an earlier discard-log gap restorable, so the interval remains unavailable rather than reporting only its later healthy portion.
 
 Check 16 warns that legacy history lacks fork identifiers. LSN-based estimates remain available, but fork compatibility cannot be verified. New centralized-history pushes preserve the required metadata. See issue #4115.
+
+For merged-source centralized history, instance-local media IDs cannot identify which source owns a media-family row. RTO remains unavailable for these ambiguous mappings.

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -752,6 +752,12 @@ RAISERROR('Add any full backups in the StartDate range that weren''t part of the
 							 LEFT OUTER JOIN #RTORecoveryPoints rp ON bFull.backup_set_uuid = rp.full_backup_set_uuid
 							 WHERE bFull.type = ''D''
 							     AND bFull.backup_finish_date IS NOT NULL
+                                 AND (bFull.backup_finish_date>=@StartTime OR EXISTS (
+                                     SELECT 1 FROM #RTOBackupSets endpoint
+                                     WHERE endpoint.database_guid=bFull.database_guid AND endpoint.database_name=bFull.database_name
+                                       AND endpoint.backup_finish_date>=@StartTime
+                                       AND ((endpoint.type=''I'' AND endpoint.differential_base_guid=bFull.backup_set_uuid)
+                                         OR (endpoint.type=''L'' AND endpoint.last_lsn>bFull.last_lsn))))
 							     AND rp.full_backup_set_uuid IS NULL
                                  AND NOT EXISTS (SELECT 1 FROM #RTOExcluded x WHERE x.database_name=bFull.database_name AND x.database_guid=bFull.database_guid);
 							';
@@ -1783,6 +1789,22 @@ END
 		END
 
 
+        /* Preserve distributed-DML-only listeners when remote RPC is disabled. */
+        DECLARE @PushMediaFacts bit=1;
+        IF @WriteBackupsToListenerName<>@@SERVERNAME
+           AND EXISTS(SELECT 1 FROM sys.servers WHERE name=@WriteBackupsToListenerName AND is_rpc_out_enabled=0)
+        BEGIN
+            SET @StringToExecute=N'SELECT @Available=CASE WHEN COUNT(*)=2 THEN 1 ELSE 0 END
+              FROM '+QUOTENAME(@WriteBackupsToListenerName)+N'.'+QUOTENAME(@WriteBackupsToDatabaseName)+N'.sys.columns c
+              JOIN '+QUOTENAME(@WriteBackupsToListenerName)+N'.'+QUOTENAME(@WriteBackupsToDatabaseName)+N'.sys.tables t ON c.object_id=t.object_id
+              JOIN '+QUOTENAME(@WriteBackupsToListenerName)+N'.'+QUOTENAME(@WriteBackupsToDatabaseName)+N'.sys.schemas s ON t.schema_id=s.schema_id
+              WHERE s.name=N''dbo'' AND t.name=N''backupset'' AND c.name IN(N''frk_media_is_usable'',N''frk_media_has_discard'');';
+            EXEC sys.sp_executesql @StringToExecute,N'@Available bit OUTPUT',@Available=@PushMediaFacts OUTPUT;
+            IF @PushMediaFacts=0
+                RAISERROR('History push continues without media facts. Add nullable bit columns frk_media_is_usable and frk_media_has_discard to the destination dbo.backupset to enable centralized RTO metadata.',0,1) WITH NOWAIT;
+        END
+        ELSE
+        BEGIN
         /* Add source-validated media facts to both new and existing destinations. */
         SET @StringToExecute=N'USE '+QUOTENAME(@WriteBackupsToDatabaseName)+N';
           IF COL_LENGTH(N''dbo.backupset'',N''frk_media_is_usable'') IS NULL
@@ -1795,6 +1817,8 @@ END
         BEGIN
             SET @InnerStringToExecute=N'EXEC(N'''+REPLACE(@StringToExecute,N'''',N'''''')+N''') AT '+QUOTENAME(@WriteBackupsToListenerName)+N';';
             EXEC sys.sp_executesql @InnerStringToExecute;
+        END;
+
         END;
 
 		RAISERROR('Beginning inserts', 0, 1) WITH NOWAIT;
@@ -1913,7 +1937,9 @@ END
 
 	EXEC sp_executesql @StringToExecute, N'@i_WriteBackupsLastHours INT', @i_WriteBackupsLastHours = @WriteBackupsLastHours;
 
-    /* Refresh newly inserted and legacy rows in the requested push window.
+    IF @PushMediaFacts=1
+    BEGIN
+    /* Refresh the push window and retained full anchors with missing facts.
        Evaluate media on the source, never by joining unqualified central media IDs. */
     SET @StringToExecute=N'UPDATE h SET
       frk_media_is_usable=CASE WHEN b.first_family_number>0 AND b.last_family_number>=b.first_family_number
@@ -1930,9 +1956,10 @@ END
       differential_base_guid=b.differential_base_guid,is_copy_only=b.is_copy_only
     FROM '+QUOTENAME(@WriteBackupsToListenerName)+N'.'+QUOTENAME(@WriteBackupsToDatabaseName)+N'.dbo.backupset h
     JOIN msdb.dbo.backupset b ON b.backup_set_uuid=h.backup_set_uuid
-    WHERE b.backup_start_date>=DATEADD(hour,@Hours,SYSDATETIME())
+    WHERE (b.backup_start_date>=DATEADD(hour,@Hours,SYSDATETIME()) OR b.type=''D'')
       AND (h.frk_media_is_usable IS NULL OR h.frk_media_has_discard IS NULL);';
     EXEC sys.sp_executesql @StringToExecute,N'@Hours int',@Hours=@WriteBackupsLastHours;
+    END;
 
 
 END;

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -573,18 +573,19 @@ CREATE TABLE #RTOBackupSets(
  backup_set_uuid uniqueidentifier,type char(1),first_lsn numeric(25,0),last_lsn numeric(25,0),
  backup_start_date datetime,backup_finish_date datetime,backup_size numeric(20,0),
  first_recovery_fork_guid uniqueidentifier,last_recovery_fork_guid uniqueidentifier,
- differential_base_guid uniqueidentifier,media_set_id int,is_copy_only bit);
+ differential_base_guid uniqueidentifier,media_set_id int,is_copy_only bit,is_damaged bit);
 SET @StringToExecute=N'
 INSERT #RTOBackupSets
 SELECT b.database_name,b.database_guid,b.backup_set_id,b.backup_set_uuid,b.type,b.first_lsn,b.last_lsn,
  b.backup_start_date,b.backup_finish_date,b.backup_size,b.first_recovery_fork_guid,b.last_recovery_fork_guid,
- b.differential_base_guid,b.media_set_id,b.is_copy_only
+ b.differential_base_guid,b.media_set_id,b.is_copy_only,b.is_damaged
 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset b
 WHERE b.type IN (''D'',''I'',''L'')
+ AND (b.is_damaged=0 OR (b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)))
  AND (b.backup_finish_date>=@StartTime OR b.backup_finish_date>=(
     SELECT MAX(anchor.backup_finish_date) FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset anchor
     WHERE anchor.database_name=b.database_name AND anchor.database_guid=b.database_guid
-      AND anchor.type=''D'' AND anchor.backup_finish_date<=@StartTime
+      AND anchor.type=''D'' AND anchor.is_damaged=0 AND anchor.backup_finish_date<=@StartTime
       AND NOT EXISTS(SELECT 1 FROM #RTODiscardMedia am
         WHERE am.media_set_id=anchor.media_set_id AND (UPPER(am.physical_device_name)=N''NUL'' OR am.physical_device_name=N''/dev/null''))
  ))
@@ -614,7 +615,11 @@ FROM #RTOBackupSets b
 JOIN #RTODiscardMedia m ON b.media_set_id=m.media_set_id
 WHERE (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')
   AND b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)
-  AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);';
+  AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
+INSERT #RTOExcluded
+SELECT DISTINCT b.database_name,b.database_guid,N''Damaged log backup or unknown integrity metadata''
+FROM #RTOBackupSets b WHERE b.type=''L'' AND (b.is_damaged=1 OR b.is_damaged IS NULL)
+ AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);';
 EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 SET @StringToExecute=N'
 INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
@@ -721,7 +726,6 @@ RAISERROR('Add any full backups in the StartDate range that weren''t part of the
 							 WHERE bFull.type = ''D''
 							     AND bFull.backup_finish_date IS NOT NULL
 							     AND rp.full_backup_set_uuid IS NULL
-							     AND bFull.backup_finish_date >= @StartTime
                                  AND NOT EXISTS (SELECT 1 FROM #RTOExcluded x WHERE x.database_name=bFull.database_name AND x.database_guid=bFull.database_guid);
 							';
 

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -450,7 +450,7 @@ GOTO PushBackupHistoryToListener
 		+ N' FullMBpsAvg, FullMBpsMin, FullMBpsMax, FullSizeMBAvg, FullSizeMBMin, FullSizeMBMax, FullCompressedSizeMBAvg, FullCompressedSizeMBMin, FullCompressedSizeMBMax, ' + @crlf
 		+ N' DiffMBpsAvg, DiffMBpsMin, DiffMBpsMax, DiffSizeMBAvg, DiffSizeMBMin, DiffSizeMBMax, DiffCompressedSizeMBAvg, DiffCompressedSizeMBMin, DiffCompressedSizeMBMax, ' + @crlf
 		+ N' LogMBpsAvg, LogMBpsMin, LogMBpsMax, LogSizeMBAvg, LogSizeMBMin, LogSizeMBMax, LogCompressedSizeMBAvg, LogCompressedSizeMBMin, LogCompressedSizeMBMax ) ' + @crlf
-		+ N'SELECT bF.database_name, bF.database_guid ' + @crlf
+		+ N'SELECT bK.database_name, bK.database_guid ' + @crlf
 		+ N' , bF.MBpsAvg AS FullMBpsAvg ' + @crlf
 		+ N' , bF.MBpsMin AS FullMBpsMin ' + @crlf
 		+ N' , bF.MBpsMax AS FullMBpsMax ' + @crlf
@@ -478,16 +478,24 @@ GOTO PushBackupHistoryToListener
 		+ N' , bL.CompressedSizeMBAvg AS LogCompressedSizeMBAvg ' + @crlf
 		+ N' , bL.CompressedSizeMBMin AS LogCompressedSizeMBMin ' + @crlf
 		+ N' , bL.CompressedSizeMBMax AS LogCompressedSizeMBMax ' + @crlf
-		+ N' FROM Backups bF ' + @crlf
-		+ N' LEFT OUTER JOIN Backups bD ON bF.database_name = bD.database_name AND bF.database_guid = bD.database_guid AND bD.backup_type = ''I''' + @crlf
-		+ N' LEFT OUTER JOIN Backups bL ON bF.database_name = bL.database_name AND bF.database_guid = bL.database_guid AND bL.backup_type = ''L''' + @crlf
-		+ N' WHERE bF.backup_type = ''D''; ' + @crlf;
+		+ N' FROM (SELECT DISTINCT database_name,database_guid FROM Backups WHERE backup_type IN (''D'',''I'',''L'')) bK LEFT JOIN Backups bF ON bK.database_name=bF.database_name AND bK.database_guid=bF.database_guid AND bF.backup_type=''D'''  + @crlf
+		+ N' LEFT OUTER JOIN Backups bD ON bK.database_name = bD.database_name AND bK.database_guid = bD.database_guid AND bD.backup_type = ''I''' + @crlf
+		+ N' LEFT OUTER JOIN Backups bL ON bK.database_name = bL.database_name AND bK.database_guid = bL.database_guid AND bL.backup_type = ''L''' + @crlf
+		+ N'; ' + @crlf;
 
 	IF @Debug = 1
 		PRINT @StringToExecute;
 
 	EXEC sys.sp_executesql @StringToExecute, N'@StartTime DATETIME2', @StartTime;
 
+
+/* Preserve visible diagnostics even when every in-window backup is unusable.
+   Seed before RPO so these rows receive the same history-gap calculation. */
+SET @StringToExecute=N'INSERT #Backups(database_name,database_guid)
+SELECT DISTINCT b.database_name,b.database_guid FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset b
+WHERE b.type IN (''D'',''I'',''L'') AND b.backup_finish_date>=@StartTime
+AND NOT EXISTS(SELECT 1 FROM #Backups x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);';
+EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 
 	RAISERROR('Updating #Backups with worst RPO case', 0, 1) WITH NOWAIT;
 
@@ -555,7 +563,15 @@ RAISERROR('Gathering RTO information', 0, 1) WITH NOWAIT;
 CREATE TABLE #RTODiscardMedia(media_set_id int,physical_device_name nvarchar(4000));
 CREATE TABLE #RTOKnownMedia(media_set_id int PRIMARY KEY);
 DECLARE @RTOMediaAvailable bit=CASE WHEN OBJECT_ID(QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily') IS NOT NULL THEN 1 ELSE 0 END;
-IF @RTOMediaAvailable=1
+/* Media IDs copied from multiple instances cannot identify a source's media. */
+DECLARE @RTOMergedSources bit=0;
+IF @MSDBName<>N'msdb'
+BEGIN
+    SET @StringToExecute=N'SELECT @Merged=CASE WHEN COUNT(*)>1 THEN 1 ELSE 0 END
+      FROM (SELECT DISTINCT server_name,machine_name FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset) sources;';
+    EXEC sys.sp_executesql @StringToExecute,N'@Merged bit OUTPUT',@Merged=@RTOMergedSources OUTPUT;
+END;
+IF @RTOMediaAvailable=1 AND @RTOMergedSources=0
 BEGIN
     SET @StringToExecute=N'WITH ExpectedFamilies AS (
         SELECT media_set_id,MIN(first_family_number) AS FirstFamily,MAX(last_family_number) AS LastFamily
@@ -643,17 +659,10 @@ WHERE first_recovery_fork_guid IS NULL OR last_recovery_fork_guid IS NULL;';
 EXEC sys.sp_executesql @StringToExecute;
 
     INSERT #RTOExcluded
-    SELECT DISTINCT b.database_name,b.database_guid,N'Backup media metadata missing'
+    SELECT DISTINCT b.database_name,b.database_guid,CASE WHEN @RTOMergedSources=1 THEN N'Merged history has ambiguous source media IDs' ELSE N'Backup media metadata missing' END
     FROM #RTOBackupSets b
     WHERE NOT EXISTS(SELECT 1 FROM #RTOKnownMedia m WHERE m.media_set_id=b.media_set_id)
       AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
-
-/* Keep databases with in-window logs visible even if their full predates the window.
-   Leave in-window throughput aggregates NULL when no full was measured there. */
-INSERT #Backups(database_name,database_guid)
-SELECT DISTINCT b.database_name,b.database_guid FROM #RTOBackupSets b
-WHERE b.backup_finish_date>=@StartTime
-AND NOT EXISTS(SELECT 1 FROM #Backups x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
 
 INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
 SELECT 15,50,database_name,N'RTO estimate unavailable',
@@ -1430,15 +1439,15 @@ IF @ProductVersionMajor >= 12
 		INSERT #Warnings ( CheckId, Priority, DatabaseName, Finding, Warning )
 		EXEC sys.sp_executesql @StringToExecute, N'@StartTime DATETIME2', @StartTime;
 
-	/*Looking for backups directed at the NUL device.*/
+	/*Looking for backups directed at a discard device.*/
 	SET @StringToExecute =N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;' + @crlf;
 
 	SET @StringToExecute += N'SELECT 
 		14 AS CheckId,
 		20 AS [Priority],
 		bs.database_name AS [Database Name],
-		''Backup to NUL device'' AS [Finding],
-		''The database '' + QUOTENAME(bs.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to the NUL device, the latest one being on ''+
+		''Backup to discard device'' AS [Finding],
+		''The database '' + QUOTENAME(bs.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to a discard device, the latest one being on ''+
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
 	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id
@@ -1450,8 +1459,8 @@ IF @ProductVersionMajor >= 12
 		14 AS CheckId,
 		10 AS [Priority],
 		bs.database_name AS [Database Name],
-		''Backup to NUL device without COPY_ONLY'' AS [Finding],
-		''The database '' + QUOTENAME(bs.database_name) + '' is not in SIMPLE recovery model and has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to the NUL device, the latest one being on ''+
+		''Backup to discard device without COPY_ONLY'' AS [Finding],
+		''The database '' + QUOTENAME(bs.database_name) + '' is not in SIMPLE recovery model and has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to a discard device, the latest one being on ''+
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist and they might mess up your current backup chain.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
 	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -551,6 +551,34 @@ GOTO PushBackupHistoryToListener
 
 RAISERROR('Gathering RTO information', 0, 1) WITH NOWAIT;
 
+/* Restrict recovery estimates to the requested window plus its preceding full.
+   Discarded copy-only backups cannot invalidate or replace a usable chain. */
+CREATE TABLE #RTOBackupSets(
+ database_name nvarchar(128),database_guid uniqueidentifier,backup_set_id int,
+ backup_set_uuid uniqueidentifier,type char(1),first_lsn numeric(25,0),last_lsn numeric(25,0),
+ backup_start_date datetime,backup_finish_date datetime,backup_size numeric(20,0),
+ first_recovery_fork_guid uniqueidentifier,last_recovery_fork_guid uniqueidentifier,
+ differential_base_guid uniqueidentifier,media_set_id int,is_copy_only bit);
+SET @StringToExecute=N'
+INSERT #RTOBackupSets
+SELECT b.database_name,b.database_guid,b.backup_set_id,b.backup_set_uuid,b.type,b.first_lsn,b.last_lsn,
+ b.backup_start_date,b.backup_finish_date,b.backup_size,b.first_recovery_fork_guid,b.last_recovery_fork_guid,
+ b.differential_base_guid,b.media_set_id,b.is_copy_only
+FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset b
+WHERE b.type IN (''D'',''I'',''L'')
+ AND b.backup_finish_date>=COALESCE((
+    SELECT MAX(anchor.backup_finish_date) FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset anchor
+    WHERE anchor.database_name=b.database_name AND anchor.database_guid=b.database_guid
+      AND anchor.type=''D'' AND anchor.backup_finish_date<=@StartTime
+      AND NOT EXISTS(SELECT 1 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupmediafamily am
+        WHERE am.media_set_id=anchor.media_set_id AND (UPPER(am.physical_device_name)=N''NUL'' OR am.physical_device_name=N''/dev/null''))
+ ),@StartTime)
+ AND NOT EXISTS(SELECT 1 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupmediafamily m
+     WHERE m.media_set_id=b.media_set_id AND b.is_copy_only=1
+       AND (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null''));';
+EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
+CREATE INDEX IX_RTOBackupSets ON #RTOBackupSets(database_guid,database_name,type,last_lsn);
+
 /* LSN ordering alone cannot establish a path across recovery forks, or restore
    a backup written to a discard device. Leave RTO unknown for these histories. */
 CREATE TABLE #RTOExcluded(database_name nvarchar(128), database_guid uniqueidentifier, Reason nvarchar(200));
@@ -558,23 +586,24 @@ SET @StringToExecute = N'
 INSERT #RTOExcluded
 SELECT database_name,database_guid,N''Multiple recovery forks''
 FROM (
-    SELECT database_name,database_guid,first_recovery_fork_guid AS fork_guid FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset
+    SELECT database_name,database_guid,first_recovery_fork_guid AS fork_guid FROM #RTOBackupSets
     UNION
-    SELECT database_name,database_guid,last_recovery_fork_guid FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset
+    SELECT database_name,database_guid,last_recovery_fork_guid FROM #RTOBackupSets
 ) forks
 GROUP BY database_name,database_guid HAVING COUNT(DISTINCT fork_guid)>1;
 INSERT #RTOExcluded
 SELECT DISTINCT b.database_name,b.database_guid,N''Backup to a discard device''
-FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset b
+FROM #RTOBackupSets b
 JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupmediafamily m ON b.media_set_id=m.media_set_id
 WHERE (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')
-  AND b.backup_finish_date>=@StartTime;';
+  AND b.backup_finish_date>=@StartTime
+  AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);';
 EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 SET @StringToExecute=N'
 INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
 SELECT DISTINCT 16,100,database_name,N''Recovery fork metadata missing'',
  N''Some backup history lacks recovery fork identifiers. RTO uses the available LSN history and cannot verify fork compatibility. Refresh centralized history with fork metadata and validate restores separately.''
-FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset
+FROM #RTOBackupSets
 WHERE first_recovery_fork_guid IS NULL OR last_recovery_fork_guid IS NULL;';
 EXEC sys.sp_executesql @StringToExecute;
 
@@ -590,7 +619,7 @@ FROM #RTOExcluded;
 	SET @StringToExecute += N'
 							 INSERT INTO #RTORecoveryPoints(database_name, database_guid, log_last_lsn)
 							 SELECT database_name, database_guid, MAX(last_lsn) AS log_last_lsn
-							 FROM ' + QUOTENAME(@MSDBName) + '.dbo.backupset bLastLog
+							 FROM #RTOBackupSets bLastLog
 							 WHERE type = ''L''
 							 AND bLastLog.backup_finish_date >= @StartTime
                              AND NOT EXISTS (SELECT 1 FROM #RTOExcluded x WHERE x.database_name=bLastLog.database_name AND x.database_guid=bLastLog.database_guid)
@@ -617,8 +646,8 @@ RAISERROR('Updating #RTORecoveryPoints', 0, 1) WITH NOWAIT;
 							 FROM #RTORecoveryPoints rp
 							 		CROSS APPLY (
 							 				SELECT TOP 1 bLog.backup_set_id AS backup_set_id_log, bLastFull.backup_set_id, bLastFull.last_lsn, bLastFull.backup_set_uuid, bLastFull.database_guid, bLastFull.database_name
-							 				FROM  ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLog 
-							 				INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLastFull 
+FROM  #RTOBackupSets bLog
+INNER JOIN #RTOBackupSets bLastFull
 							 					ON bLog.database_guid = bLastFull.database_guid 
 							 					AND bLog.database_name = bLastFull.database_name
                                     AND bLog.last_lsn > bLastFull.last_lsn
@@ -627,7 +656,7 @@ RAISERROR('Updating #RTORecoveryPoints', 0, 1) WITH NOWAIT;
 							 					AND rp.database_name = bLog.database_name
                                     AND bLog.type = ''L''
                                     AND bLog.last_lsn = rp.log_last_lsn
-                                ORDER BY bLastFull.last_lsn DESC, bLastFull.backup_set_id DESC
+                                ORDER BY bLastFull.last_lsn DESC, bLastFull.backup_set_id DESC, bLog.first_lsn ASC, bLog.backup_set_id ASC
                             ) bLasted;
 							 ';
 
@@ -645,7 +674,7 @@ RAISERROR('Add any full backups in the StartDate range that weren''t part of the
 	SET @StringToExecute += N'
 							 INSERT INTO #RTORecoveryPoints(database_name, database_guid, full_backup_set_id, full_last_lsn, full_backup_set_uuid)
 							 SELECT bFull.database_name, bFull.database_guid, bFull.backup_set_id, bFull.last_lsn, bFull.backup_set_uuid
-							 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bFull
+							 FROM #RTOBackupSets bFull
 							 LEFT OUTER JOIN #RTORecoveryPoints rp ON bFull.backup_set_uuid = rp.full_backup_set_uuid
 							 WHERE bFull.type = ''D''
 							     AND bFull.backup_finish_date IS NOT NULL
@@ -677,11 +706,11 @@ RAISERROR('Fill out the most recent log for that full, but before the next full'
 						        AND rpNextFull.full_last_lsn > rpEarlierFull.full_last_lsn
                             OUTER APPLY (
                                 SELECT TOP (1) bLog.last_lsn,bLog.backup_set_id
-                                FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLog
+FROM #RTOBackupSets bLog
                                 WHERE bLog.database_guid=rp.database_guid AND bLog.database_name=rp.database_name
                                   AND bLog.type=''L'' AND bLog.last_lsn>rp.full_last_lsn
                                   AND bLog.last_lsn<=rpNextFull.full_last_lsn
-                                ORDER BY bLog.last_lsn DESC,bLog.backup_set_id DESC
+                                ORDER BY bLog.last_lsn DESC,bLog.first_lsn ASC,bLog.backup_set_id ASC
                             ) endpoint
                             WHERE rpEarlierFull.full_backup_set_id IS NULL;
 							';
@@ -699,7 +728,7 @@ RAISERROR('Fill out a diff in that range', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'
 							UPDATE #RTORecoveryPoints
-							SET diff_last_lsn = (SELECT TOP 1 bDiff.last_lsn FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bDiff
+							SET diff_last_lsn = (SELECT TOP 1 bDiff.last_lsn FROM #RTOBackupSets bDiff
 							                        WHERE rp.database_guid = bDiff.database_guid AND rp.database_name = bDiff.database_name
 							                            AND bDiff.type = ''I''
 							                            AND bDiff.last_lsn < rp.log_last_lsn
@@ -728,8 +757,8 @@ RAISERROR('Get time & size totals for full & diff', 0, 1) WITH NOWAIT;
 							    , diff_time_seconds = DATEDIFF(ss,bDiff.backup_start_date, bDiff.backup_finish_date)
 							    , diff_file_size_mb = bDiff.backup_size / 1048576.0
 							FROM #RTORecoveryPoints rp
-							INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bFull ON rp.database_guid = bFull.database_guid AND rp.database_name = bFull.database_name AND rp.full_backup_set_id = bFull.backup_set_id
-							LEFT OUTER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bDiff ON rp.database_guid = bDiff.database_guid AND rp.database_name = bDiff.database_name AND rp.diff_last_lsn = bDiff.last_lsn AND bDiff.type = ''I'' AND bDiff.differential_base_guid=rp.full_backup_set_uuid;
+							INNER JOIN #RTOBackupSets bFull ON rp.database_guid = bFull.database_guid AND rp.database_name = bFull.database_name AND rp.full_backup_set_id = bFull.backup_set_id
+							LEFT OUTER JOIN #RTOBackupSets bDiff ON rp.database_guid = bDiff.database_guid AND rp.database_name = bDiff.database_name AND rp.diff_last_lsn = bDiff.last_lsn AND bDiff.type = ''I'' AND bDiff.differential_base_guid=rp.full_backup_set_uuid;
 							';
 
 	IF @Debug = 1
@@ -750,7 +779,7 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 								    , log_file_size = SUM(bLog.backup_size)
 								    , SUM(1) AS log_backups
 								        FROM #RTORecoveryPoints rp
-								            INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLog ON rp.database_guid = bLog.database_guid AND rp.database_name = bLog.database_name AND bLog.type = ''L''
+INNER JOIN #RTOBackupSets bLog ON rp.database_guid = bLog.database_guid AND rp.database_name = bLog.database_name AND bLog.type = ''L''
 								            AND bLog.last_lsn > COALESCE(rp.diff_last_lsn, rp.full_last_lsn)
 								            AND bLog.last_lsn <= rp.log_last_lsn
                                     /* A covering backup makes this interval redundant (for example,
@@ -758,7 +787,7 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
                                        identical intervals and never cross recovery forks. */
                                     AND NOT EXISTS (
                                         SELECT 1
-                                        FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset AS bCover
+                                        FROM #RTOBackupSets AS bCover
                                         WHERE bCover.database_guid = bLog.database_guid
                                           AND bCover.database_name = bLog.database_name
                                           AND bCover.type = ''L''
@@ -1416,7 +1445,7 @@ SELECT w.CheckId, w.Priority, w.DatabaseName, w.Finding, w.Warning
 FROM #Warnings AS w
 ORDER BY w.Priority, w.CheckId;
 
-DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints, #RTOExcluded
+DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints, #RTOExcluded, #RTOBackupSets
 
 
 RETURN;

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -569,6 +569,7 @@ BEGIN
     JOIN '+QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily m ON m.media_set_id=e.media_set_id
       AND m.family_sequence_number BETWEEN e.FirstFamily AND e.LastFamily
       AND m.physical_device_name IS NOT NULL
+      AND UPPER(m.physical_device_name)<>N''NUL'' AND m.physical_device_name<>N''/dev/null''
     GROUP BY e.media_set_id,e.FirstFamily,e.LastFamily
     HAVING COUNT(DISTINCT m.family_sequence_number)=e.LastFamily-e.FirstFamily+1;';
     EXEC sys.sp_executesql @StringToExecute;
@@ -601,12 +602,8 @@ WHERE b.type IN (''D'',''I'',''L'')
     WHERE anchor.database_name=b.database_name AND anchor.database_guid=b.database_guid
       AND anchor.type=''D'' AND anchor.is_damaged=0 AND anchor.backup_finish_date<=@StartTime
       AND EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.media_set_id=anchor.media_set_id)
-      AND NOT EXISTS(SELECT 1 FROM #RTODiscardMedia am
-        WHERE am.media_set_id=anchor.media_set_id AND (UPPER(am.physical_device_name)=N''NUL'' OR am.physical_device_name=N''/dev/null''))
  ))
- AND NOT EXISTS(SELECT 1 FROM #RTODiscardMedia m
-     WHERE m.media_set_id=b.media_set_id AND (b.is_copy_only=1 OR b.type IN (''D'',''I''))
-       AND (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null''));';
+;';
 EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 CREATE INDEX IX_RTOBackupSets ON #RTOBackupSets(database_guid,database_name,type,last_lsn);
 
@@ -630,6 +627,7 @@ FROM #RTOBackupSets b
 JOIN #RTODiscardMedia m ON b.media_set_id=m.media_set_id
 WHERE (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')
   AND b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)
+  AND NOT EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.media_set_id=b.media_set_id)
   AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
 INSERT #RTOExcluded
 SELECT DISTINCT b.database_name,b.database_guid,N''Damaged log backup or unknown integrity metadata''

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -570,7 +570,7 @@ RAISERROR('Updating #RTORecoveryPoints', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'
 							 UPDATE #RTORecoveryPoints
-							 SET log_backup_set_id = bLasted.backup_set_id
+							 SET log_backup_set_id = bLasted.backup_set_id_log
 							     ,full_backup_set_id = bLasted.backup_set_id
 							     ,full_last_lsn = bLasted.last_lsn
 							     ,full_backup_set_uuid = bLasted.backup_set_uuid
@@ -581,16 +581,14 @@ RAISERROR('Updating #RTORecoveryPoints', 0, 1) WITH NOWAIT;
 							 				INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLastFull 
 							 					ON bLog.database_guid = bLastFull.database_guid 
 							 					AND bLog.database_name = bLastFull.database_name
-							 					AND bLog.first_lsn > bLastFull.last_lsn
+                                    AND bLog.last_lsn > bLastFull.last_lsn
 							 					AND bLastFull.type = ''D''
 							 				WHERE rp.database_guid = bLog.database_guid 
 							 					AND rp.database_name = bLog.database_name
-							 			) bLasted
-							 LEFT OUTER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLaterFulls ON bLasted.database_guid = bLaterFulls.database_guid AND bLasted.database_name = bLaterFulls.database_name
-							     AND bLasted.last_lsn < bLaterFulls.last_lsn
-							     AND bLaterFulls.first_lsn < bLasted.last_lsn
-							     AND bLaterFulls.type = ''D''
-							 WHERE bLaterFulls.backup_set_id IS NULL;
+                                    AND bLog.type = ''L''
+                                    AND bLog.last_lsn = rp.log_last_lsn
+                                ORDER BY bLastFull.last_lsn DESC, bLastFull.backup_set_id DESC
+                            ) bLasted;
 							 ';
 
 	IF @Debug = 1
@@ -690,7 +688,7 @@ RAISERROR('Get time & size totals for full & diff', 0, 1) WITH NOWAIT;
 	EXEC sys.sp_executesql @StringToExecute;
 
 
-/* Get time & size totals for logs */
+/* Get time & size totals for logs, including the log that overlaps the full/diff endpoint. */
 
 RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 
@@ -703,8 +701,8 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 								    , SUM(1) AS log_backups
 								        FROM #RTORecoveryPoints rp
 								            INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLog ON rp.database_guid = bLog.database_guid AND rp.database_name = bLog.database_name AND bLog.type = ''L''
-								            AND bLog.first_lsn > COALESCE(rp.diff_last_lsn, rp.full_last_lsn)
-								            AND bLog.first_lsn <= rp.log_last_lsn
+								            AND bLog.last_lsn > COALESCE(rp.diff_last_lsn, rp.full_last_lsn)
+								            AND bLog.last_lsn <= rp.log_last_lsn
 								        GROUP BY rp.id
 								)
 								UPDATE #RTORecoveryPoints

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -557,8 +557,20 @@ CREATE TABLE #RTOKnownMedia(media_set_id int PRIMARY KEY);
 DECLARE @RTOMediaAvailable bit=CASE WHEN OBJECT_ID(QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily') IS NOT NULL THEN 1 ELSE 0 END;
 IF @RTOMediaAvailable=1
 BEGIN
-    SET @StringToExecute=N'INSERT #RTOKnownMedia SELECT DISTINCT media_set_id FROM '
-        +QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily WHERE physical_device_name IS NOT NULL;';
+    SET @StringToExecute=N'WITH ExpectedFamilies AS (
+        SELECT media_set_id,MIN(first_family_number) AS FirstFamily,MAX(last_family_number) AS LastFamily
+        FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset
+        GROUP BY media_set_id
+        HAVING MIN(first_family_number)>0 AND MAX(last_family_number)>=MIN(first_family_number)
+          AND COUNT(*)=COUNT(first_family_number) AND COUNT(*)=COUNT(last_family_number)
+    )
+    INSERT #RTOKnownMedia
+    SELECT e.media_set_id FROM ExpectedFamilies e
+    JOIN '+QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily m ON m.media_set_id=e.media_set_id
+      AND m.family_sequence_number BETWEEN e.FirstFamily AND e.LastFamily
+      AND m.physical_device_name IS NOT NULL
+    GROUP BY e.media_set_id,e.FirstFamily,e.LastFamily
+    HAVING COUNT(DISTINCT m.family_sequence_number)=e.LastFamily-e.FirstFamily+1;';
     EXEC sys.sp_executesql @StringToExecute;
     SET @StringToExecute=N'INSERT #RTODiscardMedia SELECT media_set_id,physical_device_name FROM '
         +QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily WHERE UPPER(physical_device_name)=N''NUL'' OR physical_device_name=N''/dev/null'';';
@@ -1822,7 +1834,7 @@ END
 									' 
 		SET @StringToExecute += N' (database_name, database_guid, backup_set_uuid, type, backup_size, backup_start_date, backup_finish_date, media_set_id, time_zone, 
 									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level,
-                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_lsn, differential_base_guid, is_copy_only,
+                                    first_family_number, last_family_number, first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_lsn, differential_base_guid, is_copy_only,
 									is_password_protected, is_snapshot, is_readonly, is_single_user, has_backup_checksums, is_damaged, ' + CASE WHEN @ProductVersionMajor >= 12 
 																																				THEN + N'encryptor_type, has_bulk_logged_data)' + @crlf
 																																				ELSE + N'has_bulk_logged_data)' + @crlf
@@ -1831,7 +1843,7 @@ END
 		SET @StringToExecute +=N'
 									SELECT database_name, database_guid, backup_set_uuid, type, backup_size, backup_start_date, backup_finish_date, media_set_id, time_zone, 
 									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level,
-                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_lsn, differential_base_guid, is_copy_only,
+                                    first_family_number, last_family_number, first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_lsn, differential_base_guid, is_copy_only,
 									is_password_protected, is_snapshot, is_readonly, is_single_user, has_backup_checksums, is_damaged, ' + CASE WHEN @ProductVersionMajor >= 12 
 																																				THEN + N'encryptor_type, has_bulk_logged_data' + @crlf
 																																				ELSE + N'has_bulk_logged_data' + @crlf

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -551,6 +551,17 @@ GOTO PushBackupHistoryToListener
 
 RAISERROR('Gathering RTO information', 0, 1) WITH NOWAIT;
 
+/* Centralized history may have backupset without media-family metadata. */
+CREATE TABLE #RTODiscardMedia(media_set_id int,physical_device_name nvarchar(4000));
+DECLARE @RTOMediaAvailable bit=CASE WHEN OBJECT_ID(QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily') IS NOT NULL THEN 1 ELSE 0 END;
+IF @RTOMediaAvailable=1
+BEGIN
+    SET @StringToExecute=N'INSERT #RTODiscardMedia SELECT media_set_id,physical_device_name FROM '
+        +QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily WHERE UPPER(physical_device_name)=N''NUL'' OR physical_device_name=N''/dev/null'';';
+    EXEC sys.sp_executesql @StringToExecute;
+END;
+CREATE INDEX IX_RTODiscardMedia ON #RTODiscardMedia(media_set_id);
+
 /* Restrict recovery estimates to the requested window plus its preceding full.
    Discarded copy-only backups cannot invalidate or replace a usable chain. */
 CREATE TABLE #RTOBackupSets(
@@ -566,15 +577,15 @@ SELECT b.database_name,b.database_guid,b.backup_set_id,b.backup_set_uuid,b.type,
  b.differential_base_guid,b.media_set_id,b.is_copy_only
 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset b
 WHERE b.type IN (''D'',''I'',''L'')
- AND b.backup_finish_date>=COALESCE((
+ AND (b.backup_finish_date>=@StartTime OR b.backup_finish_date>=(
     SELECT MAX(anchor.backup_finish_date) FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset anchor
     WHERE anchor.database_name=b.database_name AND anchor.database_guid=b.database_guid
       AND anchor.type=''D'' AND anchor.backup_finish_date<=@StartTime
-      AND NOT EXISTS(SELECT 1 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupmediafamily am
+      AND NOT EXISTS(SELECT 1 FROM #RTODiscardMedia am
         WHERE am.media_set_id=anchor.media_set_id AND (UPPER(am.physical_device_name)=N''NUL'' OR am.physical_device_name=N''/dev/null''))
- ),@StartTime)
- AND NOT EXISTS(SELECT 1 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupmediafamily m
-     WHERE m.media_set_id=b.media_set_id AND b.is_copy_only=1
+ ))
+ AND NOT EXISTS(SELECT 1 FROM #RTODiscardMedia m
+     WHERE m.media_set_id=b.media_set_id AND (b.is_copy_only=1 OR b.type IN (''D'',''I''))
        AND (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null''));';
 EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 CREATE INDEX IX_RTOBackupSets ON #RTOBackupSets(database_guid,database_name,type,last_lsn);
@@ -594,9 +605,9 @@ GROUP BY database_name,database_guid HAVING COUNT(DISTINCT fork_guid)>1;
 INSERT #RTOExcluded
 SELECT DISTINCT b.database_name,b.database_guid,N''Backup to a discard device''
 FROM #RTOBackupSets b
-JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupmediafamily m ON b.media_set_id=m.media_set_id
+JOIN #RTODiscardMedia m ON b.media_set_id=m.media_set_id
 WHERE (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')
-  AND b.backup_finish_date>=@StartTime
+  AND b.type=''L'' AND b.is_copy_only=0
   AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);';
 EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 SET @StringToExecute=N'
@@ -606,6 +617,19 @@ SELECT DISTINCT 16,100,database_name,N''Recovery fork metadata missing'',
 FROM #RTOBackupSets
 WHERE first_recovery_fork_guid IS NULL OR last_recovery_fork_guid IS NULL;';
 EXEC sys.sp_executesql @StringToExecute;
+
+IF @RTOMediaAvailable=0
+    INSERT #RTOExcluded
+    SELECT DISTINCT b.database_name,b.database_guid,N'Backup media metadata missing'
+    FROM #RTOBackupSets b
+    WHERE NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
+
+/* Keep databases with in-window logs visible even if their full predates the window.
+   Leave in-window throughput aggregates NULL when no full was measured there. */
+INSERT #Backups(database_name,database_guid)
+SELECT DISTINCT b.database_name,b.database_guid FROM #RTOBackupSets b
+WHERE b.backup_finish_date>=@StartTime
+AND NOT EXISTS(SELECT 1 FROM #Backups x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
 
 INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
 SELECT 15,50,database_name,N'RTO estimate unavailable',
@@ -656,14 +680,26 @@ INNER JOIN #RTOBackupSets bLastFull
 							 					AND rp.database_name = bLog.database_name
                                     AND bLog.type = ''L''
                                     AND bLog.last_lsn = rp.log_last_lsn
-                                ORDER BY bLastFull.last_lsn DESC, bLastFull.backup_set_id DESC, bLog.first_lsn ASC, bLog.backup_set_id ASC
+                                    AND bLog.backup_finish_date>=@StartTime
+                                ORDER BY bLastFull.last_lsn DESC, bLastFull.backup_set_id DESC, bLog.first_lsn ASC, bLog.is_copy_only ASC, bLog.backup_set_id DESC
                             ) bLasted;
 							 ';
 
 	IF @Debug = 1
 		PRINT @StringToExecute;
 
-	EXEC sys.sp_executesql @StringToExecute;
+	EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
+
+/* A log endpoint without a usable full must explain why no estimate is possible. */
+INSERT #RTOExcluded
+SELECT DISTINCT rp.database_name,rp.database_guid,N'No usable full backup for the log endpoint'
+FROM #RTORecoveryPoints rp WHERE rp.full_backup_set_id IS NULL
+AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=rp.database_name AND x.database_guid=rp.database_guid);
+INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
+SELECT 15,50,x.database_name,N'RTO estimate unavailable',x.Reason
+FROM #RTOExcluded x WHERE NOT EXISTS(SELECT 1 FROM #Warnings w WHERE w.CheckId=15 AND w.DatabaseName=x.database_name);
+DELETE rp FROM #RTORecoveryPoints rp
+JOIN #RTOExcluded x ON x.database_name=rp.database_name AND x.database_guid=rp.database_guid;
 
 /* Add any full backups in the StartDate range that weren't part of the above log backup chain */
 
@@ -713,7 +749,7 @@ FROM #RTOBackupSets bLog
                                 /* STOPAT can use the first log spanning the next full. */
                                 ORDER BY CASE WHEN bLog.last_lsn>=rpNextFull.full_last_lsn THEN 0 ELSE 1 END,
                                   CASE WHEN bLog.last_lsn>=rpNextFull.full_last_lsn THEN bLog.last_lsn END ASC,
-                                  bLog.last_lsn DESC,bLog.first_lsn ASC,bLog.backup_set_id ASC
+                                  bLog.last_lsn DESC,bLog.first_lsn ASC,bLog.is_copy_only ASC,bLog.backup_set_id DESC
                             ) endpoint
                             WHERE rpEarlierFull.full_backup_set_id IS NULL;
 							';
@@ -777,35 +813,25 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 	SET @StringToExecute = N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;' + @crlf;
 
 	SET @StringToExecute += N'
-							WITH LogTotals AS (
-								 SELECT rp.id, log_time_seconds = SUM(DATEDIFF(ss,bLog.backup_start_date, bLog.backup_finish_date))
-								    , log_file_size = SUM(bLog.backup_size)
-								    , SUM(1) AS log_backups
-								        FROM #RTORecoveryPoints rp
-INNER JOIN #RTOBackupSets bLog ON rp.database_guid = bLog.database_guid AND rp.database_name = bLog.database_name AND bLog.type = ''L''
-								            AND bLog.last_lsn > COALESCE(rp.diff_last_lsn, rp.full_last_lsn)
-								            AND bLog.last_lsn <= rp.log_last_lsn
-                                    /* A covering backup makes this interval redundant (for example,
-                                       COPY_ONLY followed by a regular log backup). Keep one copy of
-                                       identical intervals and never cross recovery forks. */
-                                    AND NOT EXISTS (
-                                        SELECT 1
-                                        FROM #RTOBackupSets AS bCover
-                                        WHERE bCover.database_guid = bLog.database_guid
-                                          AND bCover.database_name = bLog.database_name
-                                          AND bCover.type = ''L''
-                                          AND (bCover.first_recovery_fork_guid = bLog.first_recovery_fork_guid OR (bCover.first_recovery_fork_guid IS NULL AND bLog.first_recovery_fork_guid IS NULL))
-                                          AND (bCover.last_recovery_fork_guid = bLog.last_recovery_fork_guid OR (bCover.last_recovery_fork_guid IS NULL AND bLog.last_recovery_fork_guid IS NULL))
-                                          AND bCover.first_lsn <= bLog.first_lsn
-                                          AND bCover.last_lsn >= bLog.last_lsn
-                                          AND bCover.last_lsn <= rp.log_last_lsn
-                                          AND (bCover.first_lsn < bLog.first_lsn
-                                               OR bCover.last_lsn > bLog.last_lsn
-                                               OR bCover.backup_set_id < bLog.backup_set_id)
-                                    )
-								        GROUP BY rp.id
-								)
-								UPDATE #RTORecoveryPoints
+							WITH LogIntervals AS (
+    SELECT rp.id,bLog.backup_start_date,bLog.backup_finish_date,bLog.backup_size,bLog.last_lsn,
+        MAX(bLog.last_lsn) OVER (
+            PARTITION BY rp.id,bLog.first_recovery_fork_guid,bLog.last_recovery_fork_guid
+            ORDER BY bLog.first_lsn,bLog.last_lsn DESC,bLog.is_copy_only,bLog.backup_set_id DESC
+            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS PriorMaxLastLSN
+    FROM #RTORecoveryPoints rp
+    JOIN #RTOBackupSets bLog ON rp.database_guid=bLog.database_guid AND rp.database_name=bLog.database_name
+        AND bLog.type=''L'' AND bLog.last_lsn>COALESCE(rp.diff_last_lsn,rp.full_last_lsn)
+        AND bLog.last_lsn<=rp.log_last_lsn
+), LogTotals AS (
+    /* Ordered running maximum removes contained intervals without a range self-join.
+       Equal intervals prefer regular backups, then the newest backup ID. */
+    SELECT id,SUM(DATEDIFF(second,backup_start_date,backup_finish_date)) AS log_time_seconds,
+        SUM(backup_size) AS log_file_size,COUNT(*) AS log_backups
+    FROM LogIntervals WHERE PriorMaxLastLSN IS NULL OR last_lsn>PriorMaxLastLSN
+    GROUP BY id
+)
+                                UPDATE #RTORecoveryPoints
 								    SET log_time_seconds = lt.log_time_seconds
 								    , log_file_size_mb = lt.log_file_size / 1048576.0
 								    , log_backups = lt.log_backups
@@ -1383,7 +1409,7 @@ IF @ProductVersionMajor >= 12
 		''The database '' + QUOTENAME(bs.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to the NUL device, the latest one being on ''+
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
-	INNER JOIN ' + QUOTENAME(@MSDBName) + '.dbo.backupmediafamily bmf ON bs.media_set_id = bmf.media_set_id
+	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id
 	WHERE UPPER(bmf.physical_device_name)= N''NUL''
 	AND (bs.is_copy_only = 1 OR bs.recovery_model = N''SIMPLE'')
 	AND bs.backup_finish_date >= @StartTime
@@ -1396,7 +1422,7 @@ IF @ProductVersionMajor >= 12
 		''The database '' + QUOTENAME(bs.database_name) + '' is not in SIMPLE recovery model and has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to the NUL device, the latest one being on ''+
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist and they might mess up your current backup chain.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
-	INNER JOIN ' + QUOTENAME(@MSDBName) + '.dbo.backupmediafamily bmf ON bs.media_set_id = bmf.media_set_id
+	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id
 	WHERE UPPER(bmf.physical_device_name)= N''NUL''
 	AND bs.is_copy_only = 0 AND bs.recovery_model <> N''SIMPLE''
 	AND bs.backup_finish_date >= @StartTime
@@ -1774,7 +1800,7 @@ END
 									' 
 		SET @StringToExecute += N' (database_name, database_guid, backup_set_uuid, type, backup_size, backup_start_date, backup_finish_date, media_set_id, time_zone, 
 									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level,
-                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_guid, is_copy_only,
+                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_lsn, differential_base_guid, is_copy_only,
 									is_password_protected, is_snapshot, is_readonly, is_single_user, has_backup_checksums, is_damaged, ' + CASE WHEN @ProductVersionMajor >= 12 
 																																				THEN + N'encryptor_type, has_bulk_logged_data)' + @crlf
 																																				ELSE + N'has_bulk_logged_data)' + @crlf
@@ -1783,7 +1809,7 @@ END
 		SET @StringToExecute +=N'
 									SELECT database_name, database_guid, backup_set_uuid, type, backup_size, backup_start_date, backup_finish_date, media_set_id, time_zone, 
 									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level,
-                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_guid, is_copy_only,
+                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_lsn, differential_base_guid, is_copy_only,
 									is_password_protected, is_snapshot, is_readonly, is_single_user, has_backup_checksums, is_damaged, ' + CASE WHEN @ProductVersionMajor >= 12 
 																																				THEN + N'encryptor_type, has_bulk_logged_data' + @crlf
 																																				ELSE + N'has_bulk_logged_data' + @crlf

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -709,8 +709,11 @@ RAISERROR('Fill out the most recent log for that full, but before the next full'
 FROM #RTOBackupSets bLog
                                 WHERE bLog.database_guid=rp.database_guid AND bLog.database_name=rp.database_name
                                   AND bLog.type=''L'' AND bLog.last_lsn>rp.full_last_lsn
-                                  AND bLog.last_lsn<=rpNextFull.full_last_lsn
-                                ORDER BY bLog.last_lsn DESC,bLog.first_lsn ASC,bLog.backup_set_id ASC
+                                  AND bLog.first_lsn<=rpNextFull.full_last_lsn
+                                /* STOPAT can use the first log spanning the next full. */
+                                ORDER BY CASE WHEN bLog.last_lsn>=rpNextFull.full_last_lsn THEN 0 ELSE 1 END,
+                                  CASE WHEN bLog.last_lsn>=rpNextFull.full_last_lsn THEN bLog.last_lsn END ASC,
+                                  bLog.last_lsn DESC,bLog.first_lsn ASC,bLog.backup_set_id ASC
                             ) endpoint
                             WHERE rpEarlierFull.full_backup_set_id IS NULL;
 							';

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -553,9 +553,13 @@ RAISERROR('Gathering RTO information', 0, 1) WITH NOWAIT;
 
 /* Centralized history may have backupset without media-family metadata. */
 CREATE TABLE #RTODiscardMedia(media_set_id int,physical_device_name nvarchar(4000));
+CREATE TABLE #RTOKnownMedia(media_set_id int PRIMARY KEY);
 DECLARE @RTOMediaAvailable bit=CASE WHEN OBJECT_ID(QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily') IS NOT NULL THEN 1 ELSE 0 END;
 IF @RTOMediaAvailable=1
 BEGIN
+    SET @StringToExecute=N'INSERT #RTOKnownMedia SELECT DISTINCT media_set_id FROM '
+        +QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily WHERE physical_device_name IS NOT NULL;';
+    EXEC sys.sp_executesql @StringToExecute;
     SET @StringToExecute=N'INSERT #RTODiscardMedia SELECT media_set_id,physical_device_name FROM '
         +QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily WHERE UPPER(physical_device_name)=N''NUL'' OR physical_device_name=N''/dev/null'';';
     EXEC sys.sp_executesql @StringToExecute;
@@ -618,11 +622,11 @@ FROM #RTOBackupSets
 WHERE first_recovery_fork_guid IS NULL OR last_recovery_fork_guid IS NULL;';
 EXEC sys.sp_executesql @StringToExecute;
 
-IF @RTOMediaAvailable=0
     INSERT #RTOExcluded
     SELECT DISTINCT b.database_name,b.database_guid,N'Backup media metadata missing'
     FROM #RTOBackupSets b
-    WHERE NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
+    WHERE NOT EXISTS(SELECT 1 FROM #RTOKnownMedia m WHERE m.media_set_id=b.media_set_id)
+      AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
 
 /* Keep databases with in-window logs visible even if their full predates the window.
    Leave in-window throughput aggregates NULL when no full was measured there. */

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -551,6 +551,39 @@ GOTO PushBackupHistoryToListener
 
 RAISERROR('Gathering RTO information', 0, 1) WITH NOWAIT;
 
+/* LSN ordering alone cannot establish a path across recovery forks, or restore
+   a backup written to a discard device. Leave RTO unknown for these histories. */
+CREATE TABLE #RTOExcluded(database_name nvarchar(128), database_guid uniqueidentifier, Reason nvarchar(200));
+SET @StringToExecute = N'
+INSERT #RTOExcluded
+SELECT database_name,database_guid,N''Multiple recovery forks''
+FROM (
+    SELECT database_name,database_guid,first_recovery_fork_guid AS fork_guid FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset
+    UNION
+    SELECT database_name,database_guid,last_recovery_fork_guid FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset
+) forks
+GROUP BY database_name,database_guid HAVING COUNT(DISTINCT fork_guid)>1;
+INSERT #RTOExcluded
+SELECT DISTINCT b.database_name,b.database_guid,N''Backup to a discard device''
+FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset b
+JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupmediafamily m ON b.media_set_id=m.media_set_id
+WHERE (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')
+  AND b.backup_finish_date>=@StartTime;';
+EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
+SET @StringToExecute=N'
+INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
+SELECT DISTINCT 16,100,database_name,N''Recovery fork metadata missing'',
+ N''Some backup history lacks recovery fork identifiers. RTO uses the available LSN history and cannot verify fork compatibility. Refresh centralized history with fork metadata and validate restores separately.''
+FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset
+WHERE first_recovery_fork_guid IS NULL OR last_recovery_fork_guid IS NULL;';
+EXEC sys.sp_executesql @StringToExecute;
+
+INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
+SELECT 15,50,database_name,N'RTO estimate unavailable',
+       Reason + N': sp_BlitzBackups cannot establish a usable single-fork restore chain from this history. Validate the restore sequence separately; no RTO estimate is reported.'
+FROM #RTOExcluded;
+
+
 
 	SET @StringToExecute =N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;' + @crlf;
 
@@ -560,6 +593,7 @@ RAISERROR('Gathering RTO information', 0, 1) WITH NOWAIT;
 							 FROM ' + QUOTENAME(@MSDBName) + '.dbo.backupset bLastLog
 							 WHERE type = ''L''
 							 AND bLastLog.backup_finish_date >= @StartTime
+                             AND NOT EXISTS (SELECT 1 FROM #RTOExcluded x WHERE x.database_name=bLastLog.database_name AND x.database_guid=bLastLog.database_guid)
 							 GROUP BY database_name, database_guid;
 							';
 
@@ -616,7 +650,8 @@ RAISERROR('Add any full backups in the StartDate range that weren''t part of the
 							 WHERE bFull.type = ''D''
 							     AND bFull.backup_finish_date IS NOT NULL
 							     AND rp.full_backup_set_uuid IS NULL
-							     AND bFull.backup_finish_date >= @StartTime;
+							     AND bFull.backup_finish_date >= @StartTime
+                                 AND NOT EXISTS (SELECT 1 FROM #RTOExcluded x WHERE x.database_name=bFull.database_name AND x.database_guid=bFull.database_guid);
 							';
 
 	IF @Debug = 1
@@ -632,14 +667,23 @@ RAISERROR('Fill out the most recent log for that full, but before the next full'
 
 	SET @StringToExecute += N'
 							UPDATE rp
-						    SET log_last_lsn = (SELECT MAX(last_lsn) FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLog WHERE bLog.first_lsn >= rp.full_last_lsn AND bLog.first_lsn <= rpNextFull.full_last_lsn AND bLog.type = ''L'')
+                            SET log_last_lsn = endpoint.last_lsn,
+                                log_backup_set_id = endpoint.backup_set_id
 							FROM #RTORecoveryPoints rp
 						    INNER JOIN #RTORecoveryPoints rpNextFull ON rp.database_guid = rpNextFull.database_guid AND rp.database_name = rpNextFull.database_name
 						        AND rp.full_last_lsn < rpNextFull.full_last_lsn
 						    LEFT OUTER JOIN #RTORecoveryPoints rpEarlierFull ON rp.database_guid = rpEarlierFull.database_guid AND rp.database_name = rpEarlierFull.database_name
 						        AND rp.full_last_lsn < rpEarlierFull.full_last_lsn
 						        AND rpNextFull.full_last_lsn > rpEarlierFull.full_last_lsn
-						    WHERE rpEarlierFull.full_backup_set_id IS NULL;
+                            OUTER APPLY (
+                                SELECT TOP (1) bLog.last_lsn,bLog.backup_set_id
+                                FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLog
+                                WHERE bLog.database_guid=rp.database_guid AND bLog.database_name=rp.database_name
+                                  AND bLog.type=''L'' AND bLog.last_lsn>rp.full_last_lsn
+                                  AND bLog.last_lsn<=rpNextFull.full_last_lsn
+                                ORDER BY bLog.last_lsn DESC,bLog.backup_set_id DESC
+                            ) endpoint
+                            WHERE rpEarlierFull.full_backup_set_id IS NULL;
 							';
 
 	IF @Debug = 1
@@ -684,8 +728,8 @@ RAISERROR('Get time & size totals for full & diff', 0, 1) WITH NOWAIT;
 							    , diff_time_seconds = DATEDIFF(ss,bDiff.backup_start_date, bDiff.backup_finish_date)
 							    , diff_file_size_mb = bDiff.backup_size / 1048576.0
 							FROM #RTORecoveryPoints rp
-							INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bFull ON rp.database_guid = bFull.database_guid AND rp.database_name = bFull.database_name AND rp.full_last_lsn = bFull.last_lsn
-							LEFT OUTER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bDiff ON rp.database_guid = bDiff.database_guid AND rp.database_name = bDiff.database_name AND rp.diff_last_lsn = bDiff.last_lsn AND bDiff.last_lsn IS NOT NULL;
+							INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bFull ON rp.database_guid = bFull.database_guid AND rp.database_name = bFull.database_name AND rp.full_backup_set_id = bFull.backup_set_id
+							LEFT OUTER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bDiff ON rp.database_guid = bDiff.database_guid AND rp.database_name = bDiff.database_name AND rp.diff_last_lsn = bDiff.last_lsn AND bDiff.type = ''I'' AND bDiff.differential_base_guid=rp.full_backup_set_uuid;
 							';
 
 	IF @Debug = 1
@@ -718,8 +762,8 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
                                         WHERE bCover.database_guid = bLog.database_guid
                                           AND bCover.database_name = bLog.database_name
                                           AND bCover.type = ''L''
-                                          AND bCover.first_recovery_fork_guid = bLog.first_recovery_fork_guid
-                                          AND bCover.last_recovery_fork_guid = bLog.last_recovery_fork_guid
+                                          AND (bCover.first_recovery_fork_guid = bLog.first_recovery_fork_guid OR (bCover.first_recovery_fork_guid IS NULL AND bLog.first_recovery_fork_guid IS NULL))
+                                          AND (bCover.last_recovery_fork_guid = bLog.last_recovery_fork_guid OR (bCover.last_recovery_fork_guid IS NULL AND bLog.last_recovery_fork_guid IS NULL))
                                           AND bCover.first_lsn <= bLog.first_lsn
                                           AND bCover.last_lsn >= bLog.last_lsn
                                           AND bCover.last_lsn <= rp.log_last_lsn
@@ -1372,7 +1416,7 @@ SELECT w.CheckId, w.Priority, w.DatabaseName, w.Finding, w.Warning
 FROM #Warnings AS w
 ORDER BY w.Priority, w.CheckId;
 
-DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints
+DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints, #RTOExcluded
 
 
 RETURN;
@@ -1697,7 +1741,8 @@ END
 		SET @StringToExecute += N'INSERT ' + QUOTENAME(@WriteBackupsToListenerName) + N'.' + QUOTENAME(@WriteBackupsToDatabaseName) + N'.dbo.backupset
 									' 
 		SET @StringToExecute += N' (database_name, database_guid, backup_set_uuid, type, backup_size, backup_start_date, backup_finish_date, media_set_id, time_zone, 
-									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level, 
+									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level,
+                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_guid, is_copy_only,
 									is_password_protected, is_snapshot, is_readonly, is_single_user, has_backup_checksums, is_damaged, ' + CASE WHEN @ProductVersionMajor >= 12 
 																																				THEN + N'encryptor_type, has_bulk_logged_data)' + @crlf
 																																				ELSE + N'has_bulk_logged_data)' + @crlf
@@ -1705,7 +1750,8 @@ END
 		
 		SET @StringToExecute +=N'
 									SELECT database_name, database_guid, backup_set_uuid, type, backup_size, backup_start_date, backup_finish_date, media_set_id, time_zone, 
-									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level, 
+									compressed_backup_size, recovery_model, server_name, machine_name, first_lsn, last_lsn, user_name, compatibility_level,
+                                    first_recovery_fork_guid, last_recovery_fork_guid, fork_point_lsn, differential_base_guid, is_copy_only,
 									is_password_protected, is_snapshot, is_readonly, is_single_user, has_backup_checksums, is_damaged, ' + CASE WHEN @ProductVersionMajor >= 12 
 																																				THEN + N'encryptor_type, has_bulk_logged_data' + @crlf
 																																				ELSE + N'has_bulk_logged_data' + @crlf

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -607,7 +607,7 @@ SELECT DISTINCT b.database_name,b.database_guid,N''Backup to a discard device''
 FROM #RTOBackupSets b
 JOIN #RTODiscardMedia m ON b.media_set_id=m.media_set_id
 WHERE (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')
-  AND b.type=''L'' AND b.is_copy_only=0
+  AND b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)
   AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);';
 EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 SET @StringToExecute=N'
@@ -759,7 +759,8 @@ FROM #RTOBackupSets bLog
 
 	EXEC sys.sp_executesql @StringToExecute;
 
-/* Fill out a diff in that range */
+/* A differential is optional: use it only when its full base is known.
+   Otherwise estimate the valid full-plus-log path, including logs from the full. */
 
 RAISERROR('Fill out a diff in that range', 0, 1) WITH NOWAIT;
 
@@ -1412,7 +1413,7 @@ IF @ProductVersionMajor >= 12
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
 	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id
-	WHERE UPPER(bmf.physical_device_name)= N''NUL''
+	WHERE (UPPER(bmf.physical_device_name)=N''NUL'' OR bmf.physical_device_name=N''/dev/null'')
 	AND (bs.is_copy_only = 1 OR bs.recovery_model = N''SIMPLE'')
 	AND bs.backup_finish_date >= @StartTime
 	GROUP BY bs.database_name' + @crlf;
@@ -1425,7 +1426,7 @@ IF @ProductVersionMajor >= 12
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist and they might mess up your current backup chain.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
 	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id
-	WHERE UPPER(bmf.physical_device_name)= N''NUL''
+	WHERE (UPPER(bmf.physical_device_name)=N''NUL'' OR bmf.physical_device_name=N''/dev/null'')
 	AND bs.is_copy_only = 0 AND bs.recovery_model <> N''SIMPLE''
 	AND bs.backup_finish_date >= @StartTime
 	GROUP BY bs.database_name' + @crlf;

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -709,6 +709,24 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 								            INNER JOIN ' + QUOTENAME(@MSDBName) + N'.dbo.backupset bLog ON rp.database_guid = bLog.database_guid AND rp.database_name = bLog.database_name AND bLog.type = ''L''
 								            AND bLog.last_lsn > COALESCE(rp.diff_last_lsn, rp.full_last_lsn)
 								            AND bLog.last_lsn <= rp.log_last_lsn
+                                    /* A covering backup makes this interval redundant (for example,
+                                       COPY_ONLY followed by a regular log backup). Keep one copy of
+                                       identical intervals and never cross recovery forks. */
+                                    AND NOT EXISTS (
+                                        SELECT 1
+                                        FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset AS bCover
+                                        WHERE bCover.database_guid = bLog.database_guid
+                                          AND bCover.database_name = bLog.database_name
+                                          AND bCover.type = ''L''
+                                          AND bCover.first_recovery_fork_guid = bLog.first_recovery_fork_guid
+                                          AND bCover.last_recovery_fork_guid = bLog.last_recovery_fork_guid
+                                          AND bCover.first_lsn <= bLog.first_lsn
+                                          AND bCover.last_lsn >= bLog.last_lsn
+                                          AND bCover.last_lsn <= rp.log_last_lsn
+                                          AND (bCover.first_lsn < bLog.first_lsn
+                                               OR bCover.last_lsn > bLog.last_lsn
+                                               OR bCover.backup_set_id < bLog.backup_set_id)
+                                    )
 								        GROUP BY rp.id
 								)
 								UPDATE #RTORecoveryPoints

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -816,7 +816,7 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 							WITH LogIntervals AS (
     SELECT rp.id,bLog.backup_start_date,bLog.backup_finish_date,bLog.backup_size,bLog.last_lsn,
         MAX(bLog.last_lsn) OVER (
-            PARTITION BY rp.id,bLog.first_recovery_fork_guid,bLog.last_recovery_fork_guid
+            PARTITION BY rp.id
             ORDER BY bLog.first_lsn,bLog.last_lsn DESC,bLog.is_copy_only,bLog.backup_set_id DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS PriorMaxLastLSN
     FROM #RTORecoveryPoints rp
@@ -824,7 +824,9 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
         AND bLog.type=''L'' AND bLog.last_lsn>COALESCE(rp.diff_last_lsn,rp.full_last_lsn)
         AND bLog.last_lsn<=rp.log_last_lsn
 ), LogTotals AS (
-    /* Ordered running maximum removes contained intervals without a range self-join.
+    /* Histories with conflicting known forks were excluded above. Treat NULL fork
+       metadata as unknown within the remaining single-fork estimate.
+       Ordered running maximum removes contained intervals without a range self-join.
        Equal intervals prefer regular backups, then the newest backup ID. */
     SELECT id,SUM(DATEDIFF(second,backup_start_date,backup_finish_date)) AS log_time_seconds,
         SUM(backup_size) AS log_file_size,COUNT(*) AS log_backups

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -560,40 +560,45 @@ EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
 RAISERROR('Gathering RTO information', 0, 1) WITH NOWAIT;
 
 /* Centralized history may have backupset without media-family metadata. */
-CREATE TABLE #RTODiscardMedia(media_set_id int,physical_device_name nvarchar(4000));
-CREATE TABLE #RTOKnownMedia(media_set_id int PRIMARY KEY);
-DECLARE @RTOMediaAvailable bit=CASE WHEN OBJECT_ID(QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily') IS NOT NULL THEN 1 ELSE 0 END;
-/* Media IDs copied from multiple instances cannot identify a source's media. */
-DECLARE @RTOMergedSources bit=0;
-IF @MSDBName<>N'msdb'
+CREATE TABLE #RTODiscardMedia(backup_set_id int PRIMARY KEY);
+CREATE TABLE #RTOKnownMedia(backup_set_id int PRIMARY KEY);
+DECLARE @RTOMediaAvailable bit=CASE WHEN OBJECT_ID(QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily') IS NOT NULL THEN 1 ELSE 0 END,
+        @RTOMergedSources bit=0;
+/* Pushed facts are computed against the source instance and belong to a backup
+   UUID, so instance-local media IDs cannot collide in centralized history. */
+IF COL_LENGTH(QUOTENAME(@MSDBName)+N'.dbo.backupset',N'frk_media_is_usable') IS NOT NULL
+   AND COL_LENGTH(QUOTENAME(@MSDBName)+N'.dbo.backupset',N'frk_media_has_discard') IS NOT NULL
 BEGIN
-    SET @StringToExecute=N'SELECT @Merged=CASE WHEN COUNT(*)>1 THEN 1 ELSE 0 END
-      FROM (SELECT DISTINCT server_name,machine_name FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset) sources;';
-    EXEC sys.sp_executesql @StringToExecute,N'@Merged bit OUTPUT',@Merged=@RTOMergedSources OUTPUT;
-END;
-IF @RTOMediaAvailable=1 AND @RTOMergedSources=0
+    SET @StringToExecute=N'INSERT #RTOKnownMedia SELECT backup_set_id FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset WHERE frk_media_is_usable=1;
+      INSERT #RTODiscardMedia SELECT backup_set_id FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset WHERE frk_media_has_discard=1;';
+    EXEC sys.sp_executesql @StringToExecute;
+END
+ELSE
 BEGIN
-    SET @StringToExecute=N'WITH ExpectedFamilies AS (
-        SELECT media_set_id,MIN(first_family_number) AS FirstFamily,MAX(last_family_number) AS LastFamily
-        FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset
-        GROUP BY media_set_id
-        HAVING MIN(first_family_number)>0 AND MAX(last_family_number)>=MIN(first_family_number)
-          AND COUNT(*)=COUNT(first_family_number) AND COUNT(*)=COUNT(last_family_number)
-    )
-    INSERT #RTOKnownMedia
-    SELECT e.media_set_id FROM ExpectedFamilies e
-    JOIN '+QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily m ON m.media_set_id=e.media_set_id
-      AND m.family_sequence_number BETWEEN e.FirstFamily AND e.LastFamily
-      AND m.physical_device_name IS NOT NULL
-      AND UPPER(m.physical_device_name)<>N''NUL'' AND m.physical_device_name<>N''/dev/null''
-    GROUP BY e.media_set_id,e.FirstFamily,e.LastFamily
-    HAVING COUNT(DISTINCT m.family_sequence_number)=e.LastFamily-e.FirstFamily+1;';
-    EXEC sys.sp_executesql @StringToExecute;
-    SET @StringToExecute=N'INSERT #RTODiscardMedia SELECT media_set_id,physical_device_name FROM '
-        +QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily WHERE UPPER(physical_device_name)=N''NUL'' OR physical_device_name=N''/dev/null'';';
-    EXEC sys.sp_executesql @StringToExecute;
+    IF @MSDBName<>N'msdb'
+    BEGIN
+        SET @StringToExecute=N'SELECT @Merged=CASE WHEN COUNT(*)>1 THEN 1 ELSE 0 END
+          FROM (SELECT DISTINCT server_name,machine_name FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset) sources;';
+        EXEC sys.sp_executesql @StringToExecute,N'@Merged bit OUTPUT',@Merged=@RTOMergedSources OUTPUT;
+    END;
+    IF @RTOMediaAvailable=1 AND @RTOMergedSources=0
+    BEGIN
+        SET @StringToExecute=N'INSERT #RTOKnownMedia
+        SELECT b.backup_set_id FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset b
+        JOIN '+QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily m ON m.media_set_id=b.media_set_id
+          AND m.family_sequence_number BETWEEN b.first_family_number AND b.last_family_number
+          AND m.physical_device_name IS NOT NULL
+          AND UPPER(m.physical_device_name)<>N''NUL'' AND m.physical_device_name<>N''/dev/null''
+        WHERE b.first_family_number>0 AND b.last_family_number>=b.first_family_number
+        GROUP BY b.backup_set_id,b.first_family_number,b.last_family_number
+        HAVING COUNT(DISTINCT m.family_sequence_number)=b.last_family_number-b.first_family_number+1;
+        INSERT #RTODiscardMedia SELECT DISTINCT b.backup_set_id
+        FROM '+QUOTENAME(@MSDBName)+N'.dbo.backupset b
+        JOIN '+QUOTENAME(@MSDBName)+N'.dbo.backupmediafamily m ON m.media_set_id=b.media_set_id
+        WHERE UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'';';
+        EXEC sys.sp_executesql @StringToExecute;
+    END;
 END;
-CREATE INDEX IX_RTODiscardMedia ON #RTODiscardMedia(media_set_id);
 
 /* Restrict recovery estimates to the requested window plus its preceding full.
    Discarded copy-only backups cannot invalidate or replace a usable chain. */
@@ -611,13 +616,13 @@ SELECT b.database_name,b.database_guid,b.backup_set_id,b.backup_set_uuid,b.type,
 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset b
 WHERE b.type IN (''D'',''I'',''L'')
  AND (b.is_damaged=0 OR (b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)))
- AND (EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.media_set_id=b.media_set_id)
+ AND (EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.backup_set_id=b.backup_set_id)
       OR (b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)))
  AND (b.backup_finish_date>=@StartTime OR b.backup_finish_date>=(
     SELECT MAX(anchor.backup_finish_date) FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset anchor
     WHERE anchor.database_name=b.database_name AND anchor.database_guid=b.database_guid
       AND anchor.type=''D'' AND anchor.is_damaged=0 AND anchor.backup_finish_date<=@StartTime
-      AND EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.media_set_id=anchor.media_set_id)
+      AND EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.backup_set_id=anchor.backup_set_id)
  ))
 ;';
 EXEC sys.sp_executesql @StringToExecute,N'@StartTime datetime2',@StartTime;
@@ -640,10 +645,10 @@ GROUP BY database_name,database_guid HAVING COUNT(DISTINCT fork_guid)>1;
 INSERT #RTOExcluded
 SELECT DISTINCT b.database_name,b.database_guid,N''Backup to a discard device''
 FROM #RTOBackupSets b
-JOIN #RTODiscardMedia m ON b.media_set_id=m.media_set_id
-WHERE (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')
+JOIN #RTODiscardMedia m ON b.backup_set_id=m.backup_set_id
+WHERE 1=1
   AND b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)
-  AND NOT EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.media_set_id=b.media_set_id)
+  AND NOT EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.backup_set_id=b.backup_set_id)
   AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
 INSERT #RTOExcluded
 SELECT DISTINCT b.database_name,b.database_guid,N''Damaged log backup or unknown integrity metadata''
@@ -661,7 +666,7 @@ EXEC sys.sp_executesql @StringToExecute;
     INSERT #RTOExcluded
     SELECT DISTINCT b.database_name,b.database_guid,CASE WHEN @RTOMergedSources=1 THEN N'Merged history has ambiguous source media IDs' ELSE N'Backup media metadata missing' END
     FROM #RTOBackupSets b
-    WHERE NOT EXISTS(SELECT 1 FROM #RTOKnownMedia m WHERE m.media_set_id=b.media_set_id)
+    WHERE NOT EXISTS(SELECT 1 FROM #RTOKnownMedia m WHERE m.backup_set_id=b.backup_set_id)
       AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=b.database_name AND x.database_guid=b.database_guid);
 
 INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
@@ -1450,8 +1455,8 @@ IF @ProductVersionMajor >= 12
 		''The database '' + QUOTENAME(bs.database_name) + '' has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to a discard device, the latest one being on ''+
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
-	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id
-	WHERE (UPPER(bmf.physical_device_name)=N''NUL'' OR bmf.physical_device_name=N''/dev/null'')
+	INNER JOIN #RTODiscardMedia bmf ON bs.backup_set_id = bmf.backup_set_id
+	WHERE 1=1
 	AND (bs.is_copy_only = 1 OR bs.recovery_model = N''SIMPLE'')
 	AND bs.backup_finish_date >= @StartTime
 	GROUP BY bs.database_name' + @crlf;
@@ -1463,8 +1468,8 @@ IF @ProductVersionMajor >= 12
 		''The database '' + QUOTENAME(bs.database_name) + '' is not in SIMPLE recovery model and has had '' + CONVERT(VARCHAR(10), COUNT(*)) + '' backups to a discard device, the latest one being on ''+
 		CONVERT(NVARCHAR(25),MAX(bs.backup_finish_date),120)+''. These backups do not exist and they might mess up your current backup chain.'' AS [Warning]
 	FROM   ' + QUOTENAME(@MSDBName) + '.dbo.backupset AS bs
-	INNER JOIN #RTODiscardMedia bmf ON bs.media_set_id = bmf.media_set_id
-	WHERE (UPPER(bmf.physical_device_name)=N''NUL'' OR bmf.physical_device_name=N''/dev/null'')
+	INNER JOIN #RTODiscardMedia bmf ON bs.backup_set_id = bmf.backup_set_id
+	WHERE 1=1
 	AND bs.is_copy_only = 0 AND bs.recovery_model <> N''SIMPLE''
 	AND bs.backup_finish_date >= @StartTime
 	GROUP BY bs.database_name' + @crlf;
@@ -1778,6 +1783,20 @@ END
 		END
 
 
+        /* Add source-validated media facts to both new and existing destinations. */
+        SET @StringToExecute=N'USE '+QUOTENAME(@WriteBackupsToDatabaseName)+N';
+          IF COL_LENGTH(N''dbo.backupset'',N''frk_media_is_usable'') IS NULL
+            ALTER TABLE dbo.backupset ADD frk_media_is_usable bit NULL;
+          IF COL_LENGTH(N''dbo.backupset'',N''frk_media_has_discard'') IS NULL
+            ALTER TABLE dbo.backupset ADD frk_media_has_discard bit NULL;';
+        IF @WriteBackupsToListenerName=@@SERVERNAME
+            EXEC sys.sp_executesql @StringToExecute;
+        ELSE
+        BEGIN
+            SET @InnerStringToExecute=N'EXEC(N'''+REPLACE(@StringToExecute,N'''',N'''''')+N''') AT '+QUOTENAME(@WriteBackupsToListenerName)+N';';
+            EXEC sys.sp_executesql @InnerStringToExecute;
+        END;
+
 		RAISERROR('Beginning inserts', 0, 1) WITH NOWAIT;
 		RAISERROR(@crlf, 0, 1) WITH NOWAIT;
 
@@ -1893,6 +1912,28 @@ END
 		PRINT @StringToExecute;
 
 	EXEC sp_executesql @StringToExecute, N'@i_WriteBackupsLastHours INT', @i_WriteBackupsLastHours = @WriteBackupsLastHours;
+
+    /* Refresh newly inserted and legacy rows in the requested push window.
+       Evaluate media on the source, never by joining unqualified central media IDs. */
+    SET @StringToExecute=N'UPDATE h SET
+      frk_media_is_usable=CASE WHEN b.first_family_number>0 AND b.last_family_number>=b.first_family_number
+        AND (SELECT COUNT(DISTINCT m.family_sequence_number) FROM msdb.dbo.backupmediafamily m
+             WHERE m.media_set_id=b.media_set_id
+               AND m.family_sequence_number BETWEEN b.first_family_number AND b.last_family_number
+               AND m.physical_device_name IS NOT NULL AND UPPER(m.physical_device_name)<>N''NUL''
+               AND m.physical_device_name<>N''/dev/null'')=b.last_family_number-b.first_family_number+1 THEN 1 ELSE 0 END,
+      frk_media_has_discard=CASE WHEN EXISTS(SELECT 1 FROM msdb.dbo.backupmediafamily m WHERE m.media_set_id=b.media_set_id
+          AND (UPPER(m.physical_device_name)=N''NUL'' OR m.physical_device_name=N''/dev/null'')) THEN 1 ELSE 0 END,
+      first_family_number=b.first_family_number,last_family_number=b.last_family_number,
+      first_recovery_fork_guid=b.first_recovery_fork_guid,last_recovery_fork_guid=b.last_recovery_fork_guid,
+      fork_point_lsn=b.fork_point_lsn,differential_base_lsn=b.differential_base_lsn,
+      differential_base_guid=b.differential_base_guid,is_copy_only=b.is_copy_only
+    FROM '+QUOTENAME(@WriteBackupsToListenerName)+N'.'+QUOTENAME(@WriteBackupsToDatabaseName)+N'.dbo.backupset h
+    JOIN msdb.dbo.backupset b ON b.backup_set_uuid=h.backup_set_uuid
+    WHERE b.backup_start_date>=DATEADD(hour,@Hours,SYSDATETIME())
+      AND (h.frk_media_is_usable IS NULL OR h.frk_media_has_discard IS NULL);';
+    EXEC sys.sp_executesql @StringToExecute,N'@Hours int',@Hours=@WriteBackupsLastHours;
+
 
 END;
 

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -582,10 +582,13 @@ SELECT b.database_name,b.database_guid,b.backup_set_id,b.backup_set_uuid,b.type,
 FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset b
 WHERE b.type IN (''D'',''I'',''L'')
  AND (b.is_damaged=0 OR (b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)))
+ AND (EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.media_set_id=b.media_set_id)
+      OR (b.type=''L'' AND (b.is_copy_only=0 OR b.is_copy_only IS NULL)))
  AND (b.backup_finish_date>=@StartTime OR b.backup_finish_date>=(
     SELECT MAX(anchor.backup_finish_date) FROM ' + QUOTENAME(@MSDBName) + N'.dbo.backupset anchor
     WHERE anchor.database_name=b.database_name AND anchor.database_guid=b.database_guid
       AND anchor.type=''D'' AND anchor.is_damaged=0 AND anchor.backup_finish_date<=@StartTime
+      AND EXISTS(SELECT 1 FROM #RTOKnownMedia km WHERE km.media_set_id=anchor.media_set_id)
       AND NOT EXISTS(SELECT 1 FROM #RTODiscardMedia am
         WHERE am.media_set_id=anchor.media_set_id AND (UPPER(am.physical_device_name)=N''NUL'' OR am.physical_device_name=N''/dev/null''))
  ))
@@ -734,6 +737,12 @@ RAISERROR('Add any full backups in the StartDate range that weren''t part of the
 
 		EXEC sys.sp_executesql @StringToExecute, N'@StartTime DATETIME2', @StartTime;
 
+/* A full-only history with unavailable base metadata still needs an explanation. */
+INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
+SELECT 15,50,b.database_name,N'RTO estimate unavailable',N'No usable full backup with known media and integrity metadata was found for this interval.'
+FROM #Backups b WHERE NOT EXISTS(SELECT 1 FROM #RTORecoveryPoints rp WHERE rp.database_name=b.database_name AND rp.database_guid=b.database_guid)
+AND NOT EXISTS(SELECT 1 FROM #Warnings w WHERE w.CheckId=15 AND w.DatabaseName=b.database_name);
+
 /* Fill out the most recent log for that full, but before the next full */
 
 RAISERROR('Fill out the most recent log for that full, but before the next full', 0, 1) WITH NOWAIT;
@@ -781,7 +790,7 @@ RAISERROR('Fill out a diff in that range', 0, 1) WITH NOWAIT;
 							SET diff_last_lsn = (SELECT TOP 1 bDiff.last_lsn FROM #RTOBackupSets bDiff
 							                        WHERE rp.database_guid = bDiff.database_guid AND rp.database_name = bDiff.database_name
 							                            AND bDiff.type = ''I''
-							                            AND bDiff.last_lsn < rp.log_last_lsn
+							                            AND (rp.log_last_lsn IS NULL OR bDiff.last_lsn < rp.log_last_lsn)
 							                            AND rp.full_backup_set_uuid = bDiff.differential_base_guid
 							                            ORDER BY bDiff.last_lsn DESC)
 							FROM #RTORecoveryPoints rp

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -606,6 +606,8 @@ FROM (
     SELECT database_name,database_guid,last_recovery_fork_guid FROM #RTOBackupSets
 ) forks
 GROUP BY database_name,database_guid HAVING COUNT(DISTINCT fork_guid)>1;
+/* Preserve worst-case window semantics: a later full does not repair an
+   earlier gap in this interval. Do not report only its later healthy portion. */
 INSERT #RTOExcluded
 SELECT DISTINCT b.database_name,b.database_guid,N''Backup to a discard device''
 FROM #RTOBackupSets b
@@ -685,7 +687,7 @@ INNER JOIN #RTOBackupSets bLastFull
                                     AND bLog.type = ''L''
                                     AND bLog.last_lsn = rp.log_last_lsn
                                     AND bLog.backup_finish_date>=@StartTime
-                                ORDER BY bLastFull.last_lsn DESC, bLastFull.backup_set_id DESC, bLog.first_lsn ASC, bLog.is_copy_only ASC, bLog.backup_set_id DESC
+                                ORDER BY bLastFull.last_lsn DESC, bLastFull.backup_set_id DESC, bLog.first_lsn ASC, CASE bLog.is_copy_only WHEN 0 THEN 0 WHEN 1 THEN 1 ELSE 2 END ASC, bLog.backup_set_id DESC
                             ) bLasted;
 							 ';
 
@@ -753,7 +755,7 @@ FROM #RTOBackupSets bLog
                                 /* STOPAT can use the first log spanning the next full. */
                                 ORDER BY CASE WHEN bLog.last_lsn>=rpNextFull.full_last_lsn THEN 0 ELSE 1 END,
                                   CASE WHEN bLog.last_lsn>=rpNextFull.full_last_lsn THEN bLog.last_lsn END ASC,
-                                  bLog.last_lsn DESC,bLog.first_lsn ASC,bLog.is_copy_only ASC,bLog.backup_set_id DESC
+                                  bLog.last_lsn DESC,bLog.first_lsn ASC,CASE bLog.is_copy_only WHEN 0 THEN 0 WHEN 1 THEN 1 ELSE 2 END ASC,bLog.backup_set_id DESC
                             ) endpoint
                             WHERE rpEarlierFull.full_backup_set_id IS NULL;
 							';
@@ -822,7 +824,7 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
     SELECT rp.id,bLog.backup_start_date,bLog.backup_finish_date,bLog.backup_size,bLog.last_lsn,
         MAX(bLog.last_lsn) OVER (
             PARTITION BY rp.id
-            ORDER BY bLog.first_lsn,bLog.last_lsn DESC,bLog.is_copy_only,bLog.backup_set_id DESC
+            ORDER BY bLog.first_lsn,bLog.last_lsn DESC,CASE bLog.is_copy_only WHEN 0 THEN 0 WHEN 1 THEN 1 ELSE 2 END,bLog.backup_set_id DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS PriorMaxLastLSN
     FROM #RTORecoveryPoints rp
     JOIN #RTOBackupSets bLog ON rp.database_guid=bLog.database_guid AND rp.database_name=bLog.database_name


### PR DESCRIPTION
RTO estimates can omit logs that overlap a full or differential backup’s ending LSN. Select those logs correctly, retain the actual endpoint backup ID, and remove redundant contained intervals with an ordered running maximum. Equal intervals prefer a known regular backup.

Include the preceding full when computing worst-case recovery points for the reporting window, preserve datetime precision at that anchor, and support differential endpoints without logs. Skip unusable optional backups. Required discard/damaged logs, missing required media metadata, incompatible known forks, or an unusable full base produce an explained NULL RTO. Media validation requires every expected stripe family. A later full does not conceal an earlier restore gap within the requested interval.

Centralized history remains readable when metadata is incomplete. Missing fork identifiers produce a warning; pushes now preserve fork, differential-base, copy-only, and media-family fields. CheckIds 15 and 16 are documented.

Validation: the native SQL Server fixture creates full, differential, regular, copy-only, later-full, and two-stripe backups. It asserts endpoint IDs, counts, sizes, durations, visible RTO, legacy/partial metadata, optional and required failures, differential-only recovery, preceding anchors, and actual history-push field mappings. The expanded fixture passes on SQL Server 2022. Reverting the timestamp comparison or mixed-fork deduplication makes their regressions fail. The combined kit passed all 53 native smoke steps plus uninstall; CI runs the final change on SQL Server 2017, SQL Server 2025, and Azure. git diff --check passes.

Closes #4115.