### PR TITLE
sp_BlitzBackups: reject incomplete log coverage

### DIFF
--- a/.github/scripts/smoke-test-matrix.sql
+++ b/.github/scripts/smoke-test-matrix.sql
@@ -791,6 +791,29 @@ BEGIN TRY
           INSERT #FRKWarningProof SELECT Finding FROM #Warnings WHERE CheckId IN(14,15,16);
           DROP TABLE #Backups, #Warnings, #Recoverability, #RTORecoveryPoints');
     EXEC FRKLogHistory.sys.sp_executesql @Definition;
+    /* Focused LSN coverage cases: first gap, middle gap, overlapping replacement. */
+    DECLARE @GapCase int=1;
+    WHILE @GapCase<=3
+    BEGIN
+        UPDATE FRKLogHistory.dbo.backupset SET first_lsn=0,last_lsn=100 WHERE type='D';
+        UPDATE FRKLogHistory.dbo.backupset SET first_lsn=100,last_lsn=120 WHERE type='I';
+        UPDATE FRKLogHistory.dbo.backupset SET first_lsn=120,last_lsn=150 WHERE backup_set_id=@Copy;
+        UPDATE FRKLogHistory.dbo.backupset SET first_lsn=150,last_lsn=180 WHERE backup_set_id=@Regular;
+        UPDATE FRKLogHistory.dbo.backupset SET first_lsn=180,last_lsn=200 WHERE backup_set_id=@Endpoint;
+        IF @GapCase=1 UPDATE FRKLogHistory.dbo.backupset SET first_lsn=121 WHERE backup_set_id=@Copy;
+        IF @GapCase>=2 DELETE FRKLogHistory.dbo.backupset WHERE backup_set_id=@Regular;
+        IF @GapCase=3 UPDATE FRKLogHistory.dbo.backupset SET last_lsn=180 WHERE backup_set_id=@Copy;
+        EXEC FRKLogHistory.dbo.sp_BlitzBackups @MSDBName=N'FRKLogHistory';
+        IF @GapCase<3 AND (EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+            OR NOT EXISTS(SELECT 1 FROM #FRKWarningProof WHERE Finding=N'RTO estimate unavailable'))
+            THROW 51000,'Incomplete log coverage received an RTO estimate.',1;
+        IF @GapCase=3 AND NOT EXISTS(SELECT 1 FROM #FRKBackupProof WHERE RTOWorstCaseMinutes IS NOT NULL)
+            THROW 51000,'Overlapping replacement did not cover the missing log.',1;
+        DELETE #FRKDiffProof; DELETE #FRKRecoveryProof; DELETE #FRKBackupProof; DELETE #FRKRPOProof; DELETE #FRKWarningProof;
+        DROP TABLE FRKLogHistory.dbo.backupset;
+        SELECT * INTO FRKLogHistory.dbo.backupset FROM FRKLogHistory.dbo.AllBackupSets;
+        SET @GapCase+=1;
+    END;
     DECLARE @Case int=1, @ExpectedCount int, @ExpectedSeconds int, @ExpectedRTO decimal(18,2), @ExpectedMB decimal(18,2);
     WHILE @Case<=8
     BEGIN

--- a/sp_BlitzBackups.sql
+++ b/sp_BlitzBackups.sql
@@ -864,7 +864,8 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 
 	SET @StringToExecute += N'
 							WITH LogIntervals AS (
-    SELECT rp.id,bLog.backup_start_date,bLog.backup_finish_date,bLog.backup_size,bLog.last_lsn,
+    SELECT rp.id,bLog.backup_start_date,bLog.backup_finish_date,bLog.backup_size,bLog.first_lsn,bLog.last_lsn,
+        COALESCE(rp.diff_last_lsn,rp.full_last_lsn) AS BaseLSN,rp.log_last_lsn AS EndpointLSN,
         MAX(bLog.last_lsn) OVER (
             PARTITION BY rp.id
             ORDER BY bLog.first_lsn,bLog.last_lsn DESC,CASE bLog.is_copy_only WHEN 0 THEN 0 WHEN 1 THEN 1 ELSE 2 END,bLog.backup_set_id DESC
@@ -878,7 +879,9 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
        metadata as unknown within the remaining single-fork estimate.
        Ordered running maximum removes contained intervals without a range self-join.
        Equal intervals prefer regular backups, then the newest backup ID. */
-    SELECT id,SUM(DATEDIFF(second,backup_start_date,backup_finish_date)) AS log_time_seconds,
+    SELECT id,CASE WHEN MAX(CASE WHEN first_lsn>COALESCE(PriorMaxLastLSN,BaseLSN) THEN 1 ELSE 0 END)=0
+                         AND MAX(last_lsn)=MAX(EndpointLSN)
+                    THEN SUM(DATEDIFF(second,backup_start_date,backup_finish_date)) END AS log_time_seconds,
         SUM(backup_size) AS log_file_size,COUNT(*) AS log_backups
     FROM LogIntervals WHERE PriorMaxLastLSN IS NULL OR last_lsn>PriorMaxLastLSN
     GROUP BY id
@@ -895,6 +898,18 @@ RAISERROR('Get time & size totals for logs', 0, 1) WITH NOWAIT;
 		PRINT @StringToExecute;
 
 	EXEC sys.sp_executesql @StringToExecute;
+
+/* Do not publish a worst-case estimate from an incomplete log chain. */
+INSERT #RTOExcluded
+SELECT DISTINCT rp.database_name,rp.database_guid,N'Backup history has a gap in the required log LSN coverage.'
+FROM #RTORecoveryPoints rp
+WHERE rp.log_last_lsn IS NOT NULL AND rp.log_time_seconds IS NULL
+  AND NOT EXISTS(SELECT 1 FROM #RTOExcluded x WHERE x.database_name=rp.database_name AND x.database_guid=rp.database_guid);
+INSERT #Warnings(CheckId,Priority,DatabaseName,Finding,Warning)
+SELECT 15,50,x.database_name,N'RTO estimate unavailable',x.Reason FROM #RTOExcluded x
+WHERE NOT EXISTS(SELECT 1 FROM #Warnings w WHERE w.CheckId=15 AND w.DatabaseName=x.database_name);
+DELETE rp FROM #RTORecoveryPoints rp
+JOIN #RTOExcluded x ON x.database_name=rp.database_name AND x.database_guid=rp.database_guid;
 
 RAISERROR('Gathering RTO worst cases', 0, 1) WITH NOWAIT;
 


### PR DESCRIPTION
Return an explained NULL RTO when log history has a gap between the full/differential base and the selected endpoint. Overlapping replacement logs remain valid.

Fixes #4117.

Validation: focused SQL Server 2022 backup regression passed, including missing-first coverage, a deleted intermediate log, and an overlapping replacement. No unrelated changes.